### PR TITLE
New build from source guide guides (split macOS and ubuntu/debian)

### DIFF
--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -77,29 +77,30 @@ brew install go automake git curl wget mysql57 etcd
 
 ## Build Vitess
 
-1. Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
+Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
 
-    ```sh
-    cd $WORKSPACE
-    git clone https://github.com/vitessio/vitess.git \
-        src/vitess.io/vitess
-    cd src/vitess.io/vitess
-    ```
-2. Build Vitess using the commands below. Note that the `bootstrap.sh` script needs to download some dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`).
+```sh
+cd $WORKSPACE
+git clone https://github.com/vitessio/vitess.git \
+    src/vitess.io/vitess
+cd src/vitess.io/vitess
+```
 
-    Run the boostrap.sh script:
+Build Vitess using the commands below. Note that the `bootstrap.sh` script needs to download some dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`).
 
-    ```sh
-    BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
-    ```
+Run the boostrap.sh script:
 
-    Build Vitess:
+```sh
+BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
+```
 
-    ```sh
-    # Remaining commands to build Vitess
-    source ./dev.env
-    make build
-    ```
+Build Vitess:
+
+```sh
+# Remaining commands to build Vitess
+source ./dev.env
+make build
+```
 
 ## Common Build Issues
 

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -9,76 +9,71 @@ If you run into issues or have questions, we recommend posting in our [Slack cha
 
 The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
-### Install Dependencies
+## Install Dependencies
 
 Many of the Vitess developers use Ubuntu or macOS desktops. If you would like to extend this guide for `yum` based distributions, please [send us a pull request](https://github.com/vitessio/website).
 
-#### Ubuntu and Debian
+### Ubuntu and Debian
 
 In addition, Vitess requires the following software and libraries:
 
-1.  [Install Go 1.12+](http://golang.org/doc/install).
+#### Install Go 1.12+
 
+[Install Go 1.12+](http://golang.org/doc/install).
 The version included in your OS distribution may be older than this. You can check by running `go version`.
 
-2.  We recommend that you uninstall or disable AppArmor since it may cause permission failures when Vitess initializes MySQL instances through the `mysqlctl` tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without using `mysqlctl`:
+#### Disable AppArmor
 
-    ```sh
-    sudo service apparmor stop
-    sudo service apparmor teardown # safe to ignore if this errors
-    sudo update-rc.d -f apparmor remove
-    ```
+We recommend that you uninstall or disable AppArmor since it may cause permission failures when Vitess initializes MySQL instances through the `mysqlctl` tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without using `mysqlctl`:
 
-    Reboot to be sure that AppArmor is fully disabled.
+```sh
+sudo service apparmor stop
+sudo service apparmor teardown # safe to ignore if this errors
+sudo update-rc.d -f apparmor remove
+```
+Reboot to be sure that AppArmor is fully disabled.
 
-3.  Install dependencies required to build and run Vitess:
+#### Install Dependencies
 
-    ```sh
-    # On Apt based systems
-    sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl
-    ```
+Install dependencies required to build and run Vitess:
 
-    **Notes:**
-    * Vitess currently has some tests written in Python, but this dependency can be avoided by running the tests in Docker (recommended).
-    * The `bootstrap.sh` script can also install Zookeeper for you, which requires additional dependencies. For this guide, we will use etcd instead and skip this step.
+```sh
+sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl
+```
 
-4. [Install Docker](https://docs.docker.com/install/)
+**Notes:**
+* Vitess currently has some tests written in Python, but this dependency can be avoided by running the tests in Docker (recommended).
+* We will be using etcd as the topology service. The `bootstrap.sh` script can also install Zookeeper or Consul for you, which requires additional dependencies.
 
-Docker is required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
+#### Install Docker
 
-#### Mac OS
+[Install Docker](https://docs.docker.com/install/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
 
-1.  [Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
+### macOS
 
-    ```sh
-    sudo chown -R $(whoami):admin /usr/local
-    ```
+#### Install Xcode
 
-2.  Install [Xcode](https://developer.apple.com/xcode/).
+[Install Xcode](https://developer.apple.com/xcode/).
 
-3.  Install [etcd v3.0+](https://github.com/coreos/etcd/releases). Remember to include `etcd` command on your path.
+#### Install Homebrew
 
-4.  Run the following commands:
+[Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
 
-    ```sh
-    brew install go automake git curl wget mysql57
-    ```
+```sh
+sudo chown -R $(whoami):admin /usr/local
+```
 
-5.  The Vitess bootstrap script makes some checks for the go runtime, so it is recommended to have the following commands in your `~/.profile`, `~/.bashrc`, `~/.zshrc`, or `~/.bash_profile`:
+#### Install Dependencies
 
-    ```sh
-    export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"
-    export PATH=/usr/local/go/bin:$PATH
-    export GOROOT=/usr/local/go
-    ```
+Run the following command:
 
-6.  For the Vitess hostname resolving functions to work correctly, a new entry has to be added into the /etc/hosts file with the current LAN IP address of the computer (preferably IPv4) and the current hostname, which you get by typing the 'hostname' command in the terminal.
+```sh
+brew install go automake git curl wget mysql57 etcd
+```
 
-    It is also a good idea to put the following line to [force the Go DNS resolver](https://golang.org/doc/go1.5#net) in your `~/.profile` or `~/.bashrc` or `~/.zshrc`:
+#### Install Docker
 
-    ```sh
-    export GODEBUG=netdns=go
-    ```
+[Install Docker](https://docs.docker.com/docker-for-mac/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
 
 ## Build Vitess
 
@@ -106,13 +101,13 @@ Docker is required to run the Vitess testsuite. Should you decide to skip this s
     make build
     ```
 
-#### Common Build Issues
+## Common Build Issues
 
 {{< info >}}
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-##### Python Errors
+### Python Errors
 
 The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, but in the mean time you can run tests from within Docker. The MySQL 5.7 container provided includes the required dependencies:
 
@@ -120,31 +115,6 @@ The end-to-end test suite currently requires Python 2.7. We are working on remov
 make docker_test flavor=mysql57
 ```
 
-##### Node already exists, port in use, etc.
-
-A failed test can leave orphaned processes. If you use the default settings, you can use the following commands to identify and kill those processes:
-
-```sh
-pgrep -f -l '(vtdataroot|VTDATAROOT)' # list Vitess processes
-pkill -f '(vtdataroot|VTDATAROOT)' # kill Vitess processes
-```
-
-##### Too many connections to MySQL, or other timeouts
-
-This error may mean your disk is too slow. If you don't have access to an SSD, you can try testing on a RAM disk.
-
-##### Connection refused to tablet, MySQL socket not found, etc.
-
-These errors might indicate that the machine ran out of RAM and a server crashed when trying to allocate more RAM. Some of the heavier tests require up to 8GB RAM.
-
-##### Running out of disk space
-
-Some of the larger tests use up to 4GB of temporary space on disk.
-
-##### Too Many Open Files
-
-Some Linux distributions ship with default file descriptor limits that are too low for database servers. This issue could show up as the database crashing with the message “too many open files”. Check the system-wide file-max setting as well as user-specific ulimit values. We recommend setting them above 100K to be safe. The exact procedure may vary depending on your Linux distribution.
-
-### Next steps
+## Next steps
 
 Congratulations! You now have Vitess built locally. You can complete additional exercises by following along with [Run Vitess Locally](../../get-started/local) guide.

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -19,19 +19,19 @@ In addition, Vitess requires the following software and libraries:
 
 #### Install Go 1.12+
 
-[Install Go 1.12+](http://golang.org/doc/install).
-The version included in your OS distribution may be older than this. You can check by running `go version`.
-
-#### Disable AppArmor
-
-We recommend that you uninstall or disable AppArmor since it may cause permission failures when Vitess initializes MySQL instances through the `mysqlctl` tool. This is an issue only in test environments. If AppArmor is necessary in production, you can configure the MySQL instances appropriately without using `mysqlctl`:
+[Download and install](http://golang.org/doc/install) the latest version of Golang. For example, at writing:
 
 ```sh
-sudo service apparmor stop
-sudo service apparmor teardown # safe to ignore if this errors
-sudo update-rc.d -f apparmor remove
+curl -O https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.13.3.linux-amd64.tar.gz
 ```
-Reboot to be sure that AppArmor is fully disabled.
+
+Make sure to add go to your bashrc:
+```
+export PATH=$PATH:/usr/local/go/bin
+```
+
+**Tip:** With Ubuntu 19.10 and later, you can also install the package `golang-go` via apt. Be careful doing this on older versions, as you may end up with an older version.
 
 #### Install Dependencies
 
@@ -41,9 +41,33 @@ Install dependencies required to build and run Vitess:
 sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl
 ```
 
+The services `mysqld` and `etcd` should be shutdown, since `etcd` will conflict with the `etcd` started in the examples, and `mysqlctl` will start its own copies of `mysqld`:
+
+```sh
+sudo service mysql stop
+sudo service etcd stop
+sudo systemctl disable mysql
+sudo systemctl disable etcd
+```
+
 **Notes:**
 * Vitess currently has some tests written in Python, but this dependency can be avoided by running the tests in Docker (recommended).
 * We will be using etcd as the topology service. The `bootstrap.sh` script can also install Zookeeper or Consul for you, which requires additional dependencies.
+
+## Disable mysqld AppArmor Profile
+
+The `mysqld` AppArmor profile will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:
+
+```sh
+sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+```
+
+The following command should return an empty result:
+
+```sh
+sudo aa-status | grep mysqld
+```
 
 #### Install Docker
 
@@ -87,11 +111,18 @@ git clone https://github.com/vitessio/vitess.git \
 cd src/vitess.io/vitess
 ```
 
-Set environment variables that Vitess will require. It is recommended to put these in your .bashrc:
+Set environment variables that Vitess will require. It is recommended to put these in your `.bashrc`:
 
 ```sh
+# Additions to ~/.bashrc file
+
+# Add go PATH
+export PATH=$PATH:/usr/local/go/bin
+
+# Vitess
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
 export PATH=${VTROOT}/bin:${PATH}
 ```
 
@@ -109,11 +140,121 @@ source ./dev.env
 make build
 ```
 
+## Testing your Binaries
+
+Run the included local example:
+
+```sh
+cd examples/local
+./101_initial_cluster.sh
+```
+
+You should see the following:
+```
+$ ./101_initial_cluster.sh 
+enter etcd2 env
+add /vitess/global
+add /vitess/zone1
+add zone1 CellInfo
+etcd start done...
+enter etcd2 env
+Starting vtctld...
+Access vtctld web UI at http://ubuntu:15000
+Send commands with: vtctlclient -server ubuntu:15999 ...
+enter etcd2 env
+Starting MySQL for tablet zone1-0000000100...
+Starting MySQL for tablet zone1-0000000101...
+Starting MySQL for tablet zone1-0000000102...
+Starting vttablet for zone1-0000000100...
+Access tablet zone1-0000000100 at http://ubuntu:15100/debug/status
+Starting vttablet for zone1-0000000101...
+Access tablet zone1-0000000101 at http://ubuntu:15101/debug/status
+Starting vttablet for zone1-0000000102...
+Access tablet zone1-0000000102 at http://ubuntu:15102/debug/status
+W1027 18:52:14.592776    6426 main.go:64] W1027 18:52:14.591918 reparent.go:182] master-elect tablet zone1-0000000100 is not the shard master, proceeding anyway as -force was used
+W1027 18:52:14.600737    6426 main.go:64] W1027 18:52:14.594334 reparent.go:188] master-elect tablet zone1-0000000100 is not a master in the shard, proceeding anyway as -force was used
+New VSchema object:
+{
+  "tables": {
+    "corder": {
+
+    },
+    "customer": {
+
+    },
+    "product": {
+
+    }
+  }
+}
+If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
+enter etcd2 env
+Access vtgate at http://ubuntu:15001/debug/status
+```
+
+You can continue the remaining parts of this example by following the [local](../../get-started/local) get started guide.
+
+### Full testsuite
+
+To run the testsuite in Docker:
+
+```sh
+make docker_test flavor=mysql57
+```
+
+Running the full suite currently takes 2+ hours to complete.
+
 ## Common Build Issues
 
 {{< info >}}
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
+
+### Key Already Exists
+
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:
+```
+Error:  105: Key already exists (/vitess/zone1) [6]
+Error:  105: Key already exists (/vitess/global) [6]
+```
+
+### MySQL Fails to Initialize
+
+This error is most likely the result of an AppArmor enforcing profile being present:
+
+```
+1027 18:28:23.462926   19486 mysqld.go:734] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: mysqld: [ERROR] Failed to open required defaults file: /home/morgo/vitess/vtdataroot/vt_0000000102/my.cnf
+mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
+
+could not stat mysql error log (/home/morgo/vitess/vtdataroot/vt_0000000102/error.log): stat /home/morgo/vitess/vtdataroot/vt_0000000102/error.log: no such file or directory
+E1027 18:28:23.464117   19486 mysqlctl.go:254] failed init mysql: /usr/sbin/mysqld: exit status 1, output: mysqld: [ERROR] Failed to open required defaults file: /home/morgo/vitess/vtdataroot/vt_0000000102/my.cnf
+mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
+E1027 18:28:23.464780   19483 mysqld.go:734] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: mysqld: [ERROR] Failed to open required defaults file: /home/morgo/vitess/vtdataroot/vt_0000000101/my.cnf
+mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
+```
+
+The following command disables the AppArmor profile for `mysqld`:
+
+```sh
+sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
+sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+```
+
+The following command should now return an empty result:
+```sh
+sudo aa-status | grep mysqld
+```
+
+If this doesn't work, you can try making sure all lurking processes are shutdown, and then restart the example again in the `/tmp` directory:
+
+```bash
+for process in `pgrep -f '(vtdataroot|VTDATAROOT)'`; do 
+ kill -9 $process
+done;
+
+export VTDATAROOT=/tmp/vtdataroot
+./101_initial_cluster.sh
+```
 
 ### Python Errors
 
@@ -123,6 +264,38 @@ The end-to-end test suite currently requires Python 2.7. We are working on remov
 make docker_test flavor=mysql57
 ```
 
-## Next steps
+### No .installed_version file
 
-Congratulations! You now have Vitess built locally. You can complete additional exercises by following along with [Run Vitess Locally](../../get-started/local) guide.
+This error indicates that you have not put the required vitess environment variables in your `.bashrc` file:
+
+```
+enter etcd2 env
+cat: /dist/etcd/.installed_version: No such file or directory
+```
+
+Make sure the following variables are defined:
+```sh
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
+```
+
+### Cannot create dir /etcd
+
+This indicates that the environment variable `VTDATAROOT` is not defined, and you have not put the required vitess environment variables in your `.bashrc` file:
+
+```
+./101_initial_cluster.sh
+enter etcd2 env
+mkdir: cannot create directory ‘/etcd’: Permission denied
+```
+
+Make sure the following variables are defined:
+```sh
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
+```
+

--- a/content/en/docs/contributing/build-from-source.md
+++ b/content/en/docs/contributing/build-from-source.md
@@ -80,15 +80,22 @@ brew install go automake git curl wget mysql57 etcd
 Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
 
 ```sh
-cd $WORKSPACE
+mkdir -p ~/vitess
+cd ~/vitess
 git clone https://github.com/vitessio/vitess.git \
     src/vitess.io/vitess
 cd src/vitess.io/vitess
 ```
 
-Build Vitess using the commands below. Note that the `bootstrap.sh` script needs to download some dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`).
+Set environment variables that Vitess will require. It is recommended to put these in your .bashrc:
 
-Run the boostrap.sh script:
+```sh
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export PATH=${VTROOT}/bin:${PATH}
+```
+
+Run `bootstrap.sh` script to download additional dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`):
 
 ```sh
 BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -8,7 +8,7 @@ aliases: ['/docs/contributing/build-from-source/']
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-The following has been verified to work on __Centos 7__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+The following has been verified to work on __CentOS 7__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
 ## Install Dependencies
 

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -169,10 +169,6 @@ Running the full suite currently takes 2+ hours to complete.
 
 ## Common Build Issues
 
-{{< info >}}
-If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
-{{< /info >}}
-
 ### Key Already Exists
 
 This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -1,0 +1,140 @@
+---
+title: Build on macOS
+description: Instructions for building Vitess on your machine for testing and development purposes
+---
+
+{{< info >}}
+If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
+{{< /info >}}
+
+The following has been verified to work on __TODO__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+
+## Install Dependencies
+
+[blah]
+
+## Build Vitess
+
+Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
+
+```sh
+mkdir -p ~/vitess
+cd ~/vitess
+git clone https://github.com/vitessio/vitess.git \
+    src/vitess.io/vitess
+cd src/vitess.io/vitess
+```
+
+Set environment variables that Vitess will require. It is recommended to put these in your `.bashrc`:
+
+```sh
+# TODO: macOS no longer uses bash. Check what we should do here...
+
+# Add go PATH
+export PATH=$PATH:/usr/local/go/bin
+
+# Vitess
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
+```
+
+Run `bootstrap.sh` script to download additional dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`):
+
+```sh
+BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
+```
+
+Build Vitess:
+
+```sh
+# Remaining commands to build Vitess
+source ./dev.env
+make build
+```
+
+## Testing your Binaries
+
+Run the included local example:
+
+```sh
+cd examples/local
+./101_initial_cluster.sh
+```
+
+You should see the following:
+```
+$ ./101_initial_cluster.sh 
+TODO: do a new paste here
+```
+
+You can continue the remaining parts of this example by following the [local](../../get-started/local) get started guide.
+
+### Full testsuite
+
+To run the testsuite in Docker:
+
+```sh
+make docker_test flavor=mysql57
+```
+
+Running the full suite currently takes 2+ hours to complete.
+
+## Common Build Issues
+
+{{< info >}}
+If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
+{{< /info >}}
+
+### Key Already Exists
+
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:
+```
+Error:  105: Key already exists (/vitess/zone1) [6]
+Error:  105: Key already exists (/vitess/global) [6]
+```
+
+### Python Errors
+
+The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, but in the mean time you can run tests from within Docker. The MySQL 5.7 container provided includes the required dependencies:
+
+```bash
+make docker_test flavor=mysql57
+```
+
+### No .installed_version file
+
+This error indicates that you have not put the required vitess environment variables in your `.bashrc` file:
+
+```
+enter etcd2 env
+cat: /dist/etcd/.installed_version: No such file or directory
+```
+
+Make sure the following variables are defined:
+```sh
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
+```
+
+### Cannot create dir /etcd
+
+This indicates that the environment variable `VTDATAROOT` is not defined, and you have not put the required vitess environment variables in your `.bashrc` file:
+
+```
+./101_initial_cluster.sh
+enter etcd2 env
+mkdir: cannot create directory ‘/etcd’: Permission denied
+```
+
+Make sure the following variables are defined:
+```sh
+export VTROOT=~/vitess
+export VTTOP=~/vitess/src/vitess.io/vitess
+export VTDATAROOT=~/vitess/vtdataroot
+export PATH=${VTROOT}/bin:${PATH}
+```
+

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -7,7 +7,7 @@ description: Instructions for building Vitess on your machine for testing and de
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-The following has been verified to work on macOS Mojave. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+The following has been verified to work on __macOS Mojave__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
 ## Install Dependencies
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -7,7 +7,7 @@ description: Instructions for building Vitess on your machine for testing and de
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-The following has been verified to work on __TODO__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+The following has been verified to work on macOS Mojave. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
 ## Install Dependencies
 
@@ -15,21 +15,20 @@ The following has been verified to work on __TODO__. If you are new to Vitess, i
 
 [Install Xcode](https://developer.apple.com/xcode/).
 
-### Install Homebrew
+### Install Homebrew and Dependencies
 
-[Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
-
-```
-sudo chown -R $(whoami):admin /usr/local
-```
-
-### Install Dependencies
-
-Run the following command:
+[Install Homebrew](http://brew.sh/). From here you should be able to install:
 
 ```
-brew install go automake git curl wget mysql57 etcd
+brew install go automake git curl wget mysql@5.7 etcd
 ```
+
+Follow the step to add mysql@5.7 to your PATH:
+```
+echo 'export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"' >> ~/.bash_profile
+```
+
+Do not setup MySQL or etcd to restart at login.
 
 ### Install Docker
 
@@ -47,14 +46,9 @@ git clone https://github.com/vitessio/vitess.git \
 cd src/vitess.io/vitess
 ```
 
-Set environment variables that Vitess will require. It is recommended to put these in your `.bashrc`:
+Set environment variables that Vitess will require. It is recommended to put these in your `~/.bash_profile` file:
 
 ```
-# TODO: macOS no longer uses bash. Check what we should do here...
-
-# Add go PATH
-export PATH=$PATH:/usr/local/go/bin
-
 # Vitess
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
@@ -68,10 +62,22 @@ Run `bootstrap.sh` script to download additional dependencies. If your machine r
 BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
 ```
 
+This may result in a warning about `$GOROOT` and an unsupported architecture. It is safe to ignore these errors for now:
+
+```
+morgans-mini:vitess morgo$ BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
+WARNING: $GOROOT may not be compatible with the used go binary
+Please make sure 'go' comes from $GOROOT/bin
+go_env: /usr/local/Cellar/go/1.12.6/libexec
+go_bin: /usr/local/bin/go
+creating git hooks
+installing protoc 3.6.1
+ERROR: unsupported architecture
+```
+
 Build Vitess:
 
 ```
-# Remaining commands to build Vitess
 source ./dev.env
 make build
 ```
@@ -88,7 +94,47 @@ cd examples/local
 You should see the following:
 ```
 $ ./101_initial_cluster.sh 
-TODO: do a new paste here
+morgans-mini:local morgo$ ./101_initial_cluster.sh 
+enter etcd2 env
+add /vitess/global
+add /vitess/zone1
+add zone1 CellInfo
+Error:  client: response is invalid json. The endpoint is probably not valid etcd cluster endpoint
+Error:  client: response is invalid json. The endpoint is probably not valid etcd cluster endpoint
+etcd start done...
+enter etcd2 env
+Starting vtctld...
+Access vtctld web UI at http://morgans-mini.lan:15000
+Send commands with: vtctlclient -server morgans-mini.lan:15999 ...
+enter etcd2 env
+Starting MySQL for tablet zone1-0000000100...
+Starting MySQL for tablet zone1-0000000101...
+Starting MySQL for tablet zone1-0000000102...
+Starting vttablet for zone1-0000000100...
+Access tablet zone1-0000000100 at http://morgans-mini.lan:15100/debug/status
+Starting vttablet for zone1-0000000101...
+Access tablet zone1-0000000101 at http://morgans-mini.lan:15101/debug/status
+Starting vttablet for zone1-0000000102...
+Access tablet zone1-0000000102 at http://morgans-mini.lan:15102/debug/status
+W1027 20:11:49.555831   35859 main.go:64] W1028 02:11:49.555179 reparent.go:182] master-elect tablet zone1-0000000100 is not the shard master, proceeding anyway as -force was used
+W1027 20:11:49.556456   35859 main.go:64] W1028 02:11:49.556135 reparent.go:188] master-elect tablet zone1-0000000100 is not a master in the shard, proceeding anyway as -force was used
+New VSchema object:
+{
+  "tables": {
+    "corder": {
+
+    },
+    "customer": {
+
+    },
+    "product": {
+
+    }
+  }
+}
+If this is not what you expected, check the input data (as JSON parsing will skip unexpected fields).
+enter etcd2 env
+Access vtgate at http://morgans-mini.lan:15001/debug/status
 ```
 
 You can continue the remaining parts of this example by following the [local](../../get-started/local) get started guide.

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -31,9 +31,9 @@ Run the following command:
 brew install go automake git curl wget mysql57 etcd
 ```
 
-#### Install Docker
+### Install Docker
 
-[Install Docker](https://docs.docker.com/docker-for-mac/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
+Running the testsuite requires that you [install Docker](https://docs.docker.com/docker-for-mac/). Should you decide to skip this step, you will still be able to compile and run Vitess.
 
 ## Build Vitess
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -27,7 +27,7 @@ sudo chown -R $(whoami):admin /usr/local
 
 Run the following command:
 
-```sh
+```
 brew install go automake git curl wget mysql57 etcd
 ```
 
@@ -39,7 +39,7 @@ brew install go automake git curl wget mysql57 etcd
 
 Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
 
-```sh
+```
 mkdir -p ~/vitess
 cd ~/vitess
 git clone https://github.com/vitessio/vitess.git \
@@ -49,7 +49,7 @@ cd src/vitess.io/vitess
 
 Set environment variables that Vitess will require. It is recommended to put these in your `.bashrc`:
 
-```sh
+```
 # TODO: macOS no longer uses bash. Check what we should do here...
 
 # Add go PATH
@@ -64,13 +64,13 @@ export PATH=${VTROOT}/bin:${PATH}
 
 Run `bootstrap.sh` script to download additional dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`):
 
-```sh
+```
 BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
 ```
 
 Build Vitess:
 
-```sh
+```
 # Remaining commands to build Vitess
 source ./dev.env
 make build
@@ -80,7 +80,7 @@ make build
 
 Run the included local example:
 
-```sh
+```
 cd examples/local
 ./101_initial_cluster.sh
 ```
@@ -97,7 +97,7 @@ You can continue the remaining parts of this example by following the [local](..
 
 To run the testsuite in Docker:
 
-```sh
+```
 make docker_test flavor=mysql57
 ```
 
@@ -121,7 +121,7 @@ Error:  105: Key already exists (/vitess/global) [6]
 
 The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, but in the mean time you can run tests from within Docker. The MySQL 5.7 container provided includes the required dependencies:
 
-```bash
+```
 make docker_test flavor=mysql57
 ```
 
@@ -135,7 +135,7 @@ cat: /dist/etcd/.installed_version: No such file or directory
 ```
 
 Make sure the following variables are defined:
-```sh
+```
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
 export VTDATAROOT=~/vitess/vtdataroot
@@ -153,7 +153,7 @@ mkdir: cannot create directory ‘/etcd’: Permission denied
 ```
 
 Make sure the following variables are defined:
-```sh
+```
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
 export VTDATAROOT=~/vitess/vtdataroot

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -23,7 +23,7 @@ The following has been verified to work on __macOS Mojave__. If you are new to V
 brew install go automake git curl wget mysql@5.7 etcd
 ```
 
-Follow the step to add mysql@5.7 to your PATH:
+Add `mysql@5.7` to your `PATH`:
 ```
 echo 'export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"' >> ~/.bash_profile
 ```
@@ -150,10 +150,6 @@ make docker_test flavor=mysql57
 Running the full suite currently takes 2+ hours to complete.
 
 ## Common Build Issues
-
-{{< info >}}
-If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
-{{< /info >}}
 
 ### Key Already Exists
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -11,7 +11,29 @@ The following has been verified to work on __TODO__. If you are new to Vitess, i
 
 ## Install Dependencies
 
-[blah]
+### Install Xcode
+
+[Install Xcode](https://developer.apple.com/xcode/).
+
+### Install Homebrew
+
+[Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
+
+```
+sudo chown -R $(whoami):admin /usr/local
+```
+
+### Install Dependencies
+
+Run the following command:
+
+```sh
+brew install go automake git curl wget mysql57 etcd
+```
+
+#### Install Docker
+
+[Install Docker](https://docs.docker.com/docker-for-mac/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
 
 ## Build Vitess
 

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -75,7 +75,7 @@ sudo aa-status | grep mysqld
 
 Navigate to the directory where you want to download the Vitess source code and clone the Vitess GitHub repo. After doing so, navigate to the `src/vitess.io/vitess` directory.
 
-```sh
+```
 mkdir -p ~/vitess
 cd ~/vitess
 git clone https://github.com/vitessio/vitess.git \
@@ -85,7 +85,7 @@ cd src/vitess.io/vitess
 
 Set environment variables that Vitess will require. It is recommended to put these in your `.bashrc`:
 
-```sh
+```
 # Additions to ~/.bashrc file
 
 # Add go PATH
@@ -100,13 +100,13 @@ export PATH=${VTROOT}/bin:${PATH}
 
 Run `bootstrap.sh` script to download additional dependencies. If your machine requires a proxy to access the Internet, you will need to set the usual environment variables (e.g. `http_proxy`, `https_proxy`, `no_proxy`):
 
-```sh
+```
 BUILD_PYTHON=0 BUILD_JAVA=0 ./bootstrap.sh
 ```
 
 Build Vitess:
 
-```sh
+```
 # Remaining commands to build Vitess
 source ./dev.env
 make build
@@ -116,7 +116,7 @@ make build
 
 Run the included local example:
 
-```sh
+```
 cd examples/local
 ./101_initial_cluster.sh
 ```
@@ -170,7 +170,7 @@ You can continue the remaining parts of this example by following the [local](..
 
 To run the testsuite in Docker:
 
-```sh
+```
 make docker_test flavor=mysql57
 ```
 
@@ -207,19 +207,19 @@ mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
 
 The following command disables the AppArmor profile for `mysqld`:
 
-```sh
+```
 sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
 sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
 ```
 
 The following command should now return an empty result:
-```sh
+```
 sudo aa-status | grep mysqld
 ```
 
 If this doesn't work, you can try making sure all lurking processes are shutdown, and then restart the example again in the `/tmp` directory:
 
-```bash
+```
 for process in `pgrep -f '(vtdataroot|VTDATAROOT)'`; do 
  kill -9 $process
 done;
@@ -232,7 +232,7 @@ export VTDATAROOT=/tmp/vtdataroot
 
 The end-to-end test suite currently requires Python 2.7. We are working on removing this dependency, but in the mean time you can run tests from within Docker. The MySQL 5.7 container provided includes the required dependencies:
 
-```bash
+```
 make docker_test flavor=mysql57
 ```
 
@@ -246,7 +246,7 @@ cat: /dist/etcd/.installed_version: No such file or directory
 ```
 
 Make sure the following variables are defined:
-```sh
+```
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
 export VTDATAROOT=~/vitess/vtdataroot
@@ -264,7 +264,7 @@ mkdir: cannot create directory ‘/etcd’: Permission denied
 ```
 
 Make sure the following variables are defined:
-```sh
+```
 export VTROOT=~/vitess
 export VTTOP=~/vitess/src/vitess.io/vitess
 export VTDATAROOT=~/vitess/vtdataroot

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -8,7 +8,7 @@ aliases: ['/docs/contributing/build-from-source/']
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-The following has been verified to work on __Ubuntu 19.10__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+The following has been verified to work on __Ubuntu 19.10__ and __Debian 10__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
 ## Install Dependencies
 
@@ -33,7 +33,11 @@ export PATH=$PATH:/usr/local/go/bin
 Install dependencies required to build and run Vitess:
 
 ```
-sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl
+# Ubuntu
+sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl git
+
+# Debian
+sudo apt-get install -y default-mysql-server default-mysql-client make unzip g++ etcd curl wget
 ```
 
 The services `mysqld` and `etcd` should be shutdown, since `etcd` will conflict with the `etcd` started in the examples, and `mysqlctl` will start its own copies of `mysqld`:
@@ -67,7 +71,7 @@ sudo aa-status | grep mysqld
 
 ### Install Docker
 
-[Install Docker](https://docs.docker.com/install/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
+Running the testsuite requires that you [install Docker](https://docs.docker.com/install/). Should you decide to skip this step, you will still be able to compile and run Vitess.
 
 ## Build Vitess
 

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -10,8 +10,6 @@ If you run into issues or have questions, we recommend posting in our [Slack cha
 
 The following has been verified to work on __Ubuntu 19.10__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
 
-For installation on macOS see __TODO__. If you would like to extend this guide for `yum` based distributions, please [send us a pull request](https://github.com/vitessio/website).
-
 ## Install Dependencies
 
 ### Install Go 1.12+

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -179,10 +179,6 @@ Running the full suite currently takes 2+ hours to complete.
 
 ## Common Build Issues
 
-{{< info >}}
-If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
-{{< /info >}}
-
 ### Key Already Exists
 
 This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -1,27 +1,24 @@
 ---
-title: Build From Source
+title: Build on Ubuntu/Debian
 description: Instructions for building Vitess on your machine for testing and development purposes
+aliases: ['/docs/contributing/build-from-source/']
 ---
 
 {{< info >}}
 If you run into issues or have questions, we recommend posting in our [Slack channel](https://vitess.slack.com), click the Slack icon in the top right to join. This is a very active community forum and a great place to interact with other users.
 {{< /info >}}
 
-The following sections explain the process for manually building Vitess on Linux and macOS. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+The following has been verified to work on __Ubuntu 19.10__. If you are new to Vitess, it is recommended to start with the [local install](../../get-started/local) guide instead.
+
+For installation on macOS see __TODO__. If you would like to extend this guide for `yum` based distributions, please [send us a pull request](https://github.com/vitessio/website).
 
 ## Install Dependencies
 
-Many of the Vitess developers use Ubuntu or macOS desktops. If you would like to extend this guide for `yum` based distributions, please [send us a pull request](https://github.com/vitessio/website).
-
-### Ubuntu and Debian
-
-In addition, Vitess requires the following software and libraries:
-
-#### Install Go 1.12+
+### Install Go 1.12+
 
 [Download and install](http://golang.org/doc/install) the latest version of Golang. For example, at writing:
 
-```sh
+```
 curl -O https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
 sudo tar -C /usr/local -xzf go1.13.3.linux-amd64.tar.gz
 ```
@@ -33,17 +30,17 @@ export PATH=$PATH:/usr/local/go/bin
 
 **Tip:** With Ubuntu 19.10 and later, you can also install the package `golang-go` via apt. Be careful doing this on older versions, as you may end up with an older version.
 
-#### Install Dependencies
+### Packages from apt repos
 
 Install dependencies required to build and run Vitess:
 
-```sh
+```
 sudo apt-get install -y mysql-server mysql-client make unzip g++ etcd curl
 ```
 
 The services `mysqld` and `etcd` should be shutdown, since `etcd` will conflict with the `etcd` started in the examples, and `mysqlctl` will start its own copies of `mysqld`:
 
-```sh
+```
 sudo service mysql stop
 sudo service etcd stop
 sudo systemctl disable mysql
@@ -51,53 +48,28 @@ sudo systemctl disable etcd
 ```
 
 **Notes:**
+
 * Vitess currently has some tests written in Python, but this dependency can be avoided by running the tests in Docker (recommended).
 * We will be using etcd as the topology service. The `bootstrap.sh` script can also install Zookeeper or Consul for you, which requires additional dependencies.
 
-## Disable mysqld AppArmor Profile
+### Disable mysqld AppArmor Profile
 
 The `mysqld` AppArmor profile will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:
 
-```sh
+```
 sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
 sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
 ```
 
 The following command should return an empty result:
 
-```sh
+```
 sudo aa-status | grep mysqld
 ```
 
-#### Install Docker
+### Install Docker
 
 [Install Docker](https://docs.docker.com/install/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
-
-### macOS
-
-#### Install Xcode
-
-[Install Xcode](https://developer.apple.com/xcode/).
-
-#### Install Homebrew
-
-[Install Homebrew](http://brew.sh/). If your `/usr/local` directory is not empty and you haven't yet used Homebrew, you need to run the following command:
-
-```sh
-sudo chown -R $(whoami):admin /usr/local
-```
-
-#### Install Dependencies
-
-Run the following command:
-
-```sh
-brew install go automake git curl wget mysql57 etcd
-```
-
-#### Install Docker
-
-[Install Docker](https://docs.docker.com/docker-for-mac/). This is only required to run the Vitess testsuite. Should you decide to skip this step, you will still be able to compile and run Vitess.
 
 ## Build Vitess
 


### PR DESCRIPTION
These are new build-from-source guides. It shows the progress we've made on trimming dependencies and simplifying things.

Some further improvements to the user experience:

1. I think we should change the `BUILD_JAVA` and `BUILD_PYTHON` defaults, since we don't require these to build and contribute (the docker bootstrap will need to turn them back on for its use case).

2. etcd should be removed from bootstrap and just become a dependency like MySQL is. We can reliably get it from distros, and that way it's patched and kept up to date. We will then modify the examples to search for etcd in $PATH. See: https://github.com/vitessio/vitess/pull/5365

3. Consul should also be gated (default to off, turned on inside docker).

4. This will make `proto` the only dependency that bootstrap needs to install. I don't have an answer for this one yet. Since it's the only dependency required, it feels like we should do something... especially since the version is pinned to [3.6.1](https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.1) (July 2018). Feedback welcome.

Edit: This requires https://github.com/vitessio/vitess/pull/5365 to merge for the macOS version to work.

Signed-off-by: Morgan Tocker <tocker@gmail.com>