### PR TITLE
Update docs navigation to handle hierarchies of any depth

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -1,5 +1,4 @@
 $docs-sidebar-logo-width: 30%
-$docs-sidebar-margin: 1.75rem
 $docs-sidebar-header-margin-bottom: 2rem
 $tan: #f5993a
 
@@ -18,150 +17,144 @@ html, body
   height: 100vh
   align-items: stretch
 
-  .docs-navbar
-    position: sticky
-    top: 0
+.docs-navbar
+  position: sticky
+  top: 0
 
-  .docs-sidebar
-    +flex
-    +h-center
-    background-color: $dark
-    flex: 0 0 15%
-    border-right: 1px solid lighten($dark, 10%)
-    overflow: auto
+.docs-sidebar
+  +flex
+  +h-center
+  background-color: $dark
+  flex: 0 0 15%
+  border-right: 1px solid lighten($dark, 10%)
+  overflow: auto
 
-    .docs-menu
-      width: 100%
-      margin: $docs-sidebar-margin
+.docs-menu
+  width: 100%
+  margin: 24px 0 24px 0
 
-      .docs-menu-header
-        margin-bottom: $docs-sidebar-header-margin-bottom
+.docs-menu-header
+  margin-bottom: $docs-sidebar-header-margin-bottom
 
-        .docs-menu-logo
-          width: $docs-sidebar-logo-width
-          margin: 0 auto
-          display: block
+.docs-menu-logo
+    margin: 0 auto
+    display: block
 
-      .docs-menu-bar
-        padding-bottom: 5rem
+.docs-menu > .docs-navlist > li > a
+  font-size: 1.2rem
 
-        .docs-section
-          & + .docs-section
+.docs-navlist ul > li
+  border-left: solid 1px rgba(255, 255, 255, 0.1)
+  margin-left: 16px
+
+.docs-navlist li
+  position: relative
+
+.docs-navlist li a
+  color: $grey-lighter
+  display: block
+  font-size: 0.9rem
+  padding: 8px 24px 8px 16px
+
+  &:hover
+    background: rgba(255, 255, 255, 0.05)
+
+.docs-navlist li.active > a 
+  color: $tan
+
+.navlist-caret
+  height: 10px
+  margin-top: -5px
+  position: absolute
+  right: 16px
+  top: 22px
+  fill: rgba(255, 255, 255, 0.25)
+
+li.expanded > a > .navlist-caret
+  transform: rotate(90deg)
+
+.docs-article
+  flex: 1 1 auto
+  overflow: auto
+
+  .docs-content
+    margin: 2rem 2.5rem
+
+    +touch
+      margin: 1.5rem
+
+    padding-bottom: 5rem
+
+    .content
+      +desktop
+        width: 80%
+
+      p a, li a
+        font-weight: 700
+
+      li .highlight, ol li
+        margin-bottom: 1rem
+
+      h1
+        font-size: 1.802rem
+      h2
+        font-size: 1.602rem
+      h3
+        font-size: 1.424rem
+      h4
+        font-size: 1.266rem
+      h5
+        font-size: 1.125rem
+      h2, h3, h4, h5, h6
+        color: $vitess-orange
+
+    .docs-header
+      padding-bottom: 1rem
+      margin-bottom: 2rem
+
+    .card-content
+      padding: 0 0 1.5rem 0
+
+.docs-toc
+  flex: 0 0 15%
+  background-color: $white-bis
+  overflow: auto
+  border-left: 1px solid $grey-light
+
+  &-container
+    margin: 1rem
+
+  &-title
+    color: $dark
+    font-size: 1.25rem
+
+  &-menu
+    margin: 1.5rem 0
+
+    a
+      color: $dark
+
+      &:hover
+        color: $primary
+
+    #TableOfContents
+      ul
+        li
+          font-size: 1rem
+          line-height: 1.2rem
+
+          & + li
             margin-top: .75rem
 
-          .docs-section-title
-            font-size: 1.2rem
-            color: $grey-lighter
-            line-height: 100%
+          ul
+            margin: .5rem 0 0 1rem
 
-            &.is-active
-              color: $primary
+            li
+              font-size: 0.8rem
 
-          .docs-section-list
-            margin-left: .3rem
-            border-left: 1px solid $grey
-
-            ul
-              margin-top: .75rem
-
-              li
-                font-size: 1rem
-                margin-left: 1rem
-                line-height: 120%
-
-                a
-                  color: $grey-lighter
-
-                & + li
-                  margin-top: .8rem
-
-                &.is-active
-                  a
-                    color: $tan
-
-  .docs-article
-    flex: 1 1 auto
-    overflow: auto
-
-    .docs-content
-      margin: 2rem 2.5rem
-
-      +touch
-        margin: 1.5rem
-
-      padding-bottom: 5rem
-
-      .content
-        +desktop
-          width: 80%
-
-        p a, li a
-          font-weight: 700
-
-        li .highlight, ol li
-          margin-bottom: 1rem
-
-        h1
-          font-size: 1.802rem
-        h2
-          font-size: 1.602rem
-        h3
-          font-size: 1.424rem
-        h4
-          font-size: 1.266rem
-        h5
-          font-size: 1.125rem
-        h2, h3, h4, h5, h6
-          color: $vitess-orange
-
-      .docs-header
-        padding-bottom: 1rem
-        margin-bottom: 2rem
-        border-bottom: 1px solid $grey-lighter
-
-      .card-content
-        padding: 0 0 1.5rem 0
-
-  .docs-toc
-    flex: 0 0 15%
-    background-color: $white-bis
-    overflow: auto
-    border-left: 1px solid $grey-light
-
-    &-container
-      margin: 1rem
-
-    &-title
-      color: $dark
-      font-size: 1.25rem
-
-    &-menu
-      margin: 1.5rem 0
-
-      a
-        color: $dark
-
-        &:hover
-          color: $primary
-
-      #TableOfContents
-        ul
-          li
-            font-size: 1rem
-            line-height: 1.2rem
-
-            & + li
-              margin-top: .75rem
-
-            ul
-              margin: .5rem 0 0 1rem
-
-              li
-                font-size: 0.8rem
-
-                & + li
-                  margin-top: .75rem
-                  line-height: 1.2rem
+              & + li
+                margin-top: .75rem
+                line-height: 1.2rem
 
 
 

--- a/content/en/docs/pdfs/_index.md
+++ b/content/en/docs/pdfs/_index.md
@@ -2,6 +2,7 @@
 title: Older Version Docs
 description: PDFs of vitess.io/docs at the time of previous versions
 weight: 25
+docs_nav_disable_expand: true
 ---
 
 To view a PDF of the state of the Vitess Documentation for previous versions of Vitess please follow the links below:

--- a/content/en/docs/reference/programs/vtctl/_index.md
+++ b/content/en/docs/reference/programs/vtctl/_index.md
@@ -431,4 +431,3 @@ The following global options apply to `vtctl`:
 | -xtrabackup_stripe_block_size | uint | Size in bytes of each block that gets sent to a given stripe before rotating to the next stripe (default 102400) |
 | -xtrabackup_stripes | uint | If greater than 0, use data striping across this many destination files to parallelize data transfer and decompression |
 | -xtrabackup_user | string | User that xtrabackup will use to connect to the database server. This user must have all necessary privileges. For details, please refer to xtrabackup documentation. |
-

--- a/content/en/docs/reference/programs/vtctl/cell-aliases.md
+++ b/content/en/docs/reference/programs/vtctl/cell-aliases.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Cell Aliases Command Reference
 series: vtctl
+docs_nav_title: Cell Aliases
 ---
 
 The following `vtctl` commands are available for administering Cell Aliases.

--- a/content/en/docs/reference/programs/vtctl/cells.md
+++ b/content/en/docs/reference/programs/vtctl/cells.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Cell Command Reference
 series: vtctl
+docs_nav_title: Cells
 ---
 
 The following `vtctl` commands are available for administering Cells.

--- a/content/en/docs/reference/programs/vtctl/generic.md
+++ b/content/en/docs/reference/programs/vtctl/generic.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Generic Command Reference
 series: vtctl
+docs_nav_title: Generic Commands
 ---
 
 The following generic `vtctl` commands are available for administering Vitess.

--- a/content/en/docs/reference/programs/vtctl/keyspaces.md
+++ b/content/en/docs/reference/programs/vtctl/keyspaces.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Keyspace Command Reference
 series: vtctl
+docs_nav_title: Keyspaces
 ---
 
 The following `vtctl` commands are available for administering Keyspaces.

--- a/content/en/docs/reference/programs/vtctl/queries.md
+++ b/content/en/docs/reference/programs/vtctl/queries.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Query Command Reference
 series: vtctl
+docs_nav_title: Queries
 ---
 
 The following `vtctl` commands are available for administering queries.

--- a/content/en/docs/reference/programs/vtctl/replication-graph.md
+++ b/content/en/docs/reference/programs/vtctl/replication-graph.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Replication Graph Command Reference
 series: vtctl
+docs_nav_title: Replication Graph
 ---
 
 The following `vtctl` commands are available for administering the Replication Graph.

--- a/content/en/docs/reference/programs/vtctl/resharding-throttler.md
+++ b/content/en/docs/reference/programs/vtctl/resharding-throttler.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Resharding Throttler Command Reference
 series: vtctl
+docs_nav_title: Resharding Throttler
 ---
 
 The following `vtctl` commands are available for administering Resharding Throttler.

--- a/content/en/docs/reference/programs/vtctl/schema-version-permissions.md
+++ b/content/en/docs/reference/programs/vtctl/schema-version-permissions.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Schema, Version, Permissions Command Reference
 series: vtctl
+docs_nav_title: Schema Versions & Permissions
 ---
 
 The following `vtctl` commands are available for administering Schema, Versions and Permissions.

--- a/content/en/docs/reference/programs/vtctl/serving-graph.md
+++ b/content/en/docs/reference/programs/vtctl/serving-graph.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Serving Graph Command Reference
 series: vtctl
+docs_nav_title: Serving Graph
 ---
 
 The following `vtctl` commands are available for administering the Serving Graph.

--- a/content/en/docs/reference/programs/vtctl/shards.md
+++ b/content/en/docs/reference/programs/vtctl/shards.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Shard Command Reference
 series: vtctl
+docs_nav_title: Shards
 ---
 
 The following `vtctl` commands are available for administering shards.

--- a/content/en/docs/reference/programs/vtctl/tablets.md
+++ b/content/en/docs/reference/programs/vtctl/tablets.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Tablet Command Reference
 series: vtctl
+docs_nav_title: Tablets
 ---
 
 The following `vtctl` commands are available for administering tablets.

--- a/content/en/docs/reference/programs/vtctl/topo.md
+++ b/content/en/docs/reference/programs/vtctl/topo.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Topo Command Reference
 series: vtctl
+docs_nav_title: Topology Service
 ---
 
 The following `vtctl` commands are available for administering Topology Services.

--- a/content/en/docs/reference/programs/vtctl/workflows.md
+++ b/content/en/docs/reference/programs/vtctl/workflows.md
@@ -1,6 +1,7 @@
 ---
 title: vtctl Workflow Command Reference
 series: vtctl
+docs_nav_title: Workflows
 ---
 
 The following `vtctl` commands are available for administering workflows.

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -25,7 +25,6 @@
           {{ end }}
         {{ else }}
           {{ partial "docs/pages-in-section.html" . }}
-          <hr class="has-background-grey" />
           {{ .Content }}
         {{ end }}
       </div>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -24,7 +24,7 @@
         {{/* No breadcrumb if the current page is the first and only breadcrumb */}}
         {{ if not (and .p1.Parent.IsHome $isCurrentPage) }}
           <li {{ if eq .p1 .p2}}class="is-active"{{end}}>
-            <a href="{{ .p1.Permalink }}">{{ .p1.Title }}</a>
+            <a href="{{ .p1.Permalink }}">{{ or .p1.Params.docs_nav_title .p1.Title }}</a>
           </li>
         {{end}}
       {{ end }}

--- a/layouts/partials/docs/pages-in-section.html
+++ b/layouts/partials/docs/pages-in-section.html
@@ -1,13 +1,19 @@
-<h3>
-  Pages in this section
-</h3>
+{{ $pages := where .Pages "Params.series" "!=" "vtctl" }}
 
-<ul>
-  {{ range where .Pages "Params.series" "!=" "vtctl" }}
-  <li>
-    <a href="{{ .RelPermalink }}">
-      {{ .Title }}
-    </a>
-  </li>
-  {{ end }}
-</ul>
+{{ if gt (len $pages) 0 }}
+  <h3>
+    Pages in this section
+  </h3>
+
+  <ul>
+    {{ range $pages }}
+    <li>
+      <a href="{{ .RelPermalink }}">
+        {{ .Title }}
+      </a>
+    </li>
+    {{ end }}
+  </ul>
+
+  <hr class="has-background-grey" />
+{{ end }}

--- a/layouts/partials/docs/regular-pages-in-section.html
+++ b/layouts/partials/docs/regular-pages-in-section.html
@@ -1,13 +1,17 @@
-<h3>
-  Pages in this section
-</h3>
+{{ $pages := where .RegularPages "Params.series" "!=" "vtctl" }}
 
-<ul>
-  {{ range where .RegularPages "Params.series" "!=" "vtctl" }}
-  <li>
-    <a href="{{ .RelPermalink }}">
-      {{ .Title }}
-    </a>
-  </li>
-  {{ end }}
-</ul>
+{{ if gt (len $pages) 0 }}
+  <h3>
+    Pages in this section
+  </h3>
+
+  <ul>
+    {{ range $pages }}
+    <li>
+      <a href="{{ .RelPermalink }}">
+        {{ .Title }}
+      </a>
+    </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/partials/docs/sidebar.html
+++ b/layouts/partials/docs/sidebar.html
@@ -1,54 +1,61 @@
-{{ $logoUrl        := "img/logos/vitess.png" | relURL }}
-{{ $docsSections   := where site.Sections "Section" "docs" }}
-{{ $currentSection := .CurrentSection.Name }}
-{{ $currentUrl     := .RelPermalink }}
-{{$currentSubSection := ""}}
+{{ $logoUrl := "img/logos/vitess.png" | relURL }}
+{{ $docsSections := index (where site.Sections "Section" "docs") 0 }}
+{{ $currentRelPermalink := .RelPermalink }}
+
 <div class="docs-menu">
   <header class="docs-menu-header">
     <a href="{{ site.BaseURL }}">
-      <img class="docs-menu-logo" src="{{ $logoUrl }}">
+      <img class="docs-menu-logo" width="50" src="{{ $logoUrl }}">
     </a>
   </header>
 
-  <aside class="docs-menu-bar">
-    {{ range $docsSections }}
-    {{ $isCurrentPage := eq .RelPermalink $currentUrl }}
-    <div class="docs-section">
-      <a class="docs-section-title{{ if $isCurrentPage }} is-active{{ end }}" href="{{ .RelPermalink }}">
-        {{ .Title }}
-      </a>
-    </div>
-
-    {{ range .Sections }}
-
-    {{ if or (or (eq $currentSection "Features") (eq $currentSection "Programs") (eq $currentSection "VReplication")) }}
-      {{ $currentSubSection = $currentSection }}
-      {{ $currentSection = "Reference"}}
-    {{ end }}
-
-    {{ $isCurrentSection := eq $currentSection .Name }}
-
-    <div class="docs-section">
-      <a class="docs-section-title{{ if $isCurrentSection }} is-active{{ end }}" href="{{ .RelPermalink }}">
-        {{ .Name }}
-      </a>
-
-      {{ if $isCurrentSection }}
-      <div class="docs-section-list">
-        <ul>
-          {{ range .Pages }}
-          {{ $isCurrentPage := (or (eq $currentUrl .RelPermalink) (eq .Title $currentSubSection)) }}
-          <li{{ if $isCurrentPage }} class="is-active"{{ end }}>
-            <a href="{{ .RelPermalink }}">
-              {{ .Title }}
-            </a>
-          </li>
-          {{ end }}
-        </ul>
-      </div>
-      {{ end }}
-    </div>
-    {{ end }}
-    {{ end }}
-  </aside>
+  {{ template "navlist" (dict "entries" $docsSections.Sections "currentRelPermalink" $currentRelPermalink ) }}
 </div>
+
+{{/*
+  The "navlist" template recursively renders nested lists to any depth.
+  It is called with two parameters, "currentRelPermalink" and "entries",
+  described inline below.
+
+  The structure of the sidebar matches the structure of `content/docs` (for English)
+  or `content/xx/docs` (for other languages). This means that sidebar structure and
+  content will vary between languages.
+*/}}
+{{ define "navlist" }}
+  {{/* `currentRelPermalink` is the RelPermalink of the current content page. */}}
+  {{ $currentRelPermalink := .currentRelPermalink}}
+  {{/* `entries` is a list of Pages */}}
+  {{ $entries := .entries }}
+
+  <ul class="docs-navlist">
+    {{ range $entries }}
+      {{ $isActive := eq $currentRelPermalink .RelPermalink }}
+      {{ $activeClass := cond $isActive "active" "" }}
+
+      {{ $isExpanded := in $currentRelPermalink .RelPermalink }}
+      {{ $expandedClass := cond $isExpanded "expanded" "" }}
+
+      {{/* 'docs_nav_disable_expand' is (currently only) used to hide the caret on the "Older Version Docs" link */}}
+      {{/* We can remove it with a better versioning system: see https://github.com/vitessio/website/issues/625 */}}
+      {{ $isExpandable := and .IsSection (not .Params.docs_nav_disable_expand) }}
+      {{ $expandableClass := cond $isExpandable "expandable" "" }}
+
+      <li class="{{ $expandedClass }} {{ $activeClass }}">
+        <a href="{{ .Permalink }}">
+          <span class="navlist-tile">{{ or .Params.docs_nav_title .Title }}</span>
+          {{ if $isExpandable }}
+              <svg viewBox="0 0 749 1102" class="navlist-caret">
+                <path d="M749 551l-551 551L0 904l353-353L0 198 198 0z"></path>
+              </svg>
+          {{ end }}
+        </a>
+
+        {{ if $isExpanded }}
+          {{ if gt (len .Pages) 0 }}
+            {{ template "navlist" (dict "entries" .Pages "currentRelPermalink" $currentRelPermalink ) }}
+          {{ end }}
+        {{ end }}
+      </li>
+    {{ end }}
+  </ul>
+{{ end }}


### PR DESCRIPTION
Staged at https://deploy-preview-630--vitess.netlify.app/docs/

❤️ I've added a handful of reviewers to this as I'd like to get a lot of eyes on this! I'm not beholden to any of this implementation (including the styling) so would love your honest feedback! ~~cc @morgo also~~

# Changes
- Updates docs sidebar to handle hierarchies of any depth, which closes https://github.com/vitessio/website/issues/342 and addresses. This implementation, being generic, also removes some inconvenient hardcoding mentioned in https://github.com/vitessio/website/pull/583#issuecomment-720469238.

- Moves `content/docs/vtctl.md` to `content/docs/vtctl/_index.md`, which restructures the `vtctl` docs as a section + adds another layer of nesting. 

- Defines a new `docs_nav_title` front-matter variable, which lets pages specify a (shorter) title for the navbar that may differ from the page title.

- Defines a new `docs_nav_disable_expand` front-matter variable, and adds it to the "Older Version Docs" to hide the caret, since it gets treated like a section even though it only contains PDFs. We can likely :hocho: this when we improve version switching per https://github.com/vitessio/website/issues/625.

- Note that the size of the logo in the sidebar changed a bit. This way's a little better since we hardcode the size. Eventually I'd like to remove it as part of #618. 

# Screenshots

| | Before | After |
|-----|-----|-----|
| /docs | <img width="2672" alt="docs-root-prod" src="https://user-images.githubusercontent.com/855595/101300331-3dee0b00-3803-11eb-923d-b01fad415a22.png"> | <img width="2672" alt="docs-root-branch" src="https://user-images.githubusercontent.com/855595/101300336-42b2bf00-3803-11eb-8d6d-9dc945882d28.png"> |
| Troubleshooting | <img width="2672" alt="troubleshoot-prod" src="https://user-images.githubusercontent.com/855595/101300363-5827e900-3803-11eb-9e7e-c82883b4a94b.png"> | <img width="2672" alt="troubleshoot-branch" src="https://user-images.githubusercontent.com/855595/101300356-4fcfae00-3803-11eb-95cc-5cbeb8468b38.png"> | 
| vtctl schemas | <img width="2672" alt="vtctl-schema-prod" src="https://user-images.githubusercontent.com/855595/101300403-7988d500-3803-11eb-8c53-c24e885cf413.png"> | <img width="2672" alt="vtctl-schema-branch" src="https://user-images.githubusercontent.com/855595/101300474-b81e8f80-3803-11eb-8e66-465593727eb1.png"> |
| vtctl schemas but on a slightly smaller screen! | <img width="1792" alt="vtctl-schema-small-prod" src="https://user-images.githubusercontent.com/855595/101300303-257df080-3803-11eb-85fb-7ddfb6bc49bb.png"> | <img width="1792" alt="vtctl-schema-small-branch" src="https://user-images.githubusercontent.com/855595/101300323-375f9380-3803-11eb-94f0-6398e468a37c.png"> |
| /zh/docs | <img width="2672" alt="Screen Shot 2020-12-07 at 8 31 20 AM" src="https://user-images.githubusercontent.com/855595/101356796-9c000a00-3866-11eb-8559-f9e2c4a508b9.png"> | <img width="2672" alt="Screen Shot 2020-12-07 at 8 31 18 AM" src="https://user-images.githubusercontent.com/855595/101356801-9dc9cd80-3866-11eb-9b3f-5d3fab959b47.png"> | 


# Non-changes
There are a few things out of scope that {will, would} be cool to do:

- Handle expanding/collapsing sections of the navbar with JavaScript, so you can explore the hierarchy without requiring a full page refresh. It'll feel a lot faster. 

- We can also add expand/collapse all behaviour with JavaScript. And we can even make the sidebar's width adjustable. Or add headings (instead of the table of contents on the right.) Or... all kinds of things. 😎 

- Add a filter to the sidebar (distinct from the navbar search) to filter by title, like [terraform.io](https://www.terraform.io/docs/providers/index.html) for example:

    <img width="2672" alt="Screen Shot 2020-12-06 at 8 33 25 PM" src="https://user-images.githubusercontent.com/855595/101300074-57db1e00-3802-11eb-8793-2bc4ab79f332.png">

# Trade-offs
I spent QUITE a bit of time trying to implement this with [Hugo's menu system](https://gohugo.io/content-management/menus/). There were, however, some big drawbacks that I ran into (and this may be because Hugo is still new to me):

- Using `sectionPagesMenu = "main"` as described in ["Section Menu for Lazy Bloggers"](https://gohugo.io/templates/menu-templates/#section-menu-for-lazy-bloggers) only added `.Site.Menus.main` for the topmost level of navigation. 🤔 Not useful.

- [Defining menu structure with front-matter](https://gohugo.io/content-management/menus/#add-content-to-menus) seemed to require a change to EVERY markdown file's front-matter... 🤔 🤔 Maybe there is a way to do this with cascading front-matter changes, but I couldn't get that to work. And it's still less desirable than inferring sidebar structure from directory structure (in my opinion), especially since we still [get the benefit of page params](https://gohugo.io/templates/menu-templates/#using-params-in-menus). 

- Finally, I _think_ the menu system has to be defined per-language...? Which meant that all of the front-matter changes to add `menu` have to be done for the translated content, too. 🤔 🤔 🤔 

In any case. It _does_ seem like using the menu system is the recommended way and I'd be happy to switch to that if there are good solutions to the issues above! 