### PR TITLE
Remove confusing note about incubation

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -63,5 +63,5 @@ This is a list of third-party companies and individuals who provide products or 
 
 ### Acknowledgements
 
-Vitess [was born at YouTube](https://vitess.io/docs/overview/history/) in 2010, and joined the CNCF in [February 2018](https://www.cncf.io/blog/2018/02/05/cncf-host-vitess/) as an incubation project.
+Vitess [was born at YouTube](https://vitess.io/docs/overview/history/) in 2010, and joined the CNCF in [February 2018](https://www.cncf.io/blog/2018/02/05/cncf-host-vitess/).
 


### PR DESCRIPTION
The existing content is not wrong, but could be interpreted as Vitess is an incubating story. I think it is better to just say it joined the CNCF in Feb 2018, since the same sentence already links to history.

Signed-off-by: Morgan Tocker <tocker@gmail.com>