### PR TITLE
Updates contrib guides to require go 1.13

### DIFF
--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -12,13 +12,13 @@ The following has been verified to work on __CentOS 7__. If you are new to Vites
 
 ## Install Dependencies
 
-### Install Go 1.12+
+### Install Go 1.13+
 
-[Download and install](http://golang.org/doc/install) the latest version of Golang. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.13. For example, at writing:
 
 ```
-curl -O https://dl.google.com/go/go1.12.14.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.12.14.linux-amd64.tar.gz
+curl -O https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.13.9.linux-amd64.tar.gz
 ```
 
 Make sure to add go to your bashrc:

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -21,14 +21,14 @@ The following has been verified to work on __macOS Mojave__. If you are new to V
 [Install Homebrew](http://brew.sh/). From here you should be able to install:
 
 ```shell
-brew install go@1.12 automake git curl wget mysql@5.7 etcd
+brew install go@1.13 automake git curl wget mysql@5.7 etcd
 ```
 
-Add `mysql@5.7` and `go@1.12` to your `PATH`:
+Add `mysql@5.7` and `go@1.13` to your `PATH`:
 
 ```shell
 echo 'export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"' >> ~/.bash_profile
-echo 'export PATH="/usr/local/opt/go@1.12/bin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/go@1.13/bin:$PATH"' >> ~/.bash_profile
 ```
 
 Do not setup MySQL or etcd to restart at login.

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -12,21 +12,19 @@ The following has been verified to work on __Ubuntu 19.10__ and __Debian 10__. I
 
 ## Install Dependencies
 
-### Install Go 1.12+
+### Install Go 1.13+
 
-[Download and install](http://golang.org/doc/install) the latest version of Golang. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.13. For example, at writing:
 
 ```
-curl -O https://dl.google.com/go/go1.12.14.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.12.14.linux-amd64.tar.gz
+curl -O https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.13.9.linux-amd64.tar.gz
 ```
 
 Make sure to add go to your bashrc:
 ```
 export PATH=$PATH:/usr/local/go/bin
 ```
-
-**Tip:** With Ubuntu 19.10 and later, you can also install the package `golang-go` via apt. Be careful doing this on older versions, as you may end up with an older version.
 
 ### Packages from apt repos
 


### PR DESCRIPTION
This updates the documentation for https://github.com/vitessio/vitess/pull/5943

Signed-off-by: Morgan Tocker <tocker@gmail.com>