### PR TITLE
Add local build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This repo houses the assets used to build the website at https://vitess.io.
 
 > **NOTE**: This repo uses `prod` as the default branch rather than the usual `master`. Make sure to rebase against the `prod` branch if you have existing work branched from `master`. See [issue #210](https://github.com/vitessio/website/issues/210) for an explanation of why this was done.
 
+## Running the site locally
+
+To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Once Hugo is installed run the following:
+
+```bash
+hugo server
+```
+
+This starts Hugo in local mode. You can see access the site at http://localhost:1313.
+
 ## Adding a user logo
 
 If you'd like to add your logo to the [Who uses Vitess](https://vitess.io/#who-uses) section of the website, add a PNG, JPEG, or SVG of your logo to the [`static/img/logos/users`](./static/img/logos/users) directory in this repo and submit a pull request with your change. Name the image file something that reflects your company (e.g., if your company is called Acme, name the image `acme.png`).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repo houses the assets used to build the website at https://vitess.io.
 To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Once Hugo is installed run the following:
 
 ```bash
-hugo server
+hugo server --buildDrafts --buildFuture
 ```
 
 This starts Hugo in local mode. You can see access the site at http://localhost:1313.


### PR DESCRIPTION
👋 Hello! I'm a technical writer with @cncf, working with @lucperkins to help our CNCF projects on their documentation journey. 

Luc asked me to take a look at the Vitess site and see what I could do. I have a few bigger things to propose, but first this PR: it's usually good to include local build steps in your README, so new contributors like me don't need to go poking into the Makefile to figure out exactly what static site generator is running and how to get it to serve up docs ;) 

Cheers,
Celeste