### PR TITLE
Remove aliases from zh translation

### DIFF
--- a/content/zh/docs/faq/_index.md
+++ b/content/zh/docs/faq/_index.md
@@ -3,7 +3,6 @@ title: FAQ
 description: Frequently Asked Questions about Vitess
 weight: 8
 featured: true
-aliases: ['/docs/user-guides/faq/']
 ---
 
 ## Does the application need to know about the sharding scheme underneath Vitess?

--- a/content/zh/docs/get-started/_index.md
+++ b/content/zh/docs/get-started/_index.md
@@ -2,7 +2,6 @@
 title: Get Started
 description: Deploy Vitess on your favorite platform
 weight: 2
-aliases: ['/docs/tutorials/']
 ---
 
 Vitess supports binary deployment on the following platforms. See also [Build From Source](../../contribute/build-from-source) if you are interesting in building your own binary, or contributing to Vitess.

--- a/content/zh/docs/get-started/kubernetes.md
+++ b/content/zh/docs/get-started/kubernetes.md
@@ -2,7 +2,6 @@
 title: Run Vitess on Kubernetes
 weight: 1
 featured: true
-aliases: ['/docs/tutorials/kubernetes/']
 ---
 
 *The following example will use a simple commerce database to illustrate how Vitess can take you through the journey of scaling from a single database to a fully distributed and sharded cluster. This is a fairly common story, and it applies to many use cases beyond e-commerce.*

--- a/content/zh/docs/get-started/local.md
+++ b/content/zh/docs/get-started/local.md
@@ -3,7 +3,6 @@ title: Run Vitess Locally
 description: Instructions for using Vitess on your machine for testing purposes
 weight: 3
 featured: true
-aliases: ['/docs/tutorials/local/']
 ---
 
 This guide covers installing Vitess locally for testing purposes, from pre-compiled binaries. We will launch 3 copies of `mysqld`, so it is recommended to have greater than 4GB RAM, as well as 20GB of available disk space.

--- a/content/zh/docs/get-started/vagrant.md
+++ b/content/zh/docs/get-started/vagrant.md
@@ -3,7 +3,6 @@ title: Run Vitess with Vagrant
 description: Instructions for building Vitess on your machine for testing and development purposes using Vagrant
 weight: 3
 featured: true
-aliases: ['/docs/tutorials/vagrant/']
 ---
 
 [Vagrant](https://www.vagrantup.com/) is a tool for building and managing virtual machine environments in a single workflow. With an easy-to-use workflow and focus on automation, Vagrant lowers development environment setup time, increases production parity, and makes the "works on my machine" excuse a relic of the past.

--- a/content/zh/docs/reference/_index.md
+++ b/content/zh/docs/reference/_index.md
@@ -2,6 +2,5 @@
 title: Reference
 description: Detailed information about specific Vitess functionality
 weight: 5 
-aliases: ['/docs/advanced/']
 ---
 

--- a/content/zh/docs/reference/messaging.md
+++ b/content/zh/docs/reference/messaging.md
@@ -1,6 +1,5 @@
 ---
 title: Vitess Messaging
-aliases: ['/docs/advanced/messaging/']
 ---
 
 Vitess messaging gives the application an easy way to schedule and manage work

--- a/content/zh/docs/reference/sharding.md
+++ b/content/zh/docs/reference/sharding.md
@@ -2,7 +2,6 @@
 title: Sharding
 description: Shard widely, shard often.
 weight: 5
-aliases: ['/docs/sharding/']
 ---
 
 Sharding is a method of horizontally partitioning a database to store data across two or more database servers. This document explains how sharding works in Vitess and the types of sharding that Vitess supports.

--- a/content/zh/docs/reference/vreplication.md
+++ b/content/zh/docs/reference/vreplication.md
@@ -1,6 +1,5 @@
 ---
 title: VReplication Operator's Guide
-aliases: ['/docs/advanced/vreplication/']
 ---
 
 VReplication is a core component of vitess that can be used to compose


### PR DESCRIPTION
These are en aliases, and cause conflicts. It can lead to the english redirects switching language to zh.

Signed-off-by: Morgan Tocker <tocker@gmail.com>