### PR TITLE
Add basic page metadata

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
   <head>
+    {{ partial "meta.html" . }}
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
     {{ partial "css.html" . }}
   </head>
   <body class="page has-navbar-fixed-top">

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,0 +1,3 @@
+<meta charset="utf-8">
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+{{ .Hugo.Generator }}


### PR DESCRIPTION
We'll eventually need more metadata than this (for SEO and such) but this will at least make the site render properly on mobile.