### PR TITLE
Do vschema_customer_sharded.json before create_customer_sharded.sql.

### DIFF
--- a/content/en/docs/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/user-guides/configuration-advanced/resharding.md
@@ -136,8 +136,8 @@ helm upgrade vitess ../../helm/vitess/ -f 301_customer_sharded.yaml
 ```bash
 vtctlclient ApplySchema -sql="$(cat create_commerce_seq.sql)" commerce
 vtctlclient ApplyVSchema -vschema="$(cat vschema_commerce_seq.json)" commerce
-vtctlclient ApplySchema -sql="$(cat create_customer_sharded.sql)" customer
 vtctlclient ApplyVSchema -vschema="$(cat vschema_customer_sharded.json)" customer
+vtctlclient ApplySchema -sql="$(cat create_customer_sharded.sql)" customer
 ```
 
 ### Using a Local Deployment
@@ -145,8 +145,8 @@ vtctlclient ApplyVSchema -vschema="$(cat vschema_customer_sharded.json)" custome
 ``` sh
 vtctlclient ApplySchema -sql-file create_commerce_seq.sql commerce
 vtctlclient ApplyVSchema -vschema_file vschema_commerce_seq.json commerce
-vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer
 vtctlclient ApplyVSchema -vschema_file vschema_customer_sharded.json customer
+vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer
 ```
 
 ## Create new shards


### PR DESCRIPTION
When doing create_customer_sharded.sql (removing auto-increments) before vschema_customer_sharded.json (applying VIndex), there is a short period of time where INSERTs in the customer and corder tables would fail if the customer_id or order_id is not set.  Doing vschema_customer_sharded.json before create_customer_sharded.sql remove this failure possibility.