### PR TITLE
Fix order of drop down menu

### DIFF
--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -1,7 +1,6 @@
 ---
 title: Build From Source
 description: Instructions for building Vitess on your machine for testing and development purposes
-weight: 3
 ---
 
 {{< info >}}

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -1,6 +1,7 @@
 ---
 title: Build From Source
 description: Instructions for building Vitess on your machine for testing and development purposes
+weight: 3
 ---
 
 {{< info >}}

--- a/content/en/docs/get-started/kubernetes.md
+++ b/content/en/docs/get-started/kubernetes.md
@@ -1,6 +1,6 @@
 ---
 title: Run Vitess on Kubernetes
-weight: 1
+weight: 3
 featured: true
 aliases: ['/docs/tutorials/kubernetes/']
 ---

--- a/content/en/docs/get-started/local.md
+++ b/content/en/docs/get-started/local.md
@@ -1,7 +1,7 @@
 ---
 title: Run Vitess Locally
 description: Instructions for using Vitess on your machine for testing purposes
-weight: 3
+weight: 4
 featured: true
 aliases: ['/docs/tutorials/local/']
 ---

--- a/content/en/docs/get-started/vagrant.md
+++ b/content/en/docs/get-started/vagrant.md
@@ -1,7 +1,7 @@
 ---
 title: Run Vitess with Vagrant
 description: Instructions for building Vitess on your machine for testing and development purposes using Vagrant
-weight: 3
+weight: 4
 featured: true
 aliases: ['/docs/tutorials/vagrant/']
 ---

--- a/content/en/docs/reference/vtctl.md
+++ b/content/en/docs/reference/vtctl.md
@@ -1,7 +1,7 @@
 ---
 title: vtctl Reference
 noToc: true
-weight: 2
+weight: 9
 featured: true
 ---
 


### PR DESCRIPTION
This will make all "Run Vitess .." menu items appear together with Kubernetes first.

Signed-off-by: Morgan Tocker <tocker@gmail.com>