### PR TITLE
Update recent helm changes

### DIFF
--- a/content/en/docs/get-started/kubernetes.md
+++ b/content/en/docs/get-started/kubernetes.md
@@ -14,7 +14,7 @@ Before we get started, let’s get a few things out of the way:
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
 
     ```bash
-    minikube start --cpus=4 --memory=4000
+    minikube start
     ```
 
     Note the additional resource requirements. In order to go through all the use cases, many vttablet and MySQL instances will be launched. These require more resources than the defaults used by Minikube.
@@ -96,19 +96,19 @@ You can check the state of your cluster with `kubectl get pods,jobs`. After a fe
 ```sh
 $ kubectl get pods,jobs
 NAME                                           READY   STATUS      RESTARTS   AGE
-pod/commerce-apply-schema-initial-c9hrm        0/1     Completed   0          95s
-pod/commerce-apply-vschema-initial-tgk5h       0/1     Completed   0          95s
-pod/vtctld-58bd955948-56b77                    1/1     Running     0          95s
-pod/vtgate-zone1-c7444bbf6-25t7m               1/1     Running     3          95s
-pod/zone1-commerce-0-init-shard-master-7fzg9   0/1     Completed   0          95s
-pod/zone1-commerce-0-replica-0                 0/2     Running     0          95s
-pod/zone1-commerce-0-replica-1                 0/2     Running     0          95s
-pod/zone1-commerce-0-replica-2                 0/2     Running     0          95s
+pod/commerce-apply-schema-initial-vlc6k        0/1     Completed   0          2m42s
+pod/commerce-apply-vschema-initial-9wb2k       0/1     Completed   0          2m42s
+pod/vtctld-58bd955948-pgz7k                    1/1     Running     0          2m43s
+pod/vtgate-zone1-c7444bbf6-t5xc6               1/1     Running     3          2m43s
+pod/zone1-commerce-0-init-shard-master-gshz9   0/1     Completed   0          2m42s
+pod/zone1-commerce-0-replica-0                 2/2     Running     0          2m42s
+pod/zone1-commerce-0-replica-1                 2/2     Running     0          2m42s
+pod/zone1-commerce-0-replica-2                 2/2     Running     0          2m42s
 
 NAME                                           COMPLETIONS   DURATION   AGE
-job.batch/commerce-apply-schema-initial        1/1           87s        95s
-job.batch/commerce-apply-vschema-initial       1/1           81s        95s
-job.batch/zone1-commerce-0-init-shard-master   1/1           85s        95s
+job.batch/commerce-apply-schema-initial        1/1           94s        2m43s
+job.batch/commerce-apply-vschema-initial       1/1           87s        2m43s
+job.batch/zone1-commerce-0-init-shard-master   1/1           90s        2m43s
 ```
 
 ## Setup Port-forward

--- a/content/en/docs/get-started/kubernetes.md
+++ b/content/en/docs/get-started/kubernetes.md
@@ -17,8 +17,6 @@ Before we get started, let’s get a few things out of the way:
     minikube start
     ```
 
-    Note the additional resource requirements. In order to go through all the use cases, many vttablet and MySQL instances will be launched. These require more resources than the defaults used by Minikube.
-
 1. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and ensure it is in your `PATH`. For example, on Linux:
 
     ```bash

--- a/content/en/docs/user-guides/move-tables.md
+++ b/content/en/docs/user-guides/move-tables.md
@@ -74,20 +74,20 @@ After a few minutes the pods should appear running:
 ```sh
 $ kubectl get pods,jobs
 NAME                                           READY   STATUS      RESTARTS   AGE
-pod/vtctld-6f955957bb-jp2t2                    1/1     Running     0          18m
-pod/vtgate-zone1-86b7cb87d6-nsmw4              1/1     Running     3          18m
-pod/zone1-commerce-0-init-shard-master-d5vj4   0/1     Completed   0          18m
-pod/zone1-commerce-0-replica-0                 6/6     Running     0          18m
-pod/zone1-commerce-0-replica-1                 6/6     Running     0          18m
-pod/zone1-commerce-0-replica-2                 6/6     Running     0          18m
-pod/zone1-customer-0-init-shard-master-xhzsr   0/1     Completed   0          89s
-pod/zone1-customer-0-replica-0                 6/6     Running     0          89s
-pod/zone1-customer-0-replica-1                 6/6     Running     0          89s
-pod/zone1-customer-0-replica-2                 6/6     Running     0          89s
+pod/vtctld-58bd955948-pgz7k                    1/1     Running     0          5m36s
+pod/vtgate-zone1-c7444bbf6-t5xc6               1/1     Running     3          5m36s
+pod/zone1-commerce-0-init-shard-master-gshz9   0/1     Completed   0          5m35s
+pod/zone1-commerce-0-replica-0                 2/2     Running     0          5m35s
+pod/zone1-commerce-0-replica-1                 2/2     Running     0          5m35s
+pod/zone1-commerce-0-replica-2                 2/2     Running     0          5m35s
+pod/zone1-customer-0-init-shard-master-7w7rm   0/1     Completed   0          84s
+pod/zone1-customer-0-replica-0                 2/2     Running     0          84s
+pod/zone1-customer-0-replica-1                 2/2     Running     0          84s
+pod/zone1-customer-0-replica-2                 2/2     Running     0          84s
 
 NAME                                           COMPLETIONS   DURATION   AGE
-job.batch/zone1-commerce-0-init-shard-master   1/1           100s       18m
-job.batch/zone1-customer-0-init-shard-master   1/1           17s        89s
+job.batch/zone1-commerce-0-init-shard-master   1/1           90s        5m36s
+job.batch/zone1-customer-0-init-shard-master   1/1           23s        84s
 ```
 
 #### Using a Local Deployment
@@ -138,16 +138,12 @@ mysql --table < ../common/select_customer0_data.sql
 mysql --table < ../common/select_commerce_data.sql
 ```
 
-## Cleanup
+## Drop Sources
 
 The final step is to remove the data from the original keyspace. As well as freeing space on the original tablets, this is an important step to eliminate potential future confusions. If you have a misconfiguration down the line and accidentally route queries for the  `customer` and `corder` tables to `commerce`, it is much better to return a "table not found" error, rather than return stale data:
 
 ```sh
-vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 rdonly
-vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 replica
-vtctlclient SetShardTabletControl -blacklisted_tables=customer,corder -remove commerce/0 master
-vtctlclient ApplySchema -sql-file drop_commerce_tables.sql commerce
-vtctlclient ApplyRoutingRules -rules='{}'
+vtctlclient DropSources customer.commerce2customer
 ```
 
 After this step is complete, you should see the following error:


### PR DESCRIPTION
A few changes made, most fairly obvious from the diff:

- Reduced memory requirements, since we now use fewer pods (it now uses the default minikube of 3900MB, 2 vCPUs).
- Change the output to show the fewer pods
- Change to use pf.sh script
- Change the final delete step.
- Remove the vtctld script, since it's been removed from source.

I've also bumped the helm version, and tested on the latest minikube.

Signed-off-by: Morgan Tocker <tocker@gmail.com>