### PR TITLE
Add anchors to headings with a render hook

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -215,3 +215,11 @@ figure
 	.navbar-item-search
 		padding-left: 0
 	
+.header-link
+  color: $dark
+  opacity: 0.3 
+  transition: opacity 0.1s ease-in-out
+
+h1, h2, h3, h4, h5, h6
+  &:hover .header-link
+    opacity: 1

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -218,8 +218,7 @@ figure
 .header-link
   color: $dark
   opacity: 0.3 
-  transition: opacity 0.1s ease-in-out
+  transition: opacity 0.1s linear
 
-h1, h2, h3, h4, h5, h6
-  &:hover .header-link
+  &:hover
     opacity: 1

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -218,7 +218,6 @@ figure
 .header-link
   color: $dark
   opacity: 0.3 
-  transition: opacity 0.1s linear
 
   &:hover
     opacity: 1

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,0 +1,1 @@
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}">#</a></h{{ .Level }}>

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,1 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a href="#{{ .Anchor | safeURL }}">#</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a class="header-link" href="#{{ .Anchor | safeURL }}">#</a></h{{ .Level }}>


### PR DESCRIPTION
**Update:** Seems like the Hugo version we're using in Netlify is a few months out of date + doesn't support render hooks; see https://github.com/vitessio/website/pull/601#issuecomment-734459182

--

Hugo offers a ["render hook templates" feature](https://gohugo.io/getting-started/configuration-markup#heading-link-example), which we can use to add anchors beside every heading. 

Here's what it looks like locally:

<img width="2672" alt="Screen Shot 2020-11-26 at 2 45 18 PM" src="https://user-images.githubusercontent.com/855595/100387418-0fe41c00-2ff6-11eb-976d-1fb5cd8cfa06.png">

<img width="2672" alt="Screen Shot 2020-11-26 at 2 49 32 PM" src="https://user-images.githubusercontent.com/855595/100387648-9dc00700-2ff6-11eb-8d09-bf906af86d85.png">

I briefly considered setting `visibility:hidden` unless the heading is hovered, since that looks a little cleaner, similar to what GitHub does when rendering Markdown. Opacity, however, is a better approach since it's more accessible and works on mobile. 