### PR TITLE
Fix overflow on docs sidebar + remove table of contents from section pages 

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -28,7 +28,7 @@ html, body
     background-color: $dark
     flex: 0 0 15%
     border-right: 1px solid lighten($dark, 10%)
-    overflow: scroll
+    overflow: auto
 
     .docs-menu
       width: 100%
@@ -171,4 +171,3 @@ html, body
   margin-left: 30px;
   background-color: #f7f7f7;
   margin-bottom: 10px;
-

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -32,7 +32,5 @@
     
     </article>
   </div>
-
-  {{ partial "docs/toc.html" . }}
 </div>
 {{ end }}


### PR DESCRIPTION
Two very tiny fixes in this one!

First, changes the docs sidebar to use `overflow: auto`, since `overflow: scroll` on the docs sidebar shows the scrollbar placeholders even when no overflow is happening. 

| Before (prod) | Branch (after) |
|--|--|
| <img width="2672" alt="docs-sidebar-overflow-scroll" src="https://user-images.githubusercontent.com/855595/100618838-571a2780-32ea-11eb-962b-316f9722d4d7.png"> | <img width="2672" alt="docs-sidebar-overflow-auto" src="https://user-images.githubusercontent.com/855595/100618859-5e413580-32ea-11eb-9bb5-3d26ff3ecbf4.png"> |


Second, this removes the table of contents sidebar (on the right) from "section" page templates. The table of contents always (?) empty on these pages and, in any case, somewhat redundant given that the pages themselves are a table of contents. :) Example: https://deploy-preview-614--vitess.netlify.app/docs/reference/

| Before (prod) | Branch (after) |
|--|--|
| <img width="2672" alt="docs-section-with-toc" src="https://user-images.githubusercontent.com/855595/100618937-787b1380-32ea-11eb-882b-a162743d76de.png"> | <img width="2672" alt="docs-section-no-toc" src="https://user-images.githubusercontent.com/855595/100618977-829d1200-32ea-11eb-81b2-b87a872c1bf9.png"> | 

