### PR TITLE
Fix typos

### DIFF
--- a/content/docs/sharding/_index.md
+++ b/content/docs/sharding/_index.md
@@ -107,7 +107,7 @@ If MySQL is configured to use Row-based Replication (RBR), the filtered replicat
 is performed the following way:
 
 1. The server process uses the primary vindex to compute the keyspace ID for every row coming throug the replication stream, and sends that row to the corresponding target shard.
-2. The target shard converts the row into the corresponding DML (Data Manipulation Languate) and applies the statement.
+2. The target shard converts the row into the corresponding DML (Data Manipulation Language) and applies the statement.
 
 If using RBR, it's generally required that you have full image turned on. However, if your Primary Vindex is also part of the Primary key, it's not required, because every RBR event
 will always contain the full primary key of its affected row.

--- a/content/docs/sharding/_index.md
+++ b/content/docs/sharding/_index.md
@@ -58,7 +58,7 @@ Two key ranges are consecutive if the end value of one range equals the start va
 
 ### Shard Names
 
-A shard's name identifies the start and end of the shard's key range, printed in hexadecimal and separated by a hyphen. For instance, if a shard's key range is the array of bytes beginning with [ 0x80 ] and ending, noninclusively, with [ 0xc0], then sthe shard's name is `80-c0`.
+A shard's name identifies the start and end of the shard's key range, printed in hexadecimal and separated by a hyphen. For instance, if a shard's key range is the array of bytes beginning with [ 0x80 ] and ending, noninclusively, with [ 0xc0], then the shard's name is `80-c0`.
 
 Using this naming convention, the following four shards would be a valid full partition:
 

--- a/content/docs/tutorials/kubernetes.md
+++ b/content/docs/tutorials/kubernetes.md
@@ -96,7 +96,7 @@ You can also browse to the vtctld console using the following command (Ubuntu):
 
 ### Minikube Customizations
 
-The helm example is based on the the `values.yaml` file provided as the default helm chart for Vitess. The following overrides have been performed in order to run under minikube:
+The helm example is based on the `values.yaml` file provided as the default helm chart for Vitess. The following overrides have been performed in order to run under minikube:
 
 * `resources`: have been nulled out. This instructs the Kubernetes environment to use whatever is available. Note, this is not recommended for a production environment. In such cases, you should start with the baseline values provided in `helm/vitess/values.yaml` and iterate from those.
 * etcd and vtgate replicas are set to 1. In a production environment, there should be 3-5 etcd replicas. The number of vtgates will need to scale up based on cluster size.

--- a/content/docs/tutorials/vagrant.md
+++ b/content/docs/tutorials/vagrant.md
@@ -133,7 +133,7 @@ The `client.py` file is a simple sample application that connects to `vtgate` an
     # ...
     ```
 
-There are also sample clients in the same directory for Java, PHP, and Go. See the comments at the top of each sample file for usa e instructions.
+There are also sample clients in the same directory for Java, PHP, and Go. See the comments at the top of each sample file for usage instructions.
 
 ### Tear down the cluster
 

--- a/content/docs/user-guides/backup-and-restore.md
+++ b/content/docs/user-guides/backup-and-restore.md
@@ -98,7 +98,7 @@ access to the location where you are storing backups.
         file with a JSON object as configuration. The JSON object requires the
         following keys: <code>accessKey</code>, <code>secretKey</code>,
         <code>endPoint</code> and <code>useSSL</code>. Bucket name is computed
-        from keyspace name and shard name and is separate for different
+        from keyspace name and shard name is separated for different
         keyspaces / shards.</td>
     </tr>
     <tr>

--- a/content/docs/user-guides/faq.md
+++ b/content/docs/user-guides/faq.md
@@ -26,7 +26,7 @@ If no tablet type was specified, then VTGate chooses its default, which can be o
 
 Vitess supports different modes. In OLTP mode, the result size is typically limited to a preset number (10,000 rows by default). This limit can be adjusted based on your needs.
 
-However, OLAP mode has no limit to the number of rows returned. In order to change to this mode, you may issue the following command command before executing your query:
+However, OLAP mode has no limit to the number of rows returned. In order to change to this mode, you may issue the following command before executing your query:
 
 ```shell
 set workload='olap'

--- a/content/docs/user-guides/upgrading.md
+++ b/content/docs/user-guides/upgrading.md
@@ -5,7 +5,7 @@ weight: 8
 
 This document highlights things to look after when upgrading a Vitess production installation to a newer Vitess release.
 
-Generally speaking, upgrading Vitess is a safe and and easy process because it is explicitly designed for it. This is because in YouTube we follow the practice of releasing new versions often (usually from the tip of the Git master branch).
+Generally speaking, upgrading Vitess is a safe and easy process because it is explicitly designed for it. This is because in YouTube we follow the practice of releasing new versions often (usually from the tip of the Git master branch).
 
 ## Compatibility
 

--- a/content/docs/user-guides/vttablet-modes.md
+++ b/content/docs/user-guides/vttablet-modes.md
@@ -13,7 +13,7 @@ In the mode with the highest control, VTTablet can take backups. It can also aut
 
 It will also load other information from the my.cnf, like the location of data files, etc. When it receives a request to take a backup, it will shut down mysql, copy the mysql data files to the backup store, and restart mysql.
 
-The my.cnf file can be specified the following ways:
+The my.cnf file can be specified in the following ways:
 
 * Implicit: If mysql was initialized by the `mysqlctl` tool, then vttablet can find it based on just the `-tablet-path`. The default location for this file is `$VTDATAROOT/vt_<tablet-path>/my.cnf`.
 * `-mycnf-file`: This option can be used if the file is not present in the default location.


### PR DESCRIPTION
\+

There are:

github,twitter,slack stackoverflow - broken links, from `/docs/` path;

https://vitess.io/docs/overview/ :
broken link - https://vitess.io/docs/getting-started

https://vitess.io/docs/overview/whatisvitess/ :
broken link - https://vitess.io/docs/getting-started/kubernetes


https://vitess.io/docs/overview/scalingwithvitess/ : 
broken links -
https://vitess.io/docs/getting-started/kubernetes
https://vitess.io/docs/getting-started/local
https://vitess.io/docs/overview/scalingwithvitess/link



https://vitess.io/docs/user-guides/reparenting/ :
```
[vtctl ShardReplicationPositions](https://vitess.io/reference/vtctl/#shardreplicationpositions)
[vtctl TabletExternallyReparented](https://vitess.io/reference/vtctl/#tabletexternallyreparented)
```
\-  do not render as links in HTML output