### PR TITLE
Fix navigation issue on vitess.io docs for vreplication links

### DIFF
--- a/content/en/docs/reference/compatibility/_index.md
+++ b/content/en/docs/reference/compatibility/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Compatibility
 description: Reference documents for MySQL compatibility with Vitess 
+weight: 4
 ---
 

--- a/content/en/docs/reference/features/_index.md
+++ b/content/en/docs/reference/features/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Features
 description: Reference documents for Vitess features
+weight: 1
 ---
 

--- a/content/en/docs/reference/programs/_index.md
+++ b/content/en/docs/reference/programs/_index.md
@@ -2,5 +2,6 @@
 title: Programs
 description: Reference documents for list of Vitess programs
 notoc: true
+weight: 2
 ---
 

--- a/content/en/docs/reference/vreplication/_index.md
+++ b/content/en/docs/reference/vreplication/_index.md
@@ -1,5 +1,6 @@
 ---
 title: VReplication
 description: Command references, architecture and design docs
+weight: 3
 ---
 

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -5,7 +5,7 @@
 <nav class="navbar docs-navbar is-dark">
   <div class="navbar-brand">
     <a class="navbar-item is-hidden-desktop" href="{{ site.BaseURL }}">
-      <img src="{{ $logoUrl }}" alt="Vitess logo">
+      <img src="{{ $logoUrl }}" alt="Vitess logo" style="height:42px;width:39px">
     </a>
 
     <a role="button" class="navbar-burger burger">

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -21,7 +21,7 @@
 
     {{ range .Sections }}
 
-    {{ if or (or (eq $currentSection "Features") (eq $currentSection "Programs")) }}
+    {{ if or (or (eq $currentSection "Features") (eq $currentSection "Programs") (eq $currentSection "VReplication")) }}
       {{ $currentSubSection = $currentSection }}
       {{ $currentSection = "Reference"}}
     {{ end }}


### PR DESCRIPTION
Added VReplication to hardcoded sections aliased to Reference. This fixes the problem where the navigation on the left was collapsing while selecting a VReplication link.

Also fixed a rendering issue where the navbar would flicker if logo loaded slowly.

Signed-off-by: Rohit Nayak <rohit@planetscale.com>