### PR TITLE
Use date without time on blog. Add tag "release".

### DIFF
--- a/content/en/blog/2020-07-28-announcing-vitess-7.md
+++ b/content/en/blog/2020-07-28-announcing-vitess-7.md
@@ -1,8 +1,8 @@
 ---
 author: 'Deepthi Sigireddi'
-date: 2020-07-28T00:00:00-08:00
+date: 2020-07-28
 slug: '2020-07-28-announcing-vitess-7'
-tags: ['Guides']
+tags: ['release']
 title: 'Announcing Vitess 7'
 ---
 


### PR DESCRIPTION
We tend to copy from previous blogs. This is the recommendation from CNCF tech-docs team to avoid problems like what we ran into with trying to publish the 7.0 announcement blog post.

Signed-off-by: deepthi <deepthi@planetscale.com>