### PR TITLE
Add TOC back into reference docs

### DIFF
--- a/content/docs/reference/vitess-api.md
+++ b/content/docs/reference/vitess-api.md
@@ -1,6 +1,5 @@
 ---
 title: Vitess API Reference
-noToc: true
 weight: 1
 ---
 

--- a/content/docs/reference/vtctl.md
+++ b/content/docs/reference/vtctl.md
@@ -1,6 +1,5 @@
 ---
 title: vtctl Reference
-noToc: true
 weight: 2
 featured: true
 ---


### PR DESCRIPTION
@derekperkins Here are the relevant pages with the TOCs included (or rather not un-included):

https://deploy-preview-109--vitess.netlify.com/docs/reference/vitess-api/
https://deploy-preview-109--vitess.netlify.com/docs/reference/vtctl/

I'll leave it up to you if you prefer it this way. Feel free to merge if you think this is an improvement.