### PR TITLE
Fix occlusion of headings + navbar when jumping to heading anchors

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -221,3 +221,17 @@ figure
 
   &:hover
     opacity: 1
+
+// When jumping to anchor links, we need to account for the height of the sticky navbar.
+// Otherwise, the anchored header will be occluded by the navbar. 
+// See https://css-tricks.com/hash-tag-links-padding/
+$navbar-anchor-offset: calc(#{$navbar-height} + 16px)
+
+h1, h2, h3, h4, h5, h6
+  &:before
+    display: block
+    content: ' '
+    margin-top: calc(-1 * #{$navbar-anchor-offset})
+    height: $navbar-anchor-offset
+    visibility: hidden
+    pointer-events: none


### PR DESCRIPTION
# Changes

Up until now, clicking an anchor link to a heading results in the heading being occluded by the sticky navbar. This is true for links in the table of contents (on the right side) and the new links on the headings added in https://github.com/vitessio/website/pull/601. Here's what that looks like: https://deploy-preview-617--vitess.netlify.app/docs/reference/features/vreplication/

![header-offset-bug](https://user-images.githubusercontent.com/855595/100665648-4091c180-3326-11eb-960d-b9815e171326.gif)

The fix involves some admittedly obscure CSS contortions. Here's a good write-up on it: https://css-tricks.com/hash-tag-links-padding/ And here's what it looks like on desktop + mobile:

![header-offset-fix](https://user-images.githubusercontent.com/855595/100666101-7636aa80-3326-11eb-8cc2-4c3e68783bf2.gif)
![header-offset-fix-mobile](https://user-images.githubusercontent.com/855595/100666105-7767d780-3326-11eb-9c4d-68dbe6927abb.gif)

# One small caveat...

There is a _tiny_ bit of collateral damage from this. Pages other than the /docs pages (like Blog + Community) use a different navbar. As a result, the margin ends up being a bit _too_ generous. Here's a comparison of prod vs. this branch. You can see that prod snugs up the header + heading a little more closely: https://deploy-preview-617--vitess.netlify.app/blog/2020-10-27-announcing-vitess-8

| Prod | Branch |
|---|---|
| ![header-offset-prod-blog](https://user-images.githubusercontent.com/855595/100666862-bcd8d480-3327-11eb-8594-0109fc1a65ba.gif) | ![header-offset-fix-blog](https://user-images.githubusercontent.com/855595/100666864-be0a0180-3327-11eb-9f38-ec4ec05b669b.gif) | 

I _think_ there's likely some Hugo magic we could do to target docs-specific headings for the extra margin. However, I think it'd be cleaner + more consistent overall to unify the docs + non-docs navbars to use the same partial. 

I defer to y'all as to whether this is a dealbreaker, of course! 
