### PR TITLE
Clarify npm/yarn dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ hugo server --buildDrafts --buildFuture
 
 This starts Hugo in local mode. You can see access the site at http://localhost:1313.
 
+You will also need to either:
+
+- install `npm` and run `npm install` or,
+- install and run `yarn`
+
 ## Adding a user logo
 
 If you'd like to add your logo to the [Who uses Vitess](https://vitess.io/#who-uses) section of the website, add a PNG, JPEG, or SVG of your logo to the [`static/img/logos/users`](./static/img/logos/users) directory in this repo and submit a pull request with your change. Name the image file something that reflects your company (e.g., if your company is called Acme, name the image `acme.png`).


### PR DESCRIPTION
Fixes https://github.com/vitessio/website/issues/462

This clarifies in README.md that `npm` / `yarn` are required in order to test the site locally.