### PR TITLE
typo fix for 306_down_shard_0.sh

### DIFF
--- a/content/docs/tutorials/local.md
+++ b/content/docs/tutorials/local.md
@@ -812,7 +812,7 @@ COrder
 After celebrating your second successful resharding, you are now ready to clean up the leftover artifacts:
 
 ``` sh
-./306_down_shard.sh
+./306_down_shard_0.sh
 ```
 
 In this script, we just stopped all tablet instances for shard 0. This will cause all those vttablet and mysqld processes to be stopped. But the shard metadata is still present. We can clean that up with this command (after all vttablets have been brought down):


### PR DESCRIPTION
Signed-off-by: Chris Radcliffe <chrisr@planetscale.com>
simple typo to refer to the correct script (306_down_shard_0.sh)