### PR TITLE
updating to remove extra operator file

### DIFF
--- a/content/en/docs/user-guides/migration/materialize.md
+++ b/content/en/docs/user-guides/migration/materialize.md
@@ -18,18 +18,21 @@ In our example, we will be using `Materialize` to perform something similar to t
 Let's start by simulating this situation by loading sample data:
 
 ```sql
-mysql < ../common/insert_commerce_data.sql
+# On helm and local installs:
+mysql < /usr/local/vitess/examples/common/insert_commerce_data.sql
+# With operator:
+mysql --table < insert_commerce_data.sql
 ```
 
 We can look at what we just inserted:
 
 ```sh
 # On helm and local installs:
-mysql --table < ../common/select_commerce_data.sql
+mysql --table < /usr/local/vitess/examples/common/select_commerce_data.sql
 # With operator:
 mysql --table < select_commerce_data.sql
 
-Using commerce/0
+Using commerce
 Customer
 +-------------+--------------------+
 | customer_id | email              |
@@ -59,7 +62,7 @@ COrder
 +----------+-------------+----------+-------+
 ```
 
-Note that we are using keyspace `commerce/0` to select data from our tables.
+Note that we are using keyspace `commerce` to select data from our tables.
 
 ## Planning to use Materialize
 


### PR DESCRIPTION
This PR works in conjunction with https://github.com/vitessio/website/pull/646/ to update the Vitess docs to remove the https://github.com/vitessio/vitess/blob/master/examples/operator/select_commerce_data.sql file.
