### PR TITLE
Replace slave with replica in vtctl commands and flags

### DIFF
--- a/content/en/docs/reference/programs/vtctl.md
+++ b/content/en/docs/reference/programs/vtctl.md
@@ -18,9 +18,12 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [DeleteTablet](../vtctl/tablets#deletetablet) | `DeleteTablet [-allow_master] <tablet alias> ...` |
 | [SetReadOnly](../vtctl/tablets#setreadonly) | `SetReadOnly <tablet alias>` |
 | [SetReadWrite](../vtctl/tablets#setreadwrite) | `SetReadWrite <tablet alias>` |
-| [StartSlave](../vtctl/tablets#startslave) | `StartSlave <tablet alias>` |
-| [StopSlave](../vtctl/tablets#stopslave) | `StopSlave <tablet alias>` |
-| [ChangeSlaveType](../vtctl/tablets#changeslavetype) | `ChangeSlaveType [-dry-run] <tablet alias> <tablet type>` |
+| [StartReplication](../vtctl/tablets#startreplication) `StartReplication <tablet alias>` |
+| [StartSlave](../vtctl/tablets#startreplication) | `DEPRECATED -- Use StartReplication <tablet alias>` |
+| [StopReplication](../vtctl/tablets#stopreplication) `StopReplication <tablet alias>` |
+| [StopSlave](../vtctl/tablets#stopreplication) | `DEPRECATED -- Use StopReplication <tablet alias>` |
+| [ChangeTabletType](../vtctl/tablets#changetablettype) `ChangeTabletType [-dry-run] <tablet alias> <tablet type>` |
+| [ChangeSlaveType](../vtctl/tablets#changetablettype) | `DEPRECATED -- Use ChangeTabletType [-dry-run] <tablet alias> <tablet type>` |
 | [Ping](../vtctl/tablets#ping) | `Ping <tablet alias>` |
 | [RefreshState](../vtctl/tablets#refreshstate) | `RefreshState <tablet alias>` |
 | [RefreshStateByShard](../vtctl/tablets#refreshstatebyshard) | `RefreshStateByShard [-cells=c1,c2,...] <keyspace/shard>` |

--- a/content/en/docs/reference/programs/vtctl.md
+++ b/content/en/docs/reference/programs/vtctl.md
@@ -18,11 +18,11 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [DeleteTablet](../vtctl/tablets#deletetablet) | `DeleteTablet [-allow_master] <tablet alias> ...` |
 | [SetReadOnly](../vtctl/tablets#setreadonly) | `SetReadOnly <tablet alias>` |
 | [SetReadWrite](../vtctl/tablets#setreadwrite) | `SetReadWrite <tablet alias>` |
-| [StartReplication](../vtctl/tablets#startreplication) `StartReplication <tablet alias>` |
+| [StartReplication](../vtctl/tablets#startreplication) | `StartReplication <tablet alias>` |
 | [StartSlave](../vtctl/tablets#startreplication) | `DEPRECATED -- Use StartReplication <tablet alias>` |
-| [StopReplication](../vtctl/tablets#stopreplication) `StopReplication <tablet alias>` |
+| [StopReplication](../vtctl/tablets#stopreplication) | `StopReplication <tablet alias>` |
 | [StopSlave](../vtctl/tablets#stopreplication) | `DEPRECATED -- Use StopReplication <tablet alias>` |
-| [ChangeTabletType](../vtctl/tablets#changetablettype) `ChangeTabletType [-dry-run] <tablet alias> <tablet type>` |
+| [ChangeTabletType](../vtctl/tablets#changetablettype) | `ChangeTabletType [-dry-run] <tablet alias> <tablet type>` |
 | [ChangeSlaveType](../vtctl/tablets#changetablettype) | `DEPRECATED -- Use ChangeTabletType [-dry-run] <tablet alias> <tablet type>` |
 | [Ping](../vtctl/tablets#ping) | `Ping <tablet alias>` |
 | [RefreshState](../vtctl/tablets#refreshstate) | `RefreshState <tablet alias>` |

--- a/content/en/docs/reference/programs/vtctl.md
+++ b/content/en/docs/reference/programs/vtctl.md
@@ -56,8 +56,8 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [ListBackups](../vtctl/shards#listbackups) | `ListBackups <keyspace/shard>` |
 | [BackupShard](../vtctl/shards#backupshard) | `BackupShard [-allow_master=false] <keyspace/shard>` |
 | [RemoveBackup](../vtctl/shards#removebackup) | `RemoveBackup <keyspace/shard> <backup name>` |
-| [InitShardMaster](../vtctl/shards#initshardmaster) | `InitShardMaster [-force] [-wait_slave_timeout=<duration>] <keyspace/shard> <tablet alias>` |
-| [PlannedReparentShard](../vtctl/shards#plannedreparentshard) | `PlannedReparentShard -keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-avoid_master=<tablet alias>] [-wait_slave_timeout=<duration>]` |
+| [InitShardMaster](../vtctl/shards#initshardmaster) | `InitShardMaster [-force] [-wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>` |
+| [PlannedReparentShard](../vtctl/shards#plannedreparentshard) | `PlannedReparentShard -keyspace_shard=<keyspace/shard> [-new_master=<tablet alias>] [-avoid_master=<tablet alias>] [-wait_replicas_timeout=<duration>]` |
 | [EmergencyReparentShard](../vtctl/shards#emergencyreparentshard) | `EmergencyReparentShard -keyspace_shard=<keyspace/shard> -new_master=<tablet alias>` |
 | [TabletExternallyReparented](../vtctl/shards#tabletexternallyreparented) | `TabletExternallyReparented <tablet alias>` |
 
@@ -111,8 +111,8 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [ReloadSchemaKeyspace](../vtctl/schema-version-permissions#reloadschemakeyspace) | `ReloadSchemaKeyspace  [-concurrency=10] [-include_master=false] <keyspace>` |
 | [ValidateSchemaShard](../vtctl/schema-version-permissions#validateschemashard) | `ValidateSchemaShard  [-exclude_tables=''] [-include-views] <keyspace/shard>` |
 | [ValidateSchemaKeyspace](../vtctl/schema-version-permissions#validateschemakeyspace) | `ValidateSchemaKeyspace  [-exclude_tables=''] [-include-views] <keyspace name>` |
-| [ApplySchema](../vtctl/schema-version-permissions#applyschema) | `ApplySchema  [-allow_long_unavailability] [-wait_slave_timeout=10s] {-sql=<sql> || -sql-file=<filename>} <keyspace>` |
-| [CopySchemaShard](../vtctl/schema-version-permissions#copyschemashard) | `CopySchemaShard  [-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] [-skip-verify] [-wait_slave_timeout=10s] {<source keyspace/shard> || <source tablet alias>} <destination keyspace/shard>` |
+| [ApplySchema](../vtctl/schema-version-permissions#applyschema) | `ApplySchema  [-allow_long_unavailability] [-wait_replicas_timeout=10s] {-sql=<sql> || -sql-file=<filename>} <keyspace>` |
+| [CopySchemaShard](../vtctl/schema-version-permissions#copyschemashard) | `CopySchemaShard  [-tables=<table1>,<table2>,...] [-exclude_tables=<table1>,<table2>,...] [-include-views] [-skip-verify] [-wait_replicas_timeout=10s] {<source keyspace/shard> || <source tablet alias>} <destination keyspace/shard>` |
 | [ValidateVersionShard](../vtctl/schema-version-permissions#validateversionshard) | `ValidateVersionShard  <keyspace/shard>` |
 | [ValidateVersionKeyspace](../vtctl/schema-version-permissions#validateversionkeyspace) | `ValidateVersionKeyspace  <keyspace name>` |
 | [GetPermissions](../vtctl/schema-version-permissions#getpermissions) | `GetPermissions  <tablet alias>` |

--- a/content/en/docs/reference/programs/vtctl/schema-version-permissions.md
+++ b/content/en/docs/reference/programs/vtctl/schema-version-permissions.md
@@ -152,7 +152,7 @@ Applies the schema change to the specified keyspace on every master, running in 
 
 #### Example
 
-<pre class="command-example">ApplySchema [-allow_long_unavailability] [-wait_slave_timeout=10s] {-sql=&lt;sql&gt; || -sql-file=&lt;filename&gt;} &lt;keyspace&gt;</pre>
+<pre class="command-example">ApplySchema [-allow_long_unavailability] [-wait_replicas_timeout=10s] {-sql=&lt;sql&gt; || -sql-file=&lt;filename&gt;} &lt;keyspace&gt;</pre>
 
 #### Flags
 
@@ -161,7 +161,7 @@ Applies the schema change to the specified keyspace on every master, running in 
 | allow_long_unavailability | Boolean | Allow large schema changes which incur a longer unavailability of the database. |
 | sql | string | A list of semicolon-delimited SQL commands |
 | sql-file | string | Identifies the file that contains the SQL commands |
-| wait_slave_timeout | Duration | The amount of time to wait for replicas to receive the schema change via replication. |
+| wait_replicas_timeout | Duration | The amount of time to wait for replicas to receive the schema change via replication. |
 
 
 #### Arguments
@@ -178,7 +178,7 @@ Copies the schema from a source shard's master (or a specific tablet) to a desti
 
 #### Example
 
-<pre class="command-example">CopySchemaShard [-tables=&lt;table1&gt;,&lt;table2&gt;,...] [-exclude_tables=&lt;table1&gt;,&lt;table2&gt;,...] [-include-views] [-wait_slave_timeout=10s] {&lt;source keyspace/shard&gt; || &lt;source tablet alias&gt;} &lt;destination keyspace/shard&gt;</pre>
+<pre class="command-example">CopySchemaShard [-tables=&lt;table1&gt;,&lt;table2&gt;,...] [-exclude_tables=&lt;table1&gt;,&lt;table2&gt;,...] [-include-views] [-wait_replicas_timeout=10s] {&lt;source keyspace/shard&gt; || &lt;source tablet alias&gt;} &lt;destination keyspace/shard&gt;</pre>
 
 #### Flags
 
@@ -187,7 +187,7 @@ Copies the schema from a source shard's master (or a specific tablet) to a desti
 | exclude_tables | string | Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/ |
 | include-views | Boolean | Includes views in the output |
 | tables | string | Specifies a comma-separated list of tables to copy. Each is either an exact match, or a regular expression of the form /regexp/ |
-| wait_slave_timeout | Duration | The amount of time to wait for replicas to receive the schema change via replication. |
+| wait_replicas_timeout | Duration | The amount of time to wait for replicas to receive the schema change via replication. |
 
 
 #### Arguments

--- a/content/en/docs/reference/programs/vtctl/shards.md
+++ b/content/en/docs/reference/programs/vtctl/shards.md
@@ -318,14 +318,14 @@ Sets the initial master for a shard. Will make all other tablets in the shard re
 
 #### Example
 
-<pre class="command-example">InitShardMaster [-force] [-wait_slave_timeout=&lt;duration&gt;] &lt;keyspace/shard&gt; &lt;tablet alias&gt;</pre>
+<pre class="command-example">InitShardMaster [-force] [-wait_replicas_timeout=&lt;duration&gt;] &lt;keyspace/shard&gt; &lt;tablet alias&gt;</pre>
 
 #### Flags
 
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
 | force | Boolean | will force the reparent even if the provided tablet is not a master or the shard master |
-| wait_slave_timeout | Duration | time to wait for replicas to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
 
 #### Arguments
@@ -353,7 +353,7 @@ Reparents the shard to the new master, or away from old master. Both old and new
 | avoid_master | string | alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master |
 | keyspace_shard | string | keyspace/shard of the shard that needs to be reparented |
 | new_master | string | alias of a tablet that should be the new master |
-| wait_slave_timeout | Duration | time to wait for replicas to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
 
 #### Errors
@@ -376,7 +376,7 @@ Reparents the shard to the new master. Assumes the old master is dead and not re
 | :-------- | :--------- | :--------- |
 | keyspace_shard | string | keyspace/shard of the shard that needs to be reparented |
 | new_master | string | alias of a tablet that should be the new master |
-| wait_slave_timeout | Duration | time to wait for replicas to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
 
 #### Errors

--- a/content/en/docs/reference/programs/vtctl/tablets.md
+++ b/content/en/docs/reference/programs/vtctl/tablets.md
@@ -172,13 +172,13 @@ Sets the tablet as read-write.
 * the <code>&lt;tablet alias&gt;</code> argument is required for the <code>&lt;SetReadWrite&gt;</code> command This error occurs if the command is not called with exactly one argument.
 * failed reading tablet %v: %v
 
-### StartSlave
+### StartReplication
 
 Starts replication on the specified tablet.
 
 #### Example
 
-<pre class="command-example">StartSlave &lt;tablet alias&gt;</pre>
+<pre class="command-example">StartReplication &lt;tablet alias&gt;</pre>
 
 #### Arguments
 
@@ -186,16 +186,16 @@ Starts replication on the specified tablet.
 
 #### Errors
 
-* action <code>&lt;StartSlave&gt;</code> requires <code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly one argument.
+* action <code>&lt;StartReplication&gt;</code> requires <code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly one argument.
 * failed reading tablet %v: %v
 
-### StopSlave
+### StopReplication
 
 Stops replication on the specified tablet.
 
 #### Example
 
-<pre class="command-example">StopSlave &lt;tablet alias&gt;</pre>
+<pre class="command-example">StopReplication &lt;tablet alias&gt;</pre>
 
 #### Arguments
 
@@ -203,16 +203,16 @@ Stops replication on the specified tablet.
 
 #### Errors
 
-* action <code>&lt;StopSlave&gt;</code> requires <code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly one argument.
+* action <code>&lt;StopReplication&gt;</code> requires <code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly one argument.
 * failed reading tablet %v: %v
 
-### ChangeSlaveType
+### ChangeTabletType
 
 Changes the db type for the specified tablet, if possible. This command is used primarily to arrange replicas, and it will not convert a master.<br><br>NOTE: This command automatically updates the serving graph.<br><br>
 
 #### Example
 
-<pre class="command-example">ChangeSlaveType [-dry-run] &lt;tablet alias&gt; &lt;tablet type&gt;</pre>
+<pre class="command-example">ChangeTabletType [-dry-run] &lt;tablet alias&gt; &lt;tablet type&gt;</pre>
 
 #### Flags
 
@@ -238,7 +238,7 @@ Changes the db type for the specified tablet, if possible. This command is used 
 
 #### Errors
 
-* the <code>&lt;tablet alias&gt;</code> and <code>&lt;db type&gt;</code> arguments are required for the <code>&lt;ChangeSlaveType&gt;</code> command This error occurs if the command is not called with exactly 2 arguments.
+* the <code>&lt;tablet alias&gt;</code> and <code>&lt;db type&gt;</code> arguments are required for the <code>&lt;ChangeTabletType&gt;</code> command This error occurs if the command is not called with exactly 2 arguments.
 * failed reading tablet %v: %v
 * invalid type transition %v: %v -&gt;</code> %v
 

--- a/content/en/docs/user-guides/reparenting.md
+++ b/content/en/docs/user-guides/reparenting.md
@@ -90,4 +90,4 @@ Active reparenting might be a dangerous practice in any system that depends on e
 
 ## Fixing Replication
 
-A tablet can be orphaned after a reparenting if it is unavailable when the reparent operation is running but then recovers later on. In that case, you can manually reset the tablet's master to the current shard master using the `vtctl ReparentTablet` command. You can then restart replication on the tablet if it was stopped by calling the `vtctl StartSlave` command.
+A tablet can be orphaned after a reparenting if it is unavailable when the reparent operation is running but then recovers later on. In that case, you can manually reset the tablet's master to the current shard master using the `vtctl ReparentTablet` command. You can then restart replication on the tablet if it was stopped by calling the `vtctl StartReplication` command.

--- a/content/zh/docs/reference/vtctl.md
+++ b/content/zh/docs/reference/vtctl.md
@@ -1091,7 +1091,7 @@ Applies the schema change to the specified keyspace on every master, running in 
 
 #### Example
 
-<pre class="command-example">ApplySchema [-allow_long_unavailability] [-wait_slave_timeout=10s] {-sql=&lt;sql&gt; || -sql-file=&lt;filename&gt;} &lt;keyspace&gt;</pre>
+<pre class="command-example">ApplySchema [-allow_long_unavailability] [-wait_replicas_timeout=10s] {-sql=&lt;sql&gt; || -sql-file=&lt;filename&gt;} &lt;keyspace&gt;</pre>
 
 #### Flags
 
@@ -1100,7 +1100,7 @@ Applies the schema change to the specified keyspace on every master, running in 
 | allow_long_unavailability | Boolean | Allow large schema changes which incur a longer unavailability of the database. |
 | sql | string | A list of semicolon-delimited SQL commands |
 | sql-file | string | Identifies the file that contains the SQL commands |
-| wait_slave_timeout | Duration | The amount of time to wait for slaves to receive the schema change via replication. |
+| wait_replicas_timeout | Duration | The amount of time to wait for slaves to receive the schema change via replication. |
 
 
 #### Arguments
@@ -1146,7 +1146,7 @@ Copies the schema from a source shard's master (or a specific tablet) to a desti
 
 #### Example
 
-<pre class="command-example">CopySchemaShard [-tables=&lt;table1&gt;,&lt;table2&gt;,...] [-exclude_tables=&lt;table1&gt;,&lt;table2&gt;,...] [-include-views] [-wait_slave_timeout=10s] {&lt;source keyspace/shard&gt; || &lt;source tablet alias&gt;} &lt;destination keyspace/shard&gt;</pre>
+<pre class="command-example">CopySchemaShard [-tables=&lt;table1&gt;,&lt;table2&gt;,...] [-exclude_tables=&lt;table1&gt;,&lt;table2&gt;,...] [-include-views] [-wait_replicas_timeout=10s] {&lt;source keyspace/shard&gt; || &lt;source tablet alias&gt;} &lt;destination keyspace/shard&gt;</pre>
 
 #### Flags
 
@@ -1155,7 +1155,7 @@ Copies the schema from a source shard's master (or a specific tablet) to a desti
 | exclude_tables | string | Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/ |
 | include-views | Boolean | Includes views in the output |
 | tables | string | Specifies a comma-separated list of tables to copy. Each is either an exact match, or a regular expression of the form /regexp/ |
-| wait_slave_timeout | Duration | The amount of time to wait for slaves to receive the schema change via replication. |
+| wait_replicas_timeout | Duration | The amount of time to wait for slaves to receive the schema change via replication. |
 
 
 #### Arguments
@@ -1578,7 +1578,7 @@ Reparents the shard to the new master. Assumes the old master is dead and not re
 | :-------- | :--------- | :--------- |
 | keyspace_shard | string | keyspace/shard of the shard that needs to be reparented |
 | new_master | string | alias of a tablet that should be the new master |
-| wait_slave_timeout | Duration | time to wait for slaves to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for slaves to catch up in reparenting |
 
 
 #### Errors
@@ -1611,14 +1611,14 @@ Sets the initial master for a shard. Will make all other tablets in the shard sl
 
 #### Example
 
-<pre class="command-example">InitShardMaster [-force] [-wait_slave_timeout=&lt;duration&gt;] &lt;keyspace/shard&gt; &lt;tablet alias&gt;</pre>
+<pre class="command-example">InitShardMaster [-force] [-wait_replicas_timeout=&lt;duration&gt;] &lt;keyspace/shard&gt; &lt;tablet alias&gt;</pre>
 
 #### Flags
 
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
 | force | Boolean | will force the reparent even if the provided tablet is not a master or the shard master |
-| wait_slave_timeout | Duration | time to wait for slaves to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for slaves to catch up in reparenting |
 
 
 #### Arguments
@@ -1677,7 +1677,7 @@ Reparents the shard to the new master, or away from old master. Both old and new
 | avoid_master | string | alias of a tablet that should not be the master, i.e. reparent to any other tablet if this one is the master |
 | keyspace_shard | string | keyspace/shard of the shard that needs to be reparented |
 | new_master | string | alias of a tablet that should be the new master |
-| wait_slave_timeout | Duration | time to wait for slaves to catch up in reparenting |
+| wait_replicas_timeout | Duration | time to wait for slaves to catch up in reparenting |
 
 
 #### Errors

--- a/wip-docs/user-guides/reparenting.md
+++ b/wip-docs/user-guides/reparenting.md
@@ -185,6 +185,6 @@ In that case, you can manually reset the tablet's master to the
 current shard master using the
 <code>[vtctl ReparentTablet]({% link reference/vtctl.md %}#reparenttablet)</code>
 command. You can then restart replication on the tablet if it was stopped
-by calling the <code>[vtctl StartSlave]({% link reference/vtctl.md %}#startslave)</code>
+by calling the <code>[vtctl StartReplication]({% link reference/vtctl.md %}#startreplication)</code>
 command.
 


### PR DESCRIPTION
- [x] Rename StopSlave -> StopReplication.
- [x] Rename StartSlave -> StartReplication.
- [x] Rename ChangeSlaveType -> ChangeTabletType.
- [x] Rename flag `wait_slave_timeout` to `wait_replicas_timeout` for all vtctl commands (ISM, PRS, ERS, ApplySchema, CopySchemaShard).

This is a companion PR to https://github.com/vitessio/vitess/pull/6428