### PR TITLE
Fix icon on homepage

### DIFF
--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -23,7 +23,7 @@
 
         <a class="button is-primary is-medium has-text-weight-bold" href="{{ "/docs/get-started/local" | relLangURL }}">
           <span class="icon has-text-black">
-            <i class="fas fa-hammer"></i>
+            <i class="fas fa-server"></i>
           </span>
           <span>
             {{ T "build" }}


### PR DESCRIPTION
The current icon indicates "build", which previously the local guide did require compiling.

This just changes to server, since pre-compiled binaries are used.

Fixes #246 

Signed-off-by: Morgan Tocker <tocker@gmail.com>