### PR TITLE
Make docs dropdown menu fully accessible

### DIFF
--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -23,7 +23,7 @@
       </span>
     </a>
 
-    <div class="dropdown is-hoverable is-hidden-desktop is-right">
+    <div class="dropdown is-hoverable is-hidden-desktop">
       <div class="dropdown-trigger">
         <button class="button is-primary" aria-haspopup="true" aria-controls="docs-menu">
           <span>


### PR DESCRIPTION
Fixes #471

This fix makes the docs dropdown fully accessible on desktop and mobile. (This still isn't a perfect solution since, for very narrow displays, the dropdown now overflows on the right in a manner that isn't mobile friendly, but that should be addressed in a separate PR, if at all.)

cc @celestehorgan @zacharysarah

### Screenshot

![image](https://user-images.githubusercontent.com/4140793/88214738-a52a6a80-cc28-11ea-87f2-c6db22999367.png)
