### PR TITLE
Edited out severe inaccuracies from replication-related docs

### DIFF
--- a/content/docs/reference/row-based-replication.md
+++ b/content/docs/reference/row-based-replication.md
@@ -90,5 +90,3 @@ Then, using this in conjunction with binlog-row-image would help provide a featu
 ## Vttablet Simplifications
 
 A lot of the work done by vttablet now is to find the Primary Key of the modified rows, to rewrite the queries in an efficient way and tag each statement with the Primary Key. None of this may be necessary with RBR.
-
-We plan to eventually add a `rbr_mode` flag to vttablet to disable all the things it can skip if RBR is used.

--- a/content/docs/reference/row-based-replication.md
+++ b/content/docs/reference/row-based-replication.md
@@ -3,9 +3,9 @@ title: Row Based Replication
 weight: 7
 ---
 
-In Vitess 2.2, we are adding preliminary support for Row Based Replication. This document explains how we are managing it and how it affects various Vitess features.
+Since Vitess 2.2, Vitess has supported Row Based Replication. This document explains how it affects various Vitess features.
 
-See the Vitess and Replication document for an introduction on various types of replication and how it affects Vitess.
+See the [Vitess and Replication document](../vitess-replication) for an introduction on various types of replication and how it affects Vitess.
 
 ## MySQL Row Based Replication
 
@@ -76,8 +76,7 @@ We have future plans to:
 
 This part describes the features that are not supported for RBR in Vitess as of March 2017:
 
-* *Fractional timestamps for MariaDB*: not supported. This affects the objects of type TIMESTAMP, TIME and DATETIME. The way that feature is implemented in MariaDB, the binary logs do not contain enough information to be parsed, but instead MariaDB relies on the schema knowledge. This is very fragile. MySQL 5.6+ added new data types, and these are supported.
-* *JSON type in MySQL 5.7+*: the representation of these in the binlogs is a blob containing indexed binary data. Re-building the SQL version of the data, so it can be re-inserted during resharding, is not supported yet. It wouldn't however be a lot of work, with other libraries also supporting this, and the C++ MySQL code being well written and easy to read. See for instance https://github.com/shyiko/mysql-binlog-connector-java/pull/119
+* Floating point columns are not supported. This is because they are inherently inaccurate, and could cause inaccuracies while being replayed during resharding.
 * *Timezones support*: the binary logs store timestamps in UTC. When converting these to SQL, we print the UTC value. If the server is not in UTC, that will result in data corruption. Note: we are working on a fix for that one.
 
 ## Update Stream Extensions

--- a/content/docs/reference/row-based-replication.md
+++ b/content/docs/reference/row-based-replication.md
@@ -74,9 +74,9 @@ We have future plans to:
 
 ## Unsupported Features
 
-This part describes the features that are not supported for RBR in Vitess as of March 2017:
+This part describes the features that are not supported for RBR in Vitess as of December 2018:
 
-* Floating point columns are not supported. This is because they are inherently inaccurate, and could cause inaccuracies while being replayed during resharding.
+* *Floating point columns*: This is because they are inherently inaccurate, and could cause inaccuracies while being replayed during resharding.
 * *Timezones support*: the binary logs store timestamps in UTC. When converting these to SQL, we print the UTC value. If the server is not in UTC, that will result in data corruption. Note: we are working on a fix for that one.
 
 ## Update Stream Extensions

--- a/content/docs/reference/vitess-replication.md
+++ b/content/docs/reference/vitess-replication.md
@@ -83,8 +83,5 @@ Thus, you can survive sudden master failure without losing any transactions that
 On the other hand these behaviors also give a requirement that each shard must have at least 2 tablets with type *replica* (with addition of the master that can be demoted to type *replica* this gives a minimum of 3 tablets with initial type *replica*). This will allow for the master to have a semi-sync acker when one of the replica tablets is down for any reason (for a version update, machine reboot, schema swap or anything else).
 
 With regard to replication lag, note that this does **not** guarantee there is always at least one replica type slave from which queries will always return up-to-date results. Semi-sync guarantees that at least one slave has the transaction in its relay log, but it has not necessarily been applied yet. The only way to guarantee a fully up-to-date read is to send the request to the master.
-Appendix: Adding support for RBR in Vitess
-
-We are in the process of adding support for RBR in Vitess.
 
 See this [document](../row-based-replication) for more information.


### PR DESCRIPTION
* Removed all references to 'we will add support for RBR'
* Removed references to fractional time stamps and JSON type not being supported, @sougou confirmed they are
* Added one more item to things we don't support - floating point columns
* Added link to Replication document