### PR TITLE
Rename "Tutorials" to "Get Started", part of #212

### DIFF
--- a/content/en/docs/get-started/_index.md
+++ b/content/en/docs/get-started/_index.md
@@ -1,0 +1,8 @@
+---
+title: Get Started
+description: Deploy Vitess on your favorite platform
+weight: 2
+aliases: ['/docs/tutorials/']
+---
+
+Vitess supports binary deployment on the following platforms. See also [Build From Source](../../contribute/build-from-source) if you are interesting in building your own binary, or contributing to Vitess.

--- a/content/en/docs/get-started/kubernetes.md
+++ b/content/en/docs/get-started/kubernetes.md
@@ -2,11 +2,12 @@
 title: Run Vitess on Kubernetes
 weight: 1
 featured: true
+aliases: ['/docs/tutorials/kubernetes/']
 ---
 
 *The following example will use a simple commerce database to illustrate how Vitess can take you through the journey of scaling from a single database to a fully distributed and sharded cluster. This is a fairly common story, and it applies to many use cases beyond e-commerce.*
 
-It’s 2018 and, no surprise to anyone, people are still buying stuff online. You recently attended the first half of a seminar on disruption in the tech industry and want to create a completely revolutionary e-commerce site. In classic tech postmodern fashion, you call your products widgets instead of a more meaningful identifier and it somehow fits.
+It’s 2019 and, no surprise to anyone, people are still buying stuff online. You recently attended the first half of a seminar on disruption in the tech industry and want to create a completely revolutionary e-commerce site. In classic tech postmodern fashion, you call your products widgets instead of a more meaningful identifier and it somehow fits.
 
 Naturally, you realize the need for a reliable transactional datastore. Because of the new generation of hipsters, you’re probably going to pull traffic away from the main industry players just because you’re not them. You’re smart enough to foresee the scalability you need, so you choose Vitess as your best scaling solution.
 

--- a/content/en/docs/get-started/local.md
+++ b/content/en/docs/get-started/local.md
@@ -3,9 +3,8 @@ title: Run Vitess Locally
 description: Instructions for using Vitess on your machine for testing purposes
 weight: 3
 featured: true
+aliases: ['/docs/tutorials/local/']
 ---
-
-# Run Vitess Locally
 
 This guide covers installing Vitess locally for testing purposes, from pre-compiled binaries. We will launch 3 copies of `mysqld`, so it is recommended to have greater than 4GB RAM, as well as 20GB of available disk space.
 

--- a/content/en/docs/get-started/vagrant.md
+++ b/content/en/docs/get-started/vagrant.md
@@ -3,6 +3,7 @@ title: Run Vitess with Vagrant
 description: Instructions for building Vitess on your machine for testing and development purposes using Vagrant
 weight: 3
 featured: true
+aliases: ['/docs/tutorials/vagrant/']
 ---
 
 [Vagrant](https://www.vagrantup.com/) is a tool for building and managing virtual machine environments in a single workflow. With an easy-to-use workflow and focus on automation, Vagrant lowers development environment setup time, increases production parity, and makes the "works on my machine" excuse a relic of the past.

--- a/content/en/docs/tutorials/_index.md
+++ b/content/en/docs/tutorials/_index.md
@@ -1,9 +1,0 @@
----
-title: Tutorials
-description: Run Vitess using Kubernetes, or a manual build
-weight: 1
----
-
-These pages describe the primary ways that you can utilize to quickly get up and running with Vitess.
-
-In the coming weeks, new and updated documentation around how to get started with Kubernetes will be updated with new examples.


### PR DESCRIPTION
Part of #212

Includes aliases to redirect from prior locations.
Small bug fixes for duplicate heading, s/2018/2019/

Signed-off-by: Morgan Tocker <tocker@gmail.com>