### PR TITLE
Add reference to prebuilt binary for VTExplain.

### DIFF
--- a/content/en/docs/overview/supported-databases.md
+++ b/content/en/docs/overview/supported-databases.md
@@ -14,7 +14,7 @@ Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limit
 
 ## Vitess supports MariaDB versions 10.0 to 10.3
 
-Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess does not yet support version 10.4 of MariaDB.
+Vitess supports the core features of MariaDB versions 10.0 to 10.3. [Vitess does not yet support version 10.4 of MariaDB](https://github.com/vitessio/vitess/issues/5362).
 
 ## See also
 

--- a/content/en/docs/overview/supported-databases.md
+++ b/content/en/docs/overview/supported-databases.md
@@ -12,9 +12,9 @@ Vitess deploys, scales and manages clusters of open-source SQL database instance
 
 Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](https://vitess.io/docs/reference/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0. The [VTGate](https://vitess.io/docs/concepts/vtgate/) proxy server advertises its version as MySQL 5.7.
 
-## Vitess supports MariaDB version 10.0 to 10.3
+## Vitess supports MariaDB versions 10.0 to 10.3
 
-Vitess does not yet support version 10.4 of MariaDB.
+Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess does not yet support version 10.4 of MariaDB.
 
 ## See also
 

--- a/content/en/docs/overview/supported-databases.md
+++ b/content/en/docs/overview/supported-databases.md
@@ -1,0 +1,21 @@
+---
+title: Supported Databases  
+weight: 2
+featured: true
+---
+
+## Vitess supports MySQL and MariaDB
+
+Vitess deploys, scales and manages clusters of open-source SQL database instances. Currently, Vitess supports the [MySQL](https://www.oracle.com/mysql/) and [MariaDB](https://mariadb.org) databases.
+
+## Vitess supports MySQL versions 5.6 to 8.0
+
+Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](https://vitess.io/docs/reference/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0. The [VTGate](https://vitess.io/docs/concepts/vtgate/) proxy server advertises its version as MySQL 5.7.
+
+## Vitess supports MariaDB version 10.0 to 10.3
+
+Vitess does not yet support version 10.4 of MariaDB.
+
+## See also
+
++ [MySQL Compatibility](https://vitess.io/docs/reference/mysql-compatibility/)

--- a/content/en/docs/overview/whatisvitess.md
+++ b/content/en/docs/overview/whatisvitess.md
@@ -4,11 +4,11 @@ weight: 1
 featured: true
 ---
 
-Vitess is a database solution for deploying, scaling and managing large clusters of MySQL instances. It's architected to run as effectively in a public or private cloud architecture as it does on dedicated hardware. It combines and extends many important MySQL features with the scalability of a NoSQL database. Vitess can help you with the following problems:
+Vitess is a database solution for deploying, scaling and managing large clusters of open-source database instances. It currently supports MySQL and MariaDB. It's architected to run as effectively in a public or private cloud architecture as it does on dedicated hardware. It combines and extends many important SQL features with the scalability of a NoSQL database. Vitess can help you with the following problems:
 
-1. Scaling a MySQL database by allowing you to shard it, while keeping application changes to a minimum.
+1. Scaling a SQL database by allowing you to shard it, while keeping application changes to a minimum.
 2. Migrating from baremetal to a private or public cloud.
-3. Deploying and managing a large number of MySQL instances.
+3. Deploying and managing a large number of SQL database instances.
 
 Vitess includes compliant JDBC and Go database drivers using a native query protocol. Additionally, it implements the MySQL server protocol which is compatible with virtually any other language.
 

--- a/content/en/docs/reference/vtexplain.md
+++ b/content/en/docs/reference/vtexplain.md
@@ -9,7 +9,9 @@ The vtexplain tool provides information about how Vitess will execute a statemen
 
 ## Prerequisites
 
-You will need to build the `vtexplain` binary in your environment. To find instructions on how to build this binary please refer to the [Build From Source](../../contributing/build-from-source) guide.
+You can find a prebuilt binary version of the VTExplain tool in [the most recent release of Vitess](https://github.com/vitessio/vitess/releases/).
+
+You can also build the `vtexplain` binary in your environment. To find instructions on how to build this binary please refer to the [Build From Source](../../contributing/build-from-source) guide.
 
 ## Explaining a Query
 


### PR DESCRIPTION
I couldn't find any reference to this. Users may not want to configure a Go environment in order to use VTExplain.