### PR TITLE
Change name of operator to conform with docs elsewhere.

### DIFF
--- a/content/en/docs/get-started/operator.md
+++ b/content/en/docs/get-started/operator.md
@@ -1,10 +1,10 @@
 ---
-title: Kubernetes Operator
+title: Vitess Operator for Kubernetes
 weight: 3
 featured: true
 ---
 
-PlanetScale provides a [Kubernetes Operator for Vitess](https://github.com/planetscale/vitess-operator), released under the Apache 2.0 license. The following steps show how to get started using Minikube:
+PlanetScale provides a [Vitess Operator for Kubernetes](https://github.com/planetscale/vitess-operator), released under the Apache 2.0 license. The following steps show how to get started using Minikube:
 
 ## Prerequisites
 


### PR DESCRIPTION
The PlanetScale docs for the operator call it the "Vitess Operator (for Kubernetes)". See https://docs.planetscale.com/vitess-operator/overview. It may be less confusing if the Vitess docs use the same title. Please feel free to suggest an alternative approach.