### PR TITLE
Fix Open Graph meta tags for better unfurls

### DIFF
--- a/content/en/blog/2020-07-28-announcing-vitess-7.md
+++ b/content/en/blog/2020-07-28-announcing-vitess-7.md
@@ -4,6 +4,7 @@ date: 2020-07-28
 slug: '2020-07-28-announcing-vitess-7'
 tags: ['release']
 title: 'Announcing Vitess 7'
+description: 'We are pleased to announce the general availability of Vitess 7. Highlights include replica transactions, savepoint support, and per-session system variables.'
 ---
 
 On behalf of the Vitess maintainers team, I am pleased to announce the general availability of Vitess 7.

--- a/content/en/blog/2020-10-27-announcing-vitess-8.md
+++ b/content/en/blog/2020-10-27-announcing-vitess-8.md
@@ -4,6 +4,7 @@ date: 2020-10-27
 slug: '2020-10-27-announcing-vitess-8'
 tags: ['release']
 title: 'Announcing Vitess 8'
+description: 'We are pleased to announce the general availability of Vitess 8. In this release, we have continued to make important improvements to the Vitess project with over 200 PRs in several areas.'
 ---
 On behalf of the Vitess maintainers team, I am pleased to announce the general availability of [Vitess 8](https://github.com/vitessio/vitess/releases/tag/v8.0.0).
 
@@ -57,4 +58,3 @@ We continue to add integration of popular open-source tools and utilities on top
 There is a shortlist of incompatible changes in this release. We encourage you to spend a moment reading the release notes.
 
 Please download [Vitess 8](https://github.com/vitessio/vitess/releases/tag/v8.0.0) and try it out!
-

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -25,10 +25,10 @@
 {{ with $description }}
 <meta property="og:description" content="{{ . }}">
 {{ end }}
-<meta name="og:type" content="{{ $pageType }}">
-<meta name="og:image" content="{{ $imageUrl }}">
-<meta name="og:image:alt" content="Vitess project logo">
-<meta name="og:image:type" content="image/png">
+<meta property="og:type" content="{{ $pageType }}">
+<meta property="og:image" content="{{ $imageUrl }}">
+<meta property="og:image:alt" content="Vitess project logo">
+<meta property="og:image:type" content="image/png">
 
 
 <!-- Twitter Card metadata -->


### PR DESCRIPTION
Closes https://github.com/vitessio/website/issues/534 

## Changes
- Fixes a small typo in some of the `meta` tags: the property for [Open Graph](https://ogp.me) tags is `property` and not `name`. This should fix the unfurl behavior on sites like LinkedIn. 

- Updates two recent blog posts with a `description` property

## How to test this change
We can validate the LinkedIn embeds with the [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fvitess.io%2Fblog%2F2020-07-28-announcing-vitess-7%2F) once Netlify publishes a build for this PR. Here's what it looks like for the current page:

<img width="2672" alt="Screen Shot 2020-11-26 at 1 37 24 PM" src="https://user-images.githubusercontent.com/855595/100383815-8d0a9380-2fec-11eb-9a60-e17c640caa6e.png">

**Update:** [Here's what it looks like on this branch](https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fdeploy-preview-600--vitess.netlify.app%2Fblog%2F2020-10-27-announcing-vitess-8%2F) :tada:

<img width="2672" alt="Screen Shot 2020-11-26 at 1 42 01 PM" src="https://user-images.githubusercontent.com/855595/100384070-44070f00-2fed-11eb-89d3-8132d4cc133c.png">

## On `og:description`
The LinkedIn Post Inspector not only points out the missing `og:image` tag, but also a missing `og:description` tag. An easy fix, since we're already in here!

Authors can add per-post descriptions with the [`description` metadatum](https://gohugo.io/content-management/front-matter/#predefined), which will be used for the `og:description` Open Graph tag. I added two examples in this PR. Here's what it looks like in the source code:

<img width="2672" alt="Screen Shot 2020-11-26 at 1 28 01 PM" src="https://user-images.githubusercontent.com/855595/100383552-d5758180-2feb-11eb-8d26-c210575df19d.png">


