### PR TITLE
Vitess 5.0 install docs

### DIFF
--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -72,9 +72,8 @@ Set environment variables that Vitess will require. It is recommended to put the
 # Add go PATH
 export PATH=$PATH:/usr/local/go/bin
 
-# Vitess
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
+# Vitess binaries
+export PATH=~/vitess/bin:${PATH}
 ```
 
 Build Vitess:
@@ -104,7 +103,7 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]
@@ -123,36 +122,5 @@ E1027 18:28:23.464117   19486 mysqlctl.go:254] failed init mysql: /usr/sbin/mysq
 mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
 E1027 18:28:23.464780   19483 mysqld.go:734] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: mysqld: [ERROR] Failed to open required defaults file: /home/morgo/vitess/vtdataroot/vt_0000000101/my.cnf
 mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
-```
-
-### No .installed_version file
-
-This error indicates that you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-enter etcd2 env
-cat: /dist/etcd/.installed_version: No such file or directory
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
-```
-
-### Cannot create dir /etcd
-
-This indicates that the environment variable `VTROOT` is not defined, and you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-./101_initial_cluster.sh
-enter etcd2 env
-mkdir: cannot create directory ‘/etcd’: Permission denied
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
 ```
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -44,9 +44,8 @@ cd vitess
 Set environment variables that Vitess will require. It is recommended to put these in your `~/.bash_profile` file:
 
 ```
-# Vitess
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
+# Vitess binaries
+export PATH=~/vitess/bin:${PATH}
 ```
 
 Build Vitess:
@@ -83,40 +82,9 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]
-```
-
-### No .installed_version file
-
-This error indicates that you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-enter etcd2 env
-cat: /dist/etcd/.installed_version: No such file or directory
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
-```
-
-### Cannot create dir /etcd
-
-This indicates that the environment variable `VTROOT` is not defined, and you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-./101_initial_cluster.sh
-enter etcd2 env
-mkdir: cannot create directory ‘/etcd’: Permission denied
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
 ```
 

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -87,9 +87,8 @@ Set environment variables that Vitess will require. It is recommended to put the
 # Add go PATH
 export PATH=$PATH:/usr/local/go/bin
 
-# Vitess
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
+# Vitess binaries
+export PATH=~/vitess/bin:${PATH}
 ```
 
 Build Vitess:
@@ -120,7 +119,7 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh` and then start again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]
@@ -162,36 +161,5 @@ done;
 
 export VTDATAROOT=/tmp/vtdataroot
 ./101_initial_cluster.sh
-```
-
-### No .installed_version file
-
-This error indicates that you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-enter etcd2 env
-cat: /dist/etcd/.installed_version: No such file or directory
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
-```
-
-### Cannot create dir /etcd
-
-This indicates that the environment variable `VTROOT` is not defined, and you have not put the required vitess environment variables in your `.bashrc` file:
-
-```
-./101_initial_cluster.sh
-enter etcd2 env
-mkdir: cannot create directory ‘/etcd’: Permission denied
-```
-
-Make sure the following variables are defined:
-```
-export VTROOT=~/vitess
-export PATH=${VTROOT}/bin:${PATH}
 ```
 

--- a/content/en/docs/get-started/local.md
+++ b/content/en/docs/get-started/local.md
@@ -8,14 +8,6 @@ aliases: ['/docs/tutorials/local/']
 
 This guide covers installing Vitess locally for testing purposes, from pre-compiled binaries. We will launch multiple copies of `mysqld`, so it is recommended to have greater than 4GB RAM, as well as 20GB of available disk space.
 
-## Download Vitess Package
-
-Download and extract the [latest `.tar.gz` release](https://github.com/vitessio/vitess/releases) from GitHub. Use the following command to extract the file.
-
-```
-tar -zxvf latest-version.tar.gz
-```
-
 ## Install MySQL and etcd
 
 Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your installation method provides a choice:
@@ -29,7 +21,6 @@ sudo apt install -y default-mysql-server default-mysql-client etcd curl
 
 # Yum based
 sudo yum -y localinstall https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm
-
 sudo yum -y install mysql-community-server etcd curl
 ```
 
@@ -63,32 +54,39 @@ __SELinux__:
 sudo setenforce 0
 ```
 
-## Configure Environment
+## Install Vitess
 
-Add the following to your `$HOME/.bashrc` file. Make sure to replace `/path/to/extracted-tarball` with the actual path to where you extracted the latest release file:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 5.0:
 
 ```
-export VTROOT=/path/to/extracted-tarball
-export VTTOP=$VTROOT
-export VTDATAROOT=${HOME}/vtdataroot
-export PATH=${VTROOT}/bin:${PATH}
+tar -xzf vitess-5.20+20200204-17a806ae5.tar.gz
+cd vitess-5.20+20200204-17a806ae5
+sudo mkdir -p /usr/local/vitess
+sudo mv * /usr/local/vitess/
+```
+
+Make sure to add `/usr/local/vitess/bin` to the `PATH` environment variable. You can do this by adding the following to your `$HOME/.bashrc` file:
+
+```
+export PATH=/usr/local/vitess/bin:${PATH}
 ```
 
 You are now ready to start your first cluster! Open a new terminal window to ensure your `.bashrc` file changes take effect. 
 
 ## Start a Single Keyspace Cluster
 
-A [keyspace](../../concepts/keyspace) in Vitess is a logical database consisting of potentially multiple shards. For our first example, we are going to be using Vitess without sharding using a single keyspace. The file `101_initial_cluster.sh` is for example `1` phase `01`. Lets execute it now:
+Start by copying the local examples included with Vitess to your preferred location. For our first example we will deploy a [single unsharded keyspace](../../concepts/keyspace). The file `101_initial_cluster.sh` is for example `1` phase `01`. Lets execute it now:
 
 ```
-cd examples/local
+cp -r /usr/local/vitess/examples/local ~/my-vitess-example
+cd ~/my-vitess-example
 ./101_initial_cluster.sh
 ```
 
 You should see output similar to the following:
 
 ```
-~/...vitess/examples/local> ./101_initial_cluster.sh
+~/my-vitess-example> ./101_initial_cluster.sh
 enter etcd2 env
 add /vitess/global
 add /vitess/zone1
@@ -113,7 +111,7 @@ Starting vttablet for zone1-0000000102...
 You can also verify that the processes have started with `pgrep`:
 
 ```
-~/...vitess/examples/local> pgrep -fl vtdataroot
+~/my-vitess-example> pgrep -fl vtdataroot
 26563 etcd
 26626 vtctld
 26770 mysqld_safe
@@ -134,7 +132,7 @@ If you encounter any errors, such as ports already in use, you can kill the proc
 
 ```
 pkill -9 -e -f '(vtdataroot|VTDATAROOT)' # kill Vitess processes
-rm -rf ${HOME}/vtdataroot
+rm -rf vtdataroot
 ```
 
 ## Connect to Your Cluster
@@ -142,7 +140,7 @@ rm -rf ${HOME}/vtdataroot
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`. To connect to it with the `mysql` command line client:
 
 ```
-~/...vitess/examples/local> mysql -h 127.0.0.1 -P 15306
+~/my-vitess-example> mysql -h 127.0.0.1 -P 15306
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1
 Server version: 5.5.10-Vitess (Ubuntu)
@@ -179,7 +177,7 @@ EOF
 Repeating the previous step, you should now be able to use the `mysql` client without any settings:
 
 ```
-~/...vitess/examples/local> mysql
+~/my-vitess-example> mysql
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 1
 Server version: 5.5.10-Vitess (Ubuntu)
@@ -248,4 +246,5 @@ Or alternatively, if you would like to teardown your example:
 
 ```
 ./401_teardown.sh
+rm -rf vtdataroot
 ```


### PR DESCRIPTION
In Vitess 5.0, we will no longer need to set VTROOT.

I have modified the binary install instructions to install the download in `/usr/local/vitess` and then copy the examples directory for your usage locally. I think this will start to make more sense as we stream-line the examples and remove the other files... and then we encourage users to make their own edits.

Several of the common issues experienced are no longer relevant, because VTROOT is no longer required. vtdataroot will default to $PWD/vtdataroot.

Signed-off-by: Morgan Tocker <tocker@gmail.com>