### PR TITLE
Adding link to unsupported cases doc

### DIFF
--- a/content/docs/user-guides/faq.md
+++ b/content/docs/user-guides/faq.md
@@ -37,7 +37,7 @@ The general convention is to send OLTP queries to `REPLICA` tablet types, and OL
 
 ## Is there a list of supported/unsupported queries?
 
-The list of unsupported constructs is currently in the form of test cases contained in this test file. However, contrary to the test cases, there is limited support for SET, DDL and DBA constructs. This will be documented soon.
+The list of unsupported constructs is currently in the form of test cases contained in [this test file](https://github.com/vitessio/vitess/blob/b2b3aeb7cf5316eeedbe667fecaa91b1c34a6cea/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt). However, contrary to the test cases, there is limited support for SET, DDL and DBA constructs. This will be documented in greater detail soon. Until then, [this test file](https://github.com/vitessio/vitess/blob/b2b3aeb7cf5316eeedbe667fecaa91b1c34a6cea/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt) serves as the canonical source of information on unsupported queries. Do also check on the [Vitess Slack channel](https://vitess.slack.com) (click [here](https://vitess.slack.com/join/shared_invite/enQtMzIxMDMyMzA0NzA1LTBjYjY1M2I2Yjg5YmY3ODIwOTk0N2M1YzI4Y2ViODdiNmIxMDdiMDM5YWQ1ZTc0YmJhZDdiOTliMGVkNDY4MjM) to join) to ask our friendly community about other queries you have in mind. 
 
 ## If I have a log of all queries from my app. Is there a way I can try them against vitess to see how they’ll work?
 


### PR DESCRIPTION
Previously, hyperlink to unsupported cases file was missing.

Also added some text to make the paragraph more user-friendly, i.e. asking people reading it to join Slack to ask questions if they still have more questions.

Signed-off-by: Adrianna Tan <skinnylatte@gmail.com>