### PR TITLE
Fix escaping of instructions

### DIFF
--- a/content/docs/launching/server-configuration.md
+++ b/content/docs/launching/server-configuration.md
@@ -158,7 +158,7 @@ By default, a vttablet will use a subdirectory in VTDATAROOT named vt_NNNNNNNNNN
 
 When starting up and using mysqlctl to manage MySQL, the MySQL files will be in subdirectories of the tablet root. For instance, bin-logs for the binary logs, data for the data files, and relay-logs for the relay logs.
 
-It is possible to host different parts of a MySQL server files on different partitions. For instance, the data file may reside in flash, while the bin logs and relay logs are on spindle. To achieve this, create a symlink from $VTDATAROOT/<dir name> to the proper location on disk. When MySQL is configured by mysqlctl, it will realize this directory exists, and use it for the files it would otherwise have put in the tablet directory. For instance, to host the binlogs in /mnt/bin-logs:
+It is possible to host different parts of a MySQL server files on different partitions. For instance, the data file may reside in flash, while the bin logs and relay logs are on spindle. To achieve this, create a symlink from $VTDATAROOT/\<dir name\> to the proper location on disk. When MySQL is configured by mysqlctl, it will realize this directory exists, and use it for the files it would otherwise have put in the tablet directory. For instance, to host the binlogs in /mnt/bin-logs:
 
 * Create a symlink from $VTDATAROOT/bin-logs to /mnt/bin-logs.
 * When starting up a tablet:


### PR DESCRIPTION
This escaping issue causes the indentation of the docs to be funky: https://vitess.io/docs/launching/server-configuration/#initialization