### PR TITLE
cp -r files in /usr/local/vitess (instead of mv)

### DIFF
--- a/content/en/docs/get-started/local.md
+++ b/content/en/docs/get-started/local.md
@@ -64,7 +64,7 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 tar -xzf vitess-6.0.20-20200508-147bc5a.tar.gz
 cd vitess-6.0.20-20200508-147bc5a
 sudo mkdir -p /usr/local/vitess
-sudo mv * /usr/local/vitess/
+sudo cp -r * /usr/local/vitess/
 ```
 
 Make sure to add `/usr/local/vitess/bin` to the `PATH` environment variable. You can do this by adding the following to your `$HOME/.bashrc` file:


### PR DESCRIPTION
When using mv, the ownership of files are preserved, which is not right.  By using cp -r, the files are copied (instead of moved).  As this is run as root (sudo), the files are now owned by root, and the current user cannot modified them.