### PR TITLE
stop crawling zh docs

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
+Disallow: /zh/docs/
 
 SITEMAP: https://vitess.io/sitemap.xml


### PR DESCRIPTION
update the robots.txt to stop crawling the Chinese documentation as it is not currently maintained. 