### PR TITLE
Fix vctl links in reparenting.md

### DIFF
--- a/content/en/docs/user-guides/reparenting.md
+++ b/content/en/docs/user-guides/reparenting.md
@@ -59,7 +59,7 @@ The `EmergencyReparentShard` command is used to force a reparent to a new master
 
 As such, this command does not rely on the current master at all to replicate data to the new master. Instead, it makes sure that the master-elect is the most advanced in replication within all of the available slaves.
 
-**Important**: Before calling this command, you must first identify the slave with the most advanced replication position as that slave must be designated as the new master. You can use the `[vtctl ShardReplicationPositions](https://vitess.io/reference/vtctl/#shardreplicationpositions)` command to determine the current replication positions of a shard's slaves.
+**Important**: Before calling this command, you must first identify the slave with the most advanced replication position as that slave must be designated as the new master. You can use the [`vtctl ShardReplicationPositions`](https://vitess.io/reference/vtctl/#shardreplicationpositions) command to determine the current replication positions of a shard's slaves.
 
 This command performs the following actions:
 
@@ -71,7 +71,7 @@ This command performs the following actions:
 
 ## [External Reparenting](#external-reparenting)
 
-External reparenting occurs when another tool handles the process of changing a shard's master tablet. After that occurs, the tool needs to call the `[vtctl TabletExternallyReparented](https://vitess.io/reference/vtctl/#tabletexternallyreparented)` command to ensure that the topology server, replication graph, and serving graph are updated accordingly.
+External reparenting occurs when another tool handles the process of changing a shard's master tablet. After that occurs, the tool needs to call the [`vtctl TabletExternallyReparented`](https://vitess.io/reference/vtctl/#tabletexternallyreparented) command to ensure that the topology server, replication graph, and serving graph are updated accordingly.
 
 That command performs the following operations:
 


### PR DESCRIPTION
Move the code ticks inside the link name