### PR TITLE
Improve CSS on homepage

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -5,7 +5,7 @@ $tan: #f5993a
 
 html, body
   overflow: auto
- 
+
 =flex
   display: flex
 
@@ -52,7 +52,7 @@ html, body
             font-size: 1.3rem
             color: $grey-lighter
             line-height: 100%
-            
+
             &.is-active
               color: $primary
 
@@ -77,7 +77,7 @@ html, body
                 &.is-active
                   a
                     color: $tan
-      
+
   .docs-article
     flex: 1 1 auto
     overflow: auto

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -94,7 +94,7 @@ figure
           font-style: normal;
           font-weight: 700;
 
-        
+
 
 .toc-column
   overlow-y: auto
@@ -147,8 +147,7 @@ figure
   justify-content: right
 
   .is-user-logo
-    max-height: 2.5rem
-    max-width: 10rem
+    max-height: 1.5rem
     margin: 1.25rem
 
 =logo($touch, $tablet)
@@ -174,7 +173,7 @@ figure
 
   .icon + span
     margin-left: .4rem
-
+    
 .section
   &.is-light
     background-color: $light

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -77,22 +77,22 @@ figure
       margin-bottom: 1.5rem
 
     figure
-      padding: 1em 0;
-      width: 100%;
-      max-width: 800px;
-      display: flex;
-      flex-direction: column;
-      margin: 0 auto;
+      padding: 1em 0
+      width: 100%
+      max-width: 800px
+      display: flex
+      flex-direction: column
+      margin: 0 auto
       img
-        border: 1px solid $grey-lighter;
+        border: 1px solid $grey-lighter
       figcaption
-        border: 1px solid $grey-lighter;
-        border-top: 0;
-        padding: 1em;
-        text-align: left;
+        border: 1px solid $grey-lighter
+        border-top: 0
+        padding: 1em
+        text-align: left
         .figure-title
-          font-style: normal;
-          font-weight: 700;
+          font-style: normal
+          font-weight: 700
 
 
 
@@ -173,7 +173,7 @@ figure
 
   .icon + span
     margin-left: .4rem
-    
+
 .section
   &.is-light
     background-color: $light

--- a/layouts/partials/home/cncf.html
+++ b/layouts/partials/home/cncf.html
@@ -1,6 +1,6 @@
 {{ $cncfLogo := "img/logos/cncf.png" | relURL }}
 <section class="section has-text-centered">
-  <p class="title is-size-3 is-size-4-mobile">
+  <p class="title is-size-4 is-size-4-mobile">
     {{ T "cncf" | markdownify }}
   </p>
 

--- a/layouts/partials/home/cncf.html
+++ b/layouts/partials/home/cncf.html
@@ -1,6 +1,6 @@
 {{ $cncfLogo := "img/logos/cncf.png" | relURL }}
 <section class="section has-text-centered">
-  <p class="title is-size-4 is-size-4-mobile">
+  <p class="title is-size-4 is-size-5-mobile">
     {{ T "cncf" | markdownify }}
   </p>
 


### PR DESCRIPTION
A few small changes to the CSS on the homepage:
- Reduce the title size of the " Vitess is a Cloud Native Computing Foundation graduated project" line. It's a touch large and aggressive at the moment :)
- Reduce `max-height` on the user logos in the homepage, and remove the `max-width` property entirely. This reduces the height a smidge (obviously) but more importantly removes the stretching/incorrect width:height ratio visible on some logos on the homepage. 