### PR TITLE
Fix edit link to be "prod" branch

### DIFF
--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -1,7 +1,7 @@
 {{ $docsSections := where site.Sections "Section" "docs" }}
 {{ $path         := .File.Path }}
 {{ $language     := .Language }}
-{{ $editUrl      := printf "https://github.com/vitessio/website/tree/master/content/%s/%s" $language $path }}
+{{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
 <header class="docs-header">
   <p class="title is-size-1 is-size-2-mobile has-text-weight-light{{ if .Params.description }} is-spaced{{ end }}">
     {{ .Title }}


### PR DESCRIPTION
This fixes the "Edit" link on each manual page to be the prod branch.

We switched to this branch because "master" is indexed by search engines.

Signed-off-by: Morgan Tocker <tocker@gmail.com>