### PR TITLE
adding in an enabled robots.txt

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,6 +2,7 @@ baseURL = "https://vitess.io"
 canonifyurls = true
 disableKinds = ["taxonomy", "taxonomyTerm"]
 googleAnalytics = "UA-163836834-1"
+enableRobotsTXT = true
 
 # Syntax highlighting settings
 pygmentsCodeFences = true


### PR DESCRIPTION
We didn't have robots.txt either enabled or disabled. Our sitemap was getting a lot of no indexed links even though none of the links had a noindex header. Thus I'm adding in an enabled robots.txt to see if we can fix the no index issues by allowing the site to be crawled. 

If pages need to then be removed we can manually adjust the robots.txt that hugo will create. 