### PR TITLE
url to loc tag

### DIFF
--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -3,7 +3,7 @@
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
-    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <loc>**https://vitess.io/com**{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
     <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
     <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}


### PR DESCRIPTION
Google isn't reading the URLs of the new site map. This was one of the main recommended fixes [here](https://github.com/netlify-templates/victor-hugo/issues/142)