### PR TITLE
Show search input on all routes

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -211,7 +211,7 @@ figure
       min-width: fit-content
 
 
-// Snug up the search input + social icons for the full-width navbar  
+// Cuddle up the search input + social icons for the full-width navbar  
 +from($navbar-breakpoint)
 	.navbar-item-search
 		padding-left: 0

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -193,3 +193,5 @@ figure
   &.is-active
     position: fixed
 
+.navbar-item-search
+  padding-left: 0

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -193,5 +193,26 @@ figure
   &.is-active
     position: fixed
 
-.navbar-item-search
-  padding-left: 0
+// Display the search input above other nav links for the mobile navbar,
+// plus fixes for the DocSearch widget to prevent clipping on mobile.
++until($navbar-breakpoint)
+	.navbar-menu.is-active
+		display: flex
+		flex-direction: column-reverse
+
+  #search-bar
+    display: block
+
+  .algolia-autocomplete
+    display: block !important
+
+    .ds-dropdown-menu
+      max-width: 100vw
+      min-width: fit-content
+
+
+// Snug up the search input + social icons for the full-width navbar  
++from($navbar-breakpoint)
+	.navbar-item-search
+		padding-left: 0
+	

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -55,4 +55,4 @@ other = "Slack"
 other = "Stack Overflow"
 
 [search]
-other = "Search"
+other = "Search the docs"

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -55,4 +55,4 @@ other = "Slack"
 other = "Stack Overflow"
 
 [search]
-other = "Search"
+other = "Search the docs"

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -6,7 +6,6 @@
 {{ $cssProdOpts  := (dict "includePaths" $includes "targetPath" $target "outputStyle" "compressed") }}
 {{ $cssOpts      := cond $inServerMode $cssDevOpts $cssProdOpts }}
 {{ $css          := resources.Get $style | resources.ExecuteAsTemplate $style . | toCSS $cssOpts }}
-{{ $isDoc        := eq .Section "docs" }}
 {{ if $inServerMode }}
 <link rel="stylesheet" href="{{ $css.RelPermalink }}">
 {{ else }}
@@ -14,6 +13,4 @@
 <link rel="stylesheet" href="{{ $prodCss.RelPermalink }}" integrity="{{ $prodCss.Data.Integrity }}">
 {{ end }}
 
-{{ if $isDoc }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css">
-{{ end }}

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -17,7 +17,6 @@
 
   <div class="navbar-menu">
     <div class="navbar-end">
-      {{ partial "search-bar.html" . }}
 
       <a class="navbar-item has-text-weight-bold" href="{{ "/docs" | relLangURL }}">
         {{ T "docs" }}
@@ -34,6 +33,8 @@
       <div class="navbar-item">
         {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
       </div>
+
+      {{ partial "search-bar.html" . }}
     </div>
   </div>
 </nav>

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -33,8 +33,8 @@
       <div class="navbar-item">
         {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
       </div>
-
-      {{ partial "search-bar.html" . }}
-    </div>
+	</div>
+	
+	{{ partial "search-bar.html" . }}
   </div>
 </nav>

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -1,4 +1,3 @@
-{{ $isDoc        := eq .Section "docs" }}
 {{ $jsFiles := site.Params.assets.js }}
 {{ range $jsFiles }}
 {{ $path := printf "js/%s.js" . }}
@@ -6,7 +5,6 @@
 <script src="{{ $js.RelPermalink }}" integrity="{{ $js.Data.Integrity }}"></script>
 {{ end }}
 
-{{ if $isDoc }}
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
 <script type="text/javascript">
 docsearch({
@@ -16,4 +14,3 @@ docsearch({
   debug: false
 });
 </script>
-{{ end }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -88,9 +88,9 @@
         <div class="navbar-item">
           {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
         </div>
-
-        {{ partial "search-bar.html" . }}
-      </div>
+	  </div>
+	  
+	  {{ partial "search-bar.html" . }}
     </div>
   </div>
 </nav>

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -88,6 +88,8 @@
         <div class="navbar-item">
           {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
         </div>
+
+        {{ partial "search-bar.html" . }}
       </div>
     </div>
   </div>

--- a/layouts/partials/search-bar.html
+++ b/layouts/partials/search-bar.html
@@ -1,7 +1,7 @@
-<div class="navbar-item">
-  <p class="control has-icons-right">
+<div class="navbar-item navbar-item-search">
+  <p class="control has-icons-left">
     <input class="input" type="search" id="search-bar" placeholder="{{ T "search" }}">
-    <span class="icon is-small is-right">
+    <span class="icon is-small is-left">
       <i class="fas fa-sm fa-search"></i>
     </span>
   </p>


### PR DESCRIPTION
# Changes
- Shows the search input on all routes instead of just /docs, which closes #509
- Moves the search input to the right of the social icons, except on mobile where it appears first. This required some divergence from the [bulma.io](http://bulma.io/) styling, but not much. (Their breakpoints are quite nice!) 
- Fixes styling on the [DocSearch widget](https://docsearch.algolia.com/) for mobile (screenshot below)
- Updates search input placeholder text to be more specific about search scope ("Search the docs" instead of just "Search")
- Moves the search input's icon to the left, which looks cleaner when the "x" icon is shown

# Screenshots
| | Before (prod) | After (branch) |
|---|---|---|
| Landing page | <img width="2672" alt="searchbar-home-prod" src="https://user-images.githubusercontent.com/855595/100524033-c5dc7100-3182-11eb-926f-858a6cf69e02.png"> | <img width="2672" alt="searchbar-home-branch" src="https://user-images.githubusercontent.com/855595/100524035-ca088e80-3182-11eb-8b29-d13e88d04a4a.png"> |
| /docs | <img width="2672" alt="searchbar-docs-prod" src="https://user-images.githubusercontent.com/855595/100524037-cd9c1580-3182-11eb-846b-14a11f6dbe0b.png"> | <img width="2672" alt="searchbar-docs-branch" src="https://user-images.githubusercontent.com/855595/100524038-cf65d900-3182-11eb-903a-a3e45828221a.png"> |
| /blog | <img width="2672" alt="searchbar-blog-prod" src="https://user-images.githubusercontent.com/855595/100524042-d1c83300-3182-11eb-896a-533b32ddf0e5.png"> | <img width="2672" alt="searchbar-blog-branch" src="https://user-images.githubusercontent.com/855595/100524044-d4c32380-3182-11eb-9599-1d491936e086.png"> |
| Mobile | <img width="1355" alt="searchbar-mobile-prod" src="https://user-images.githubusercontent.com/855595/100524030-c07f2680-3182-11eb-87d7-bfc38368a853.png"> | <img width="1355" alt="searchbar-mobile-branch" src="https://user-images.githubusercontent.com/855595/100524031-c2e18080-3182-11eb-975c-f95f5f8d60a2.png"> | 


