### PR TITLE
Minor fixes to contribute

### DIFF
--- a/content/en/docs/contributing/_index.md
+++ b/content/en/docs/contributing/_index.md
@@ -1,7 +1,7 @@
 ---
-title: Contributing to Vitess
-description: We love contributors, here's how to take part
-weight: 9
+title: Contribute
+description: Get involved with Vitess development
+weight: 6
 ---
 
 You want to contribute to Vitess? That's awesome!

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -2,14 +2,11 @@
 title: Build From Source
 description: Instructions for building Vitess on your machine for testing and development purposes
 weight: 1
-featured: true
 ---
 
 {{< info >}}
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
-
-## Build From Source
 
 The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../tutorials/local) guide instead.
 


### PR DESCRIPTION
These are mostly cosmetic changes:

In #212 after changing the TOC "Contributing to Vitess" becomes the longest top-level title, so I've shortened it to just "Contribute".

There is also a minor cleanup to remove "Build from Source" from featured. It was originally copied from "Local Install" -- which makes sense as a feature. Build from source does not.

Signed-off-by: Morgan Tocker <tocker@gmail.com>