### PR TITLE
Mapping /blog/rss to /blog/index.xml

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -37,3 +37,7 @@
 /overview/*        /docs/overview/:splat
 /reference         /docs/reference
 /reference/*       /docs/reference/:splat
+
+# RSS URL Redirect
+/blog/rss          /blog/index.xml	 301
+


### PR DESCRIPTION
Looking at mapping the URL `blog/rss` to deliver RSS, in addition to `blog/index.xml`, as per comment https://github.com/vitessio/website/pull/595#pullrequestreview-536280795