### PR TITLE
Add breadcrumb navigation to docs (for desktop)

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -53,7 +53,7 @@ figure
 .has-extra-padding
   padding: 2.5rem
 
-.docs-article ul li
+.docs-article .content ul li
   margin-left: -.5rem
   list-style-type: square
 

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -3,6 +3,34 @@
 {{ $language     := .Language }}
 {{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
 <header class="docs-header">
+  {{/* Hide breadcrumbs on mobile since bulma.io doesn't handle overflows nicely for long crumbs */}}
+  <nav class="breadcrumb is-hidden-touch" aria-label="breacrumbs">
+    <ul>
+      {{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
+    </ul>
+
+    {{/* See: https://gohugo.io/content-management/sections/#example-breadcrumb-navigation */}}
+    {{ define "breadcrumbnav" }}
+      {{ $isCurrentPage := eq .p1 .p2 }}
+      
+      {{ if .p1.Parent }}
+        {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  }}
+      {{ else if not .p1.IsHome }}
+        {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
+      {{end}}
+      
+      {{/* No breadcrumb for root URL since we already have the logo */}}
+      {{ if not .p1.IsHome }}
+        {{/* No breadcrumb if the current page is the first and only breadcrumb */}}
+        {{ if not (and .p1.Parent.IsHome $isCurrentPage) }}
+          <li {{ if eq .p1 .p2}}class="is-active"{{end}}>
+            <a href="{{ .p1.Permalink }}">{{ .p1.Title }}</a>
+          </li>
+        {{end}}
+      {{ end }}
+    {{ end }}
+  </nav>
+
   <p class="title is-size-1 is-size-2-mobile has-text-weight-light{{ if .Params.description }} is-spaced{{ end }}">
     {{ .Title }}
   </p>


### PR DESCRIPTION
In reading the Hugo docs for https://github.com/vitessio/website/issues/342, I found an [example of breadcrumb navigation](https://gohugo.io/content-management/sections/#example-breadcrumb-navigation) which seems like a useful enhancement. There isn't an open GitHub issue for this, so I understand if you'd rather not merge it! :) 

A couple small details to note!

First, here's what it looks like on the /docs route where breadcrumbs are NOT shown. This is because /docs is the root of the breadcrumb navigation, so the "breadcrumbs" render as a single, unlinked `<li>` and it looked goofy.

<img width="2672" alt="Screen Shot 2020-11-29 at 1 01 29 PM" src="https://user-images.githubusercontent.com/855595/100549858-95104080-3243-11eb-9287-c239df1ed3c8.png">

Here's what the breadcrumbs look like as you navigate through the doc hierarchy. As pointed out in #342, the "Reference" section of the docs has three levels of navigation, which still works just fine.

<img width="2672" alt="Screen Shot 2020-11-29 at 1 06 58 PM" src="https://user-images.githubusercontent.com/855595/100549898-eae4e880-3243-11eb-8601-145978b739b7.png">
<img width="2672" alt="Screen Shot 2020-11-29 at 1 07 00 PM" src="https://user-images.githubusercontent.com/855595/100549899-ecaeac00-3243-11eb-8054-e6b5f73d6a7a.png">
<img width="2672" alt="Screen Shot 2020-11-29 at 1 07 04 PM" src="https://user-images.githubusercontent.com/855595/100549900-ee786f80-3243-11eb-9145-dd04453ff1b2.png">

Here's an example of a particularly long breadcrumb:

<img width="2672" alt="Screen Shot 2020-11-29 at 1 11 26 PM" src="https://user-images.githubusercontent.com/855595/100549952-68105d80-3244-11eb-9ecb-9a49ccf6ff1a.png">

Finally, I decided to hide the breadcrumbs on mobile/tablet. This isn't _ideal_ since I think they'd be particularly useful on mobile. However, [bulma.io's breadcrumb component](https://bulma.io/documentation/components/breadcrumb/) doesn't handle reflows very well: 

<img width="2672" alt="Screen Shot 2020-11-29 at 1 01 57 PM" src="https://user-images.githubusercontent.com/855595/100549916-21226800-3244-11eb-92d4-5cfcab90d6a5.png">

 I spent a bit of time messing with the CSS, but didn't end up with anything I was happy with. I think mobile breadcrumbs deserve special consideration (like a dropdown, perhaps combined with the current orange dropdown?) and a separate PR. :) 