### PR TITLE
Updated the documentation for unmanaged tablets

### DIFF
--- a/content/en/docs/reference/programs/vttablet.md
+++ b/content/en/docs/reference/programs/vttablet.md
@@ -57,11 +57,19 @@ vttablet \
  -db_port 5726 \
  -db_app_user msandbox \
  -db_app_password msandbox \
+ -db_dba_user msandbox \
+ -db_dba_password msandbox \
+ -db_repl_user msandbox \
+ -db_repl_password msandbox \
+ -db_filtered_user msandbox \
+ -db_filtered_password msandbox \
+ -db_allprivs_user msandbox \
+ -db_allprivs_password msandbox \
  -init_db_name_override legacy \
  -init_populate_metadata &
 
 sleep 10
-vtctlclient InitShardMaster -force legacy/0 zone1-401
+vtctlclient TabletExternallyReparented zone1-401
 ```
 
 See [Unmanaged Tablet](../../../user-guides/unmanaged-tablet) for the full guide.


### PR DESCRIPTION
Key points:
- use `TabletExternallyReparented` instead of `InitShardMaster`
- pass replication source type to the MoveTables command
- instructions on how to move tables out of unmanaged tablets