### PR TITLE
fixing link to be correct

### DIFF
--- a/content/en/docs/reference/programs/vtctl/keyspaces.md
+++ b/content/en/docs/reference/programs/vtctl/keyspaces.md
@@ -139,7 +139,7 @@ Updates the sharding information for a keyspace.</pre>
 
 ### SetKeyspaceServedFrom
 
-Changes the ServedFromMap manually. This command is intended for emergency fixes. This field is automatically set when you call the [*MigrateServedFrom*](https://vitess.io/docs/reference/programs/vtctl/keyspaces/#migrateservedfrom-1) command. This command does not rebuild the serving graph.
+Changes the ServedFromMap manually. This command is intended for emergency fixes. This field is automatically set when you call the [*MigrateServedFrom*](https://vitess.io/docs/reference/programs/vtctl/keyspaces/#migrateservedfrom) command. This command does not rebuild the serving graph.
 
 #### Example
 


### PR DESCRIPTION
Of course I grabbed the link to the duplicate entry I deleted 🤦🏼 . I'm fixing the link to reference the correct *migrateservedfrom*