### PR TITLE
Upgrade to Hugo v0.78.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This repo houses the assets used to build the website at https://vitess.io.
 
 ## Running the site locally
 
-To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Once Hugo is installed run the following:
+To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Installing the Hugo version in [netlify.toml](./netlify.toml) is recommended.
+
+Once Hugo is installed run the following:
 
 ```bash
 hugo server --buildDrafts --buildFuture

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.65.3"
+HUGO_VERSION = "0.78.2"
 
 [context.production]
 HUGO_ENVIRONMENT = "production"


### PR DESCRIPTION
Upgrades to Hugo v.0.78.2. The [release notes](https://github.com/gohugoio/hugo/releases) do not mention any breaking changes. There are, however, tons of cool new features!

Building with Hugo v.0.78.2 works as expected on my machine. I will also check out the Netlify deploy once it's up. :) 

Upgrading Hugo will let us add section anchors by way of https://github.com/vitessio/website/pull/601, since render hooks were [added in v.0.71.0](https://github.com/gohugoio/hugo/releases/tag/v0.71.0).

We can likely add some makefile magic to verify that a user's local Hugo version matches the version in netlify.toml, but I'll leave that as a future enhancement. 