### PR TITLE
Fix mobile nav scroll behavior + logo size

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -193,26 +193,25 @@ figure
   &.is-active
     position: fixed
 
-// Display the search input above other nav links for the mobile navbar,
-// plus fixes for the DocSearch widget to prevent clipping on mobile.
 +until($navbar-breakpoint)
-	.navbar-menu.is-active
-		display: flex
-		flex-direction: column-reverse
-
   #search-bar
     display: block
 
   .algolia-autocomplete
+    // Fixes for the DocSearch widget to prevent clipping on mobile.
     display: block !important
 
     .ds-dropdown-menu
       max-width: 100vw
       min-width: fit-content
 
-
-// Cuddle up the search input + social icons for the full-width navbar  
 +from($navbar-breakpoint)
+	// On mobile (and by default), the search input is displayed at the top of the menu,
+	// whereas on desktop, it's displayed at the right side of the menu bar (i.e., flex-end)
+	.navbar-menu
+		flex-direction: row-reverse
+
+	// Cuddle up the search input + social icons for the full-width navbar  	
 	.navbar-item-search
 		padding-left: 0
 	

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -202,8 +202,8 @@ figure
     display: block !important
 
     .ds-dropdown-menu
-      max-width: 100vw
-      min-width: fit-content
+      max-width: 100vw !important
+      min-width: fit-content !important
 
 +from($navbar-breakpoint)
 	// On mobile (and by default), the search input is displayed at the top of the menu,

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -16,6 +16,7 @@
   </div>
 
   <div class="navbar-menu">
+	{{ partial "search-bar.html" . }}
     <div class="navbar-end">
 
       <a class="navbar-item has-text-weight-bold" href="{{ "/docs" | relLangURL }}">
@@ -34,7 +35,5 @@
         {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
       </div>
 	</div>
-	
-	{{ partial "search-bar.html" . }}
   </div>
 </nav>

--- a/layouts/partials/docs/navbar.html
+++ b/layouts/partials/docs/navbar.html
@@ -5,7 +5,7 @@
 <nav class="navbar docs-navbar is-dark">
   <div class="navbar-brand">
     <a class="navbar-item is-hidden-desktop" href="{{ site.BaseURL }}">
-      <img src="{{ $logoUrl }}" alt="Vitess logo" style="height:42px;width:39px">
+      <img src="{{ $logoUrl }}" alt="Vitess logo" height="42">
     </a>
 
     <a role="button" class="navbar-burger burger">

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -26,6 +26,8 @@
     </div>
 
     <div class="navbar-menu">
+		{{ partial "search-bar.html" . }}
+		
       <div class="navbar-end">
         <div class="navbar-item has-dropdown is-hoverable">
           <a class="navbar-link has-text-weight-bold" href="{{ "/docs" | relLangURL }}">
@@ -89,8 +91,6 @@
           {{ partial "social-buttons.html" (dict "footer" false "social" $social) }}
         </div>
 	  </div>
-	  
-	  {{ partial "search-bar.html" . }}
     </div>
   </div>
 </nav>


### PR DESCRIPTION
Two small fixes in this one!

First, #609 introduced an annoying little bug: when opening mobile nav, the content is scrolled to the bottom. This is because I was setting `flex-direction: column-reverse` on mobile to place the search input at the beginning (top) of the nav on mobile and leaving it and the end (right) on desktop. It's simpler to let the menu be `display: block` on mobile + set the flex direction on desktop (which already uses `display flex`)

| Prod | Branch | 
|----|----|
| ![mobile-nav-scroll-bug](https://user-images.githubusercontent.com/855595/100546526-d696f080-322f-11eb-9132-f7edf418e997.gif)  | ![mobile-nav-scroll-fix](https://user-images.githubusercontent.com/855595/100546532-d8f94a80-322f-11eb-84f3-6d2bb8e8306f.gif) | 


Second, the mobile navbar Vitess logo was getting both height and width set, which made it look a lil squashed. All we need is a height. 

| Prod | Branch | 
|----|----|
| <img width="1392" alt="vitess-logo-squishy" src="https://user-images.githubusercontent.com/855595/100546608-4a38fd80-3230-11eb-8f14-395d14a4f1eb.png"> | <img width="1392" alt="vitess-logo-regular" src="https://user-images.githubusercontent.com/855595/100546610-4c02c100-3230-11eb-8eae-440c2f460484.png"> |

