### PR TITLE
Only add spacing pseudo-element to headings rendered with render-heading.html

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -228,7 +228,7 @@ figure
 $navbar-anchor-offset: calc(#{$navbar-height} + 16px)
 
 h1, h2, h3, h4, h5, h6
-  &:before
+  &.anchored-header[id]:before
     display: block
     content: ' '
     margin-top: calc(-1 * #{$navbar-anchor-offset})

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -1,1 +1,1 @@
-<h{{ .Level }} id="{{ .Anchor | safeURL }}">{{ .Text | safeHTML }} <a class="header-link" href="#{{ .Anchor | safeURL }}">#</a></h{{ .Level }}>
+<h{{ .Level }} id="{{ .Anchor | safeURL }}" class="anchored-header">{{ .Text | safeHTML }} <a class="header-link" href="#{{ .Anchor | safeURL }}">#</a></h{{ .Level }}>


### PR DESCRIPTION
Closes https://github.com/vitessio/website/issues/619

Soooo, #617 added a pseudo-element that adds spacing to account for the navbar when jumping to header links. Unfortunately, that didn't go so well for pages using the [landing-page.html](https://github.com/vitessio/website/blob/29f5773732c7604e6aeccc2f5c6c87823af3c947/layouts/partials/docs/landing-page.html) partial, like this one: https://vitess.io/docs/user-guides/

![image](https://user-images.githubusercontent.com/855595/100812888-174b6100-340c-11eb-8164-d342927cbb8f.png)

There were a few issues happening here.......... which I will describe in way too much detail. 😂 

Each of those sections on the landing page corresponds to a `.card` class, which is styled by bulma.io. `.card` classes have `position: relative` and also `background: white`. Further, the heading `:before` pseudo-element has `visibility: hidden`, so it takes up space in the DOM. As a result, the card ends up too tall and overlaps whatever's above it:

<img width="1792" alt="Screen Shot 2020-12-01 at 7 34 51 PM" src="https://user-images.githubusercontent.com/855595/100813041-701af980-340c-11eb-8463-a5fdffbd902d.png">

One thing I was unsure of: why do those headings in the cards not have `#` anchors? Well, the render-heading.html render hook added in #601 _only_ runs on Markdown files. The card headers are defined in `landing-page.html`, which is not a Markdown file. :)

So, this PR ultimately does two tiny things:
- Adds a new `.anchored-header` class to the render-heading.html render hook, so that _only_ headings rendered with that hook get the psuedo-class
- Also only add the spacing for headings that have an `id` property defined (which should always be the case, but! doesn't hurt) 

Aaand back to normal: https://deploy-preview-620--vitess.netlify.app/docs/user-guides/

<img width="1792" alt="Screen Shot 2020-12-01 at 7 43 12 PM" src="https://user-images.githubusercontent.com/855595/100813524-84132b00-340d-11eb-8746-627e008f068a.png">

