### PR TITLE
Fix typo in concepts.md

### DIFF
--- a/content/docs/overview/concepts.md
+++ b/content/docs/overview/concepts.md
@@ -18,7 +18,7 @@ The *keyspace ID* is the value that is used to decide on which shard a given row
 
 Using this technique means you can split a given shard by replacing it with two or more new shards that combine to cover the original range of keyspace IDs, without having to move any records in other shards.
 
-The keyspace ID itself is computed using a function of some column in your data, such as the user ID. Vitess allows you to choose from a variety of functions ([vindexes](../../schema-management/vschema/) to perform this mapping. This allows you to choose the right one to achieve optimal distribution of the data across shards.
+The keyspace ID itself is computed using a function of some column in your data, such as the user ID. Vitess allows you to choose from a variety of functions ([vindexes](../../schema-management/vschema/)) to perform this mapping. This allows you to choose the right one to achieve optimal distribution of the data across shards.
 
 ## VSchema
 


### PR DESCRIPTION
Missing a trailing parens after the vindexes link.