### PR TITLE
Improve Local Tutorial (split for packages vs contributors)

### DIFF
--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -11,7 +11,7 @@ If you run into issues or have questions, we recommend posting in our [Slack cha
 
 ## Build From Source
 
-The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../tutorial/local.md) guide instead.
+The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../tutorial/local) guide instead.
 
 ### Install Dependencies
 
@@ -45,7 +45,7 @@ _Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your in
 
 4.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
 
-    We will use ectd for the [topology service](../overview/concepts.md). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+    We will use ectd for the [topology service](../../overview/concepts). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
 
 5.  Install the following other tools needed to build and run Vitess:
 
@@ -86,7 +86,7 @@ _Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your in
 
 3.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
 
-    We will use ectd for the [topology service](../overview/concepts.md). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+    We will use ectd for the [topology service](../../overview/concepts). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
 
 5.  Run the following commands:
 
@@ -263,4 +263,4 @@ http://localhost:15000
 
 ### Next steps
 
-Congratulations! You now have a local vitess cluster up and running. You can complete additional exercises by following along with [Run Vitess Locally](../tutorial/local.md) guide.
+Congratulations! You now have a local vitess cluster up and running. You can complete additional exercises by following along with [Run Vitess Locally](../../tutorial/local) guide.

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -9,7 +9,7 @@ featured: true
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-## Build from Source
+## Build From Source
 
 The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../tutorial/local.md) guide instead.
 

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -11,7 +11,7 @@ If you run into issues or have questions, we recommend posting in our [Slack cha
 
 ## Build From Source
 
-The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../tutorial/local) guide instead.
+The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../tutorials/local) guide instead.
 
 ### Install Dependencies
 
@@ -263,4 +263,4 @@ http://localhost:15000
 
 ### Next steps
 
-Congratulations! You now have a local vitess cluster up and running. You can complete additional exercises by following along with [Run Vitess Locally](../../tutorial/local) guide.
+Congratulations! You now have a local vitess cluster up and running. You can complete additional exercises by following along with [Run Vitess Locally](../../tutorials/local) guide.

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -1,0 +1,262 @@
+---
+title: Build From Source
+description: Instructions for building Vitess on your machine for testing and development purposes
+weight: 1
+featured: true
+---
+
+{{< info >}}
+If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
+{{< /info >}}
+
+## Build from Source
+
+The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../tutorial/local.md) guide instead.
+
+### Install Dependencies
+
+We currently test Vitess regularly on Ubuntu 14.04 (Trusty) and Debian 8 (Jessie).  macOS 10.11 (El Capitan) and above should work as well. The installation instructions are [below](#macos).
+
+#### Ubuntu and Debian
+
+In addition, Vitess requires the following software and libraries:
+
+1.  [Install Go 1.11+](http://golang.org/doc/install).
+
+2. Install MySQL:
+```bash
+# Apt based
+sudo apt-get install mysql-server
+# Yum based
+sudo yum install mysql-server
+```
+
+_Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your installation method provides a choice._
+
+3.  Uninstall or disable [AppArmor](https://wiki.ubuntu.com/AppArmor). Some versions of MySQL come with default AppArmor configurations that the Vitess tools don't yet recognize. This causes various permission failures when Vitess initializes MySQL instances through the `mysqlctl` tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without going through `mysqlctl`.
+
+    ```sh
+    sudo service apparmor stop
+    sudo service apparmor teardown # safe to ignore if this errors
+    sudo update-rc.d -f apparmor remove
+    ```
+
+    Reboot to be sure that AppArmor is fully disabled.
+
+4.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
+
+    We will use ectd for the lock service. Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+
+5.  Install the following other tools needed to build and run Vitess:
+
+    - make
+    - automake
+    - libtool
+    - python-dev
+    - python-virtualenv
+    - python-mysqldb
+    - libssl-dev
+    - g++
+    - git
+    - pkg-config
+    - bison
+    - curl
+    - unzip
+
+    These can be installed with the following apt-get command:
+
+    ```sh
+    $ sudo apt-get install make automake libtool python-dev python-virtualenv python-mysqldb libssl-dev g++ git pkg-config bison curl unzip
+    ```
+
+#### Mac OS
+
+1.  [Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
+
+    ```sh
+    sudo chown -R $(whoami):admin /usr/local
+    ```
+
+2.  If [Xcode](https://developer.apple.com/xcode/) is installed (with Console tools, which should be bundled
+    automatically since version 7.1), all the dev dependencies should be satisfied in this step. If Xcode isn't present, you'll need to install [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/).
+
+    ```sh
+    brew install pkg-config
+    ```
+
+3.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
+
+    We will use ectd for the lock service. Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+
+5.  Run the following commands:
+
+    ```sh
+    brew install go ant automake libtool python git bison curl wget mysql57
+    pip install --upgrade pip setuptools
+    pip install virtualenv
+    pip install MySQL-python
+    pip install tox
+    ```
+
+6.  The Vitess bootstrap script makes some checks for the go runtime, so it is recommended to have the following commands in your `~/.profile`, `~/.bashrc`, `~/.zshrc`, or `~/.bash_profile`:
+
+    ```sh
+    export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
+    export PATH=/usr/local/go/bin:$PATH
+    export GOROOT=/usr/local/go
+    ```
+
+7.  For the Vitess hostname resolving functions to work correctly, a new entry has to be added into the /etc/hosts file with the current LAN IP address of the computer (preferably IPv4) and the current hostname, which you get by typing the 'hostname' command in the terminal.
+
+    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) in your ~/.profile or ~/.bashrc or ~/.zshrc:
+
+    ```sh
+    export GODEBUG=netdns=go
+    ```
+
+## Build Vitess
+
+1. Navigate to the directory where you want to download the Vitess source code and clone the Vitess Github repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
+
+    ```sh
+    cd $WORKSPACE
+    git clone https://github.com/vitessio/vitess.git \
+        src/vitess.io/vitess
+    cd src/vitess.io/vitess
+    ```
+
+2. Set the `MYSQL_FLAVOR`:
+```sh
+# It is recommended to use MySQL56 even for MySQL 5.7 and 8.0. For MariaDB you can use MariaDB:
+export MYSQL_FLAVOR=MySQL56
+```
+
+3. If your selected database installed in a location other than `/usr/bin`, set the `VT_MYSQL_ROOT` variable to the root directory of your MySQL installation:
+
+    ```sh
+    # For generic tarballs on Linux
+    export VT_MYSQL_ROOT=/usr/local/mysql
+
+    # On macOS with Homebrew
+    export VT_MYSQL_ROOT=/usr/local/opt/mysql@5.7
+    ```
+
+    Note that the command indicates that the `mysql` executable should be found at `/usr/local/opt/mysql@5.7/bin/mysql`.
+
+4. Run `mysqld --version` and confirm that you are running MySQL 5.7.
+
+5. Build Vitess using the commands below. Note that the `bootstrap.sh` script needs to download some dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`).
+
+    Run the boostrap.sh script:
+
+    ```sh
+    BUILD_TESTS=0 ./bootstrap.sh
+    ### example output:
+    # skipping zookeeper build
+    # go install golang.org/x/tools/cmd/cover ...
+    # Found MariaDB installation in ...
+    # creating git pre-commit hooks
+    #
+    # source dev.env in your shell before building
+    ```
+
+    ```sh
+    # Remaining commands to build Vitess
+    source ./dev.env
+    make build
+    ```
+
+#### Common Build Issues
+
+{{< info >}}
+If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
+{{< /info >}}
+
+##### Python errors
+
+The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, and recommend that you bootstrap with test-building disabled (`BUILD_TESTS=0 ./bootstrap.sh`).
+
+##### Node already exists, port in use, etc.
+
+A failed test can leave orphaned processes. If you use the default settings, you can use the following commands to identify and kill those processes:
+
+```sh
+pgrep -f -l '(vtdataroot|VTDATAROOT)' # list Vitess processes
+pkill -f '(vtdataroot|VTDATAROOT)' # kill Vitess processes
+```
+
+##### Too many connections to MySQL, or other timeouts
+
+This error may mean your disk is too slow. If you don't have access to an SSD, you can try [testing against a ramdisk](https://github.com/vitessio/vitess/blob/master/doc/TestingOnARamDisk.md).
+
+##### Connection refused to tablet, MySQL socket not found, etc.
+
+These errors might indicate that the machine ran out of RAM and a server crashed when trying to allocate more RAM. Some of the heavier tests require up to 8GB RAM.
+
+##### Running out of disk space
+
+Some of the larger tests use up to 4GB of temporary space on disk.
+
+##### Too Many Open Files
+
+Some Linux distributions ship with default file descriptor limits that are too low for database servers. This issue could show up as the database crashing with the message “too many open files”. Check the system-wide file-max setting as well as user-specific ulimit values. We recommend setting them above 100K to be safe. The exact procedure may vary depending on your Linux distribution.
+
+## Starting a single keyspace cluster
+
+You can quickly test out your Vitess build by using one of the included local examples. `101_initial_cluster.sh` starts an initial Vitess cluster with a single keyspace:
+
+``` sh
+cd examples/local
+./101_initial_cluster.sh
+```
+
+### Verify cluster
+
+Once successful, you should see the following state:
+
+``` sh
+$ pgrep -fl vtdataroot
+5451 zksrv.sh
+5452 zksrv.sh
+5453 zksrv.sh
+5463 java
+5464 java
+5465 java
+5627 vtctld
+5762 mysqld_safe
+5767 mysqld_safe
+5799 mysqld_safe
+10162 mysqld
+10164 mysqld
+10190 mysqld
+10281 vttablet
+10282 vttablet
+10283 vttablet
+10447 vtgate
+```
+
+You should now be able to connect to the cluster using the following command:
+
+``` sh
+$ mysql -h 127.0.0.1 -P 15306
+Welcome to the MySQL monitor.  Commands end with ; or \g.
+mysql> show tables;
++-----------------------+
+| Tables_in_vt_commerce |
++-----------------------+
+| corder                |
+| customer              |
+| product               |
++-----------------------+
+3 rows in set (0.01 sec)
+```
+
+You can also browse to the vtctld console using the following URL:
+
+```
+http://localhost:15000
+```
+
+### Next steps
+
+Congratulations! You now have a local vitess cluster up and running. You can complete additional exercises by following along with [Run Vitess Locally](../tutorial/local.md) guide.

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -15,7 +15,7 @@ The following sections explain the process for manually building Vitess on Linux
 
 ### Install Dependencies
 
-We currently test Vitess regularly on Ubuntu 14.04 (Trusty) and Debian 8 (Jessie).  macOS 10.11 (El Capitan) and above should work as well. The installation instructions are [below](#macos).
+We currently test Vitess regularly on Ubuntu 14.04 (Trusty) and Debian 8 (Jessie). macOS 10.11 (El Capitan) and above should work as well. The installation instructions are [below](#macos).
 
 #### Ubuntu and Debian
 
@@ -45,7 +45,7 @@ _Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your in
 
 4.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
 
-    We will use ectd for the lock service. Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+    We will use ectd for the [topology service](../overview/concepts.md). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
 
 5.  Install the following other tools needed to build and run Vitess:
 
@@ -86,7 +86,7 @@ _Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your in
 
 3.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
 
-    We will use ectd for the lock service. Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
+    We will use ectd for the [topology service](../overview/concepts.md). Vitess also includes built-in support for [ZooKeeper](https://zookeeper.apache.org) and [Consul](https://www.consul.io/).
 
 5.  Run the following commands:
 
@@ -108,7 +108,7 @@ _Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your in
 
 7.  For the Vitess hostname resolving functions to work correctly, a new entry has to be added into the /etc/hosts file with the current LAN IP address of the computer (preferably IPv4) and the current hostname, which you get by typing the 'hostname' command in the terminal.
 
-    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) in your ~/.profile or ~/.bashrc or ~/.zshrc:
+    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) in your `~/.profile` or `~/.bashrc` or `~/.zshrc`:
 
     ```sh
     export GODEBUG=netdns=go
@@ -172,9 +172,13 @@ export MYSQL_FLAVOR=MySQL56
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-##### Python errors
+##### Python Errors
 
-The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, and recommend that you bootstrap with test-building disabled (`BUILD_TESTS=0 ./bootstrap.sh`).
+The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, but in the mean time you can run tests from within Docker. The MySQL 5.7 container provided includes the required dependencies:
+
+```bash
+make docker_test flavor=mysql57
+```
 
 ##### Node already exists, port in use, etc.
 

--- a/content/en/docs/overview/concepts.md
+++ b/content/en/docs/overview/concepts.md
@@ -91,9 +91,9 @@ There can be a different `ServedFrom` record for each `(cell, tablet type)` pair
 
 The *replication graph* identifies the relationships between master databases and their respective replicas. During a master failover, the replication graph enables Vitess to point all existing replicas to a newly designated master database so that replication can continue.
 
-## Topology Service
+## Topology Service (TOPO)
 
-The [*Topology Service*](../../user-guides/topology-service) is a set of backend processes running on different servers. Those servers store topology data and provide a distributed locking service.
+The [*Topology Service*](../../user-guides/topology-service) (also referred to as the lock service) is a set of backend processes running on different servers. Those servers store topology data and provide a distributed locking service.
 
 Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, our [local example](../../tutorials/local) uses the ZooKeeper plugin, and the [Kubernetes example](../../tutorials/kubernetes) uses etcd.
 

--- a/content/en/docs/overview/concepts.md
+++ b/content/en/docs/overview/concepts.md
@@ -95,7 +95,7 @@ The *replication graph* identifies the relationships between master databases an
 
 The [*Topology Service*](../../user-guides/topology-service) (also referred to as the lock service) is a set of backend processes running on different servers. Those servers store topology data and provide a distributed locking service.
 
-Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, our [local example](../../tutorials/local) uses the ZooKeeper plugin, and the [Kubernetes example](../../tutorials/kubernetes) uses etcd.
+Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, our [local example](../../tutorials/local) uses the etcd2 plugin.
 
 The topology service exists for several reasons:
 
@@ -125,5 +125,4 @@ A *cell* is a group of servers and network infrastructure collocated in an area,
 
 Each cell in a Vitess implementation has a [local topology service](#topology-service), which is hosted in that cell. The topology service contains most of the information about the Vitess tablets in its cell. This enables a cell to be taken down and rebuilt as a unit.
 
-Vitess limits cross-cell traffic for both data and metadata. While it may be useful to also have the ability to route read traffic to individual cells, Vitess currently serves reads only from the local cell. Writes will go cross-cell when necessary, to wherever the master for that shard
-resides.
+Vitess limits cross-cell traffic for both data and metadata. While it may be useful to also have the ability to route read traffic to individual cells, Vitess currently serves reads only from the local cell. Writes will go cross-cell when necessary, to wherever the master for that shard resides.

--- a/content/en/docs/overview/concepts.md
+++ b/content/en/docs/overview/concepts.md
@@ -95,7 +95,7 @@ The *replication graph* identifies the relationships between master databases an
 
 The [*Topology Service*](../../user-guides/topology-service) (also referred to as the lock service) is a set of backend processes running on different servers. Those servers store topology data and provide a distributed locking service.
 
-Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, our [local example](../../tutorials/local) uses the etcd2 plugin.
+Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, Vitess uses the `etcd2` plugin.
 
 The topology service exists for several reasons:
 

--- a/content/en/docs/overview/concepts.md
+++ b/content/en/docs/overview/concepts.md
@@ -95,7 +95,7 @@ The *replication graph* identifies the relationships between master databases an
 
 The [*Topology Service*](../../user-guides/topology-service) (also referred to as the lock service) is a set of backend processes running on different servers. Those servers store topology data and provide a distributed locking service.
 
-Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, Vitess uses the `etcd2` plugin.
+Vitess uses a plug-in system to support various backends for storing topology data, which are assumed to provide a distributed, consistent key-value store. By default, the [tutorials](../../tutorials/) use the `etcd2` plugin.
 
 The topology service exists for several reasons:
 

--- a/content/en/docs/tutorials/local.md
+++ b/content/en/docs/tutorials/local.md
@@ -1,275 +1,84 @@
 ---
 title: Run Vitess Locally
-description: Instructions for using Vitess on your machine for testing and development purposes
+description: Instructions for using Vitess on your machine for testing purposes
 weight: 3
 featured: true
 ---
 
-You can build Vitess using the [manual](#manual) build process outlined below.
+# Run Vitess Locally
 
-{{< info >}}
-If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
-{{< /info >}}
+This guide covers installing Vitess locally for testing purposes, from pre-compiled binaries. We will launch 3 copies of `mysqld`, so it is recommended to have greater than 4GB RAM, as well as 20GB of available disk space.
 
-## Manual Build
+## Install Packages
 
-The following sections explain the process for manually building Vitess on Linux without using Docker.
+PlanetScale provides [weekly builds](https://github.com/planetscale/vitess-releases/releases) of Vitess for 64-bit Linux.
 
-### Install Dependencies
-
-We currently test Vitess regularly on Ubuntu 14.04 (Trusty) and Debian 8 (Jessie).
-macOS 10.11 (El Capitan) should work as well. The installation instructions are [below](#macos).
-
-#### Ubuntu and Debian
-
-In addition, Vitess requires the software and libraries listed below.
-
-1.  [Install Go 1.11+](http://golang.org/doc/install).
-
-2.  Install [MariaDB 10.0 (or later)](https://downloads.mariadb.org/) or [MySQL 5.6 (or later)](http://dev.mysql.com/downloads/mysql). You can use any installation method (src/bin/rpm/deb), but be sure to include the client development headers (`libmariadbclient-dev` or `libmysqlclient-dev`).
-
-    Vitess tests are written to run against all MySQL and MariaDB flavors (mysql 5.6, MySql 5.7, MariaDB 10.2, MariaDB 10.3, Percona 5.6, Percona 5.7 as of this writing), however the CI system only uses the MySQL 5.7 images to run the official tests.
-
-    If you are installing MariaDB, note that you must install version 10.0 or higher. If you are using `apt-get`, confirm that your repository offers an option to install that version. You can also download the source directly from [mariadb.org](https://downloads.mariadb.org/mariadb/).
-
-    If you are using Ubuntu 14.04 with MySQL 5.6, the default install may be missing a file too, `/usr/share/mysql/my-default.cnf`. It would show as an error like `Could not find my-default.cnf`. If you run into this, just add
-    it with the following contents:
-
-    ``` sh
-    conf
-	  [mysqld]
-	  sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
-    ```
-
-3.  Uninstall or disable [AppArmor](https://wiki.ubuntu.com/AppArmor). Some versions of MySQL come with default AppArmor configurations that the Vitess tools don't yet recognize. This causes various permission failures when Vitess initializes MySQL instances through the `mysqlctl` tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without going through `mysqlctl`.
-
-    ```sh
-    $ sudo service apparmor stop
-    $ sudo service apparmor teardown
-    $ sudo update-rc.d -f apparmor remove
-    ```
-
-    Reboot to be sure that AppArmor is fully disabled.
-
-
-4.  Select a lock service from the options listed below. It is technically possible to use another lock server, but plugins currently exist only for [ZooKeeper](https://zookeeper.apache.org), [etcd](https://coreos.com/etcd/), and [Consul](https://www.consul.io/).
-
-    - ZooKeeper 3.4.10 is included by default.
-    - Install [etcd v3.0+](https://github.com/coreos/etcd/releases). If you use etcd, remember to include the `etcd` command on your path.
-    - Install [Consul](https://www.consul.io/). If you use Consul, remember to include the `consul` command on your path.
-
-5.  Install the following other tools needed to build and run Vitess:
-
-    - make
-    - automake
-    - libtool
-    - python-dev
-    - python-virtualenv
-    - python-mysqldb
-    - libssl-dev
-    - g++
-    - git
-    - pkg-config
-    - bison
-    - curl
-    - unzip
-
-    These can be installed with the following apt-get command:
-
-    ```sh
-    $ sudo apt-get install make automake libtool python-dev python-virtualenv python-mysqldb libssl-dev g++ git pkg-config bison curl unzip
-    ```
-
-6.  If you've opted to use ZooKeeper in step 3, you also need to install a
-    Java runtime, such as [OpenJDK](https://openjdk.java.net/).
-
-    ```sh
-    $ sudo apt-get install openjdk-8-jre
-    ```
-
-#### Mac OS
-
-1.  [Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
-
-    ```sh
-    sudo chown -R $(whoami):admin /usr/local
-    ```
-
-2.  On Mac OS, you must use MySQL 5.6, as MariaDB does not yet work. MySQL should be installed using Homebrew
-    (install steps are below).
-
-3.  If [Xcode](https://developer.apple.com/xcode/) is installed (with Console tools, which should be bundled
-    automatically since version 7.1), all the dev dependencies should be satisfied in this step. If Xcode isn't present, you'll need to install [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/).
-
-    ```sh
-    brew install pkg-config
-    ```
-
-4.  ZooKeeper is used as a lock service. To compile ZooKeeper, you need to install a
-    Java 8 runtime, and only Oracle JDK 8 is available at this time. [Oracle JavaSE Development Kit 8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html).
-
-5.  Run the following commands:
-
-    ```sh
-    brew install go ant automake libtool python git bison curl wget mysql56
-    pip install --upgrade pip setuptools
-    pip install virtualenv
-    pip install MySQL-python
-    pip install tox
-    ```
-
-6.  The Vitess bootstrap script makes some checks for the go runtime, so it is recommended to have the following commands in your `~/.profile`, `~/.bashrc`, `~/.zshrc`, or `~/.bash_profile`:
-
-    ```sh
-    export PATH="/usr/local/opt/mysql@5.6/bin:$PATH"
-    export PATH=/usr/local/go/bin:$PATH
-    export GOROOT=/usr/local/go
-    ```
-
-7.  For the Vitess hostname resolving functions to work correctly, a new entry has to be added into the /etc/hosts file with the current LAN IP address of the computer (preferably IPv4) and the current hostname, which you get by typing the 'hostname' command in the terminal.
-
-    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) in your ~/.profile or ~/.bashrc or ~/.zshrc:
-
-    ```sh
-    export GODEBUG=netdns=go
-    ```
-
-### Build Vitess
-
-1. Navigate to the directory where you want to download the Vitess source code and clone the Vitess Github repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
-
-    ```sh
-    cd $WORKSPACE
-    git clone https://github.com/vitessio/vitess.git \
-        src/vitess.io/vitess
-    cd src/vitess.io/vitess
-    ```
-
-2. Set the `MYSQL_FLAVOR` environment variable. Choose the appropriate value for your database. This value is case-sensitive.
-
-    ```sh
-    # export MYSQL_FLAVOR=MariaDB
-    # or (mandatory for macOS)
-    export MYSQL_FLAVOR=MySQL56
-    ```
-
-3. If your selected database installed in a location other than `/usr/bin`, set the `VT_MYSQL_ROOT` variable to the root directory of your MariaDB installation. For example, if mysql is installed in `/usr/local/mysql`, run the following command.
-
-    ```sh
-    # export VT_MYSQL_ROOT=/usr/local/mysql
-
-    # on macOS, this is the correct value:
-    export VT_MYSQL_ROOT=/usr/local/opt/mysql@5.6
-    ```
-
-    Note that the command indicates that the `mysql` executable should be found at `/usr/local/opt/mysql@5.6/bin/mysql`.
-
-4. Run `mysqld --version` and confirm that you are running the correct version of MariaDB or MySQL. The value should be 10 or higher for MariaDB and 5.6.x for MySQL.
-
-5. Build Vitess using the commands below. Note that the `bootstrap.sh` script needs to download some dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`).
-
-    Run the boostrap.sh script:
-
-    ```sh
-    ./bootstrap.sh
-    ### example output:
-    # skipping zookeeper build
-    # go install golang.org/x/tools/cmd/cover ...
-    # Found MariaDB installation in ...
-    # creating git pre-commit hooks
-    #
-    # source dev.env in your shell before building
-    ```
-
-    ```sh
-    # Remaining commands to build Vitess
-    source ./dev.env
-    make build
-    ```
-
-#### Common Test Issues
-
-Attempts to run the full developer test suite (`make test`) on an underpowered machine often results in failure. If you still see the same failures when running the lighter set of tests (`make site_test`), please let the development team know in the [vitess@googlegroups.com](https://groups.google.com/forum/#!forum/vitess) discussion forum.
-
-##### Node already exists, port in use, etc.
-
-A failed test can leave orphaned processes. If you use the default settings, you can use the following commands to identify and kill those processes:
-
-```sh
-pgrep -f -l '(vtdataroot|VTDATAROOT)' # list Vitess processes
-pkill -f '(vtdataroot|VTDATAROOT)' # kill Vitess processes
+1. Download and extract the [latest `.tar.gz` release](https://github.com/planetscale/vitess-releases/releases) from GitHub.
+2. Install MySQL:
+```bash
+# Apt based
+sudo apt-get install mysql-server
+# Yum based
+sudo yum install mysql-server
 ```
 
-##### Too many connections to MySQL, or other timeouts
+_Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your installation method provides a choice._
 
-This error often means your disk is too slow. If you don't have access to an SSD, you can try [testing against a ramdisk](https://github.com/vitessio/vitess/blob/master/doc/TestingOnARamDisk.md).
+## Disable AppArmor
 
-##### Connection refused to tablet, MySQL socket not found, etc.
+We recommend that you uninstall or disable AppArmor. Some versions of MySQL come with default AppArmor configurations that the Vitess tools don't yet recognize. This causes various permission failures when Vitess initializes MySQL instances through the mysqlctl tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without using `mysqlctl`:
 
-These errors might indicate that the machine ran out of RAM and a server crashed when trying to allocate more RAM. Some of the heavier tests require up to 8GB RAM.
-
-##### Connection refused in zkctl test
-
-This error might indicate that the machine does not have a Java Runtime installed, which is a requirement if you are using ZooKeeper as the lock server.
-
-##### Running out of disk space
-
-Some of the larger tests use up to 4GB of temporary space on disk.
-
-
-## Start a Vitess cluster
-
-*The following example will use a simple commerce database to illustrate how Vitess can take you through the journey of scaling from a single database to a fully distributed and sharded cluster. This is a fairly common story, and it applies to many use cases beyond e-commerce.*
-
-It’s 2018 and, no surprise to anyone, people are still buying stuff online. You recently attended the first half of a seminar on disruption in the tech industry and want to create a completely revolutionary e-commerce site. In classic tech postmodern fashion, you call your products widgets instead of a more meaningful identifier and it somehow fits.
-
-Naturally, you realize the need for a reliable transactional datastore. Because of the new generation of hipsters, you’re probably going to pull traffic away from the main industry players just because you’re not them. You’re smart enough to foresee the scalability you need, so you choose Vitess as your best scaling solution.
-
-### Prerequisites
-
-Before we get started, let’s get a few things out of the way.
-
-* Check system settings
-    * Some Linux distributions ship with default file descriptor limits that are too low for database servers. This issue could show up as the database crashing with the message “too many open files”.
-    * Check the system-wide file-max setting as well as user-specific ulimit values. We recommend setting them above 100K to be safe. The exact procedure may vary depending on your Linux distribution.
-* Configure environment variables
-    * If you are still in the same terminal window that you used to run the build commands, you can skip to the next step since the environment variables will already be set.
-    * If you’re adapting this example to your own deployment, the only environment variables required before running the scripts are VTROOT and VTDATAROOT.
-    * Set VTROOT to the parent of the Vitess source tree. For example, if you ran make build while in $HOME/vt/src/vitess.io/vitess, then you should set:
-
-``` sh
-export VTROOT=$HOME/vt
+```bash
+sudo service apparmor stop
+sudo service apparmor teardown # safe to ignore if this errors
+sudo update-rc.d -f apparmor remove
 ```
 
- * Set VTDATAROOT to the directory where you want data files and logs to be stored. For example
+Reboot to be sure that AppArmor is fully disabled.
 
-``` sh
-export VTDATAROOT=$HOME/vtdataroot
+## Configure Environment
+
+Add the following to your `.bashrc` file. Make sure to replace `/path/to/extracted-tarball` with the actual path to where you extracted the latest release file:
+
+```bash
+export VTROOT=/path/to/extracted-tarball
+export VTTOP=$VTROOT
+export MYSQL_FLAVOR=MySQL56
+export VTDATAROOT=${HOME}/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
 ```
 
-**CAUTION**: Do not store any other critical files in that directory. The final cleanup script will delete everything underneath.
+You are now ready to start your first cluster!
 
-## Starting a single keyspace cluster
+## Start a single keyspace cluster
 
-So you searched keyspace on Google and got a bunch of stuff about NoSQL… what’s the deal? It took a few hours, but after diving through the ancient Vitess scrolls you figure out that in the NewSQL world, keyspaces and databases are essentially the same thing when unsharded. Finally, it’s time to get started.
-
-Change to the local example directory:
+A [keyspace](../overview/concepts.md#keyspace) in Vitess is a logical database consisting of potentially multiple shards. For our first example, we are going to be using Vitess without sharding using a single keyspace. The file `101_initial_cluster.sh` is for example `1` phase `01`. Lets execute it now:
 
 ``` sh
 cd examples/local
-```
-
-In this directory, you will see a group of script files `(*.sh)`. The first digit of each file name indicates the phase of example. The next two digits indicate the order in which to execute them. For example, ‘`101_initial_cluster.sh`’ is the first file of the first phase. We shall execute that now:
-
-``` sh
 ./101_initial_cluster.sh
 ```
 
-This will bring up the initial Vitess cluster with a single keyspace.
+You should see output similar to the following:
 
-### Verify cluster
+```
+~/...vitess/examples/local> ./101_initial_cluster.sh
+enter zk2 env
+Starting zk servers...
+Waiting for zk servers to be ready...
+Started zk servers.
+Configured zk servers.
+enter zk2 env
+Starting vtctld...
+Access vtctld web UI at http://ryzen:15000
+Send commands with: vtctlclient -server ryzen:15999 ...
+enter zk2 env
+Starting MySQL for tablet zone1-0000000100...
+Starting MySQL for tablet zone1-0000000101...
+Starting MySQL for tablet zone1-0000000102...
+```
 
-Once successful, you should see the following state:
+You can also verify that the processes have started with `pgrep`:
 
 ``` sh
 ~/...vitess/examples/local> pgrep -fl vtdataroot
@@ -291,6 +100,14 @@ Once successful, you should see the following state:
 10283 vttablet
 10447 vtgate
 ```
+
+If you encounter any errors, such as ports already in use, you can kill the processes and start over:
+
+```bash
+pkill -f '(vtdataroot|VTDATAROOT)' # kill Vitess processes
+```
+
+## Connecting to your Cluster
 
 You should now be able to connect to the cluster using the following command:
 
@@ -350,10 +167,9 @@ create table corder(
 ```
 
 The schema has been simplified to include only those fields that are significant to the example:
-
 * The `product` table contains the product information for all of the products.
-* The `customer` table has a customer_id that has an auto-increment. A typical customer table would have a lot more columns, and sometimes additional detail tables.
-* The `corder` table (named so because `order` is an SQL reserved word) has an order_id auto-increment column. It also has foreign keys into customer(customer_id) and product(sku).
+* The `customer` table has a `customer_id` that has an auto-increment. A typical customer table would have a lot more columns, and sometimes additional detail tables.
+* The `corder` table (named so because `order` is an SQL reserved word) has an `order_id` auto-increment column. It also has foreign keys into `customer(customer_id)` and `product(sku)`.
 
 ### VSchema
 

--- a/content/en/docs/tutorials/local.md
+++ b/content/en/docs/tutorials/local.md
@@ -61,7 +61,7 @@ cd examples/local
 
 You should see output similar to the following:
 
-```
+```bash
 ~/...vitess/examples/local> ./101_initial_cluster.sh
 enter zk2 env
 Starting zk servers...

--- a/content/en/docs/tutorials/vagrant.md
+++ b/content/en/docs/tutorials/vagrant.md
@@ -11,7 +11,7 @@ featured: true
 The following guide will show you how to build and run Vitess in your local environment using this tool. 
 
 {{< info >}}
-If you run into issues or have questions, we recommend posting in the [Vitess Google Group](https://groups.google.com/forum/#!forum/vitess). This is a very active community forum and a great place to interact with other users.
+If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
 ## Install dependencies
@@ -75,7 +75,7 @@ make site_test
 
 ## Start a Vitess cluster
 
-After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use ZooKeeper as the [topology service](../../overview/concepts). ZooKeeper is included in the Vitess distribution.
+After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use `etcd2` as the default [topology service](../../overview/concepts) plugin.
 
 1. **Start Cluster**
 
@@ -147,4 +147,4 @@ When you are done testing, you can tear down the cluster with the following scri
 
 If anything goes wrong, check the logs in your `$VTDATAROOT/tmp` directory for error messages. There are also some tablet-specific logs, as well as MySQL logs in the various `$VTDATAROOT/vt_*` directories.
 
-If you need help diagnosing a problem, send a message to our [mailing list](https://groups.google.com/forum/#!forum/vitess). In addition to any errors you see at the command-line, it would also help to upload an archive of your `VTDATAROOT` directory to a file sharing service and provide a link to it.
+If you need help diagnosing a problem, send a message to our [Slack channel](https://vitess.slack.com). In addition to any errors you see at the command-line, it would also help to upload an archive of your `VTDATAROOT` directory to a file sharing service and provide a link to it.

--- a/content/en/docs/tutorials/vagrant.md
+++ b/content/en/docs/tutorials/vagrant.md
@@ -75,7 +75,7 @@ make site_test
 
 ## Start a Vitess cluster
 
-After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use ZooKeeper as the lock service. ZooKeeper is included in the Vitess distribution.
+After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use ZooKeeper as the [topology service](../overview/concepts.md). ZooKeeper is included in the Vitess distribution.
 
 1. **Start Cluster**
 

--- a/content/en/docs/tutorials/vagrant.md
+++ b/content/en/docs/tutorials/vagrant.md
@@ -75,7 +75,7 @@ make site_test
 
 ## Start a Vitess cluster
 
-After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use ZooKeeper as the [topology service](../overview/concepts.md). ZooKeeper is included in the Vitess distribution.
+After completing the instructions above to [build Vitess](#build-vitess-vagrant), you can use the example scripts in the Github repo to bring up a Vitess cluster on your local machine. These scripts use ZooKeeper as the [topology service](../../overview/concepts). ZooKeeper is included in the Vitess distribution.
 
 1. **Start Cluster**
 


### PR DESCRIPTION
This PR changes the "local" tutorial to be based on packages provided by PlanetScale, simplifying a number of steps.

The compile steps are moved into a separate tutorial and placed under contributing.

There are some other small wording/grammatical/formatting changes.

Signed-off-by: Morgan Tocker <tocker@gmail.com>