### PR TITLE
Documenting new Online DDL behavior for DROP TABLE

### DIFF
--- a/content/en/docs/reference/features/table-lifecycle.md
+++ b/content/en/docs/reference/features/table-lifecycle.md
@@ -63,7 +63,7 @@ All subsets end with a `drop`, even if not explicitly mentioned. Thus, `"purge"`
 
 ## Stateless flow by table name hints
 
-Vitess does not track the state of table lifecycle. The process is stateless thanks to an encoding schema in the table names. Examples:
+Vitess does not track the state of the table lifecycle. The process is stateless thanks to an encoding scheme in the table names. Examples:
 
 - The table `_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20210915120000` is held until `2021-09-15 12:00:00`. The data remains intact.
 - The table `_vt_PURGE_6ace8bcef73211ea87e9f875a4d24e90_20210915123000` is at the state where it is being purged, or queued to be purged. Once it's fully purged (zero rows remain), it transitions to the next stage.

--- a/content/en/docs/reference/features/table-lifecycle.md
+++ b/content/en/docs/reference/features/table-lifecycle.md
@@ -78,4 +78,4 @@ Vitess internally uses the above table lifecycle for [online, managed schema mig
 
 When using an online `ddl_strategy`, a `DROP TABLE` is a [managed schema migration](../../../user-guides/schema-changes/managed-online-schema-changes/). It is internally replaced by a `RENAME TABLE` statement, renaming it into a `HOLD` state (e.g. `_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20210915120000`). It will then participate in the table lifecycle mechanism. If `table_gc_lifecycle` does not include the `hold` state, the table proceeds to transition to next included state. 
 
-
+A multi-table `DROP TABLE` statement is converted to multiple single-table `DROP TABLE` statements, each to then convert to a `RENAME TABLE` statement.

--- a/content/en/docs/reference/features/table-lifecycle.md
+++ b/content/en/docs/reference/features/table-lifecycle.md
@@ -5,7 +5,7 @@ aliases: ['/docs/user-guides/table-lifecycle/','/docs/reference/table-lifecycle/
 
 Vitess manages a table lifecycle flow, an abstraction and automation for a `DROP TABLE` operation.
 
-# Problems with DROP TABLE
+## Problems with DROP TABLE
 
 Vitess inherits the same issues that MySQL has with `DROP TABLE`.  Doing a direct
 `DROP TABLE my_table` in production can be a risky operation. In busy environments
@@ -29,7 +29,7 @@ various factors:
 It is common practice to avoid direct `DROP TABLE` statements and to follow
 a more elaborate table lifecycle.
 
-# Vitess table lifecycle
+## Vitess table lifecycle
 
 The lifecycle offered by Vitess consists of the following stages or some subset:
 
@@ -47,7 +47,7 @@ To understand the flow better, consider the following breakdown:
 - `drop`: an actual `DROP TABLE` is imminent
 - _removed_: table is dropped. When using InnoDB and `innodb_file_per_table` this means the `.ibd` data file backing the table is removed, and disk space is reclaimed.
 
-# Lifecycle subsets and configuration
+## Lifecycle subsets and configuration
 
 Different environments and users have different requirements and workflows. For example:
 
@@ -61,10 +61,21 @@ Vitess will always work the steps in this order: `hold -> purge -> evac -> drop`
 
 All subsets end with a `drop`, even if not explicitly mentioned. Thus, `"purge"` is interpreted as `"purge,drop"`.
 
-# Automated lifecycle
+## Stateless flow by table name hints
+
+Vitess does not track the state of table lifecycle. The process is stateless thanks to an encoding schema in the table names. Examples:
+
+- The table `_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20210915120000` is held until `2021-09-15 12:00:00`. The data remains intact.
+- The table `_vt_PURGE_6ace8bcef73211ea87e9f875a4d24e90_20210915123000` is at the state where it is being purged, or queued to be purged. Once it's fully purged (zero rows remain), it transitions to the next stage.
+- The table `_vt_EVAC_6ace8bcef73211ea87e9f875a4d24e90_20210918093000` is held until `2021-09-18 09:30:00`
+- The table `_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20210921170000` is eligible to be dropped on `2021-09-21 17:00:00`
+
+## Automated lifecycle
 
 Vitess internally uses the above table lifecycle for [online, managed schema migrations](../../../user-guides/schema-changes/managed-online-schema-changes/). Online schema migration tools `gh-ost` and `pt-online-schema-change` create artifact tables or end with leftover tables: Vitess automatically collects those tables. The artifact or leftover tables are immediate moved to `purge` state. Depending on `-table_gc_lifecycle`, they may spend time in this state, getting purged, or immediately transitioned to the next state.
 
-# User-facing DROP TABLE lifecycle
+## User-facing DROP TABLE lifecycle
 
-Table lifecycle is not yet available directly to the application user. Vitess will introduce a special syntax to allow users to indicate they want Vitess to manage a table's lifecycle.
+When using an online `ddl_strategy`, a `DROP TABLE` is a [managed schema migration](../../../user-guides/schema-changes/managed-online-schema-changes/). It is internally replaced by a `RENAME TABLE` statement, renaming it into a `HOLD` state (e.g. `_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20210915120000`). It will then participate in the table lifecycle mechanism. If `table_gc_lifecycle` does not include the `hold` state, the table proceeds to transition to next included state. 
+
+

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -58,7 +58,7 @@ Use the standard MySQL `CREATE TABLE` syntax. The query goes through the same [m
 
 ### DROP TABLE
 
-Use the standard MySQL `DROP TABLE` syntax. The query goes through the same [migration flow](#migration-flow-and-states) as `ALTER TABLE` does. Tables are not immediately dropped. Instead, they are renamed into special names, recognizable by the table lifecycle mechanism, then to slowly and safely transition through lifecycle states into finally getting dropped.
+Use the standard MySQL `DROP TABLE` syntax. The query goes through the same [migration flow](#migration-flow-and-states) as `ALTER TABLE` does. Tables are not immediately dropped. Instead, they are renamed into special names, recognizable by the table lifecycle mechanism, to then slowly and safely transition through lifecycle states into finally getting dropped.
 
 ### Statement transformations
 
@@ -177,7 +177,7 @@ We highlight how Vitess manages migrations internally, and explain what states a
 - For `DROP TABLE` statements:
   - A multi-table `DROP TABLE` statement is converted to multiple single-table `DROP TABLE` statements
   - Each `DROP TABLE` is internally replaced with a `RENAME TABLE`
-  - Table is renamed into special name, identified by the [Table Lifecycle](../../../reference/features/table-lifecycle/) mechanism
+  - Table is renamed using a special naming convention, identified by the [Table Lifecycle](../../../reference/features/table-lifecycle/) mechanism
   - As result, a single `DROP TABLE` statement may generate multiple distinct migrations with distinct migration UUIDs.
 
 By way of illustration, suppose a migration is now in `running` state, and is expected to keep on running for the next few hours. The user may initiate a new `ALTER TABLE...` statement. It will persist in global `topo`. `vtctld` will pick it up and advertise it to the relevant tablets. Each will persist the migration request in `queued` state. None will run the migration yet, since another migration is already in progress. In due time, and when the executing migration completes (whether successfully or not), and assuming no other migrations are `queued`, the `primary` tablets, each in its own good time, will execute the new migration. 

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -4,9 +4,9 @@ weight: 2
 aliases: ['/docs/user-guides/managed-online-schema-changes/']
 ---
 
-**Note:** this feature is **EXPERIMENTAL**. The syntax for online DDL statements is **subject to change**.
+**Note:** this feature is **EXPERIMENTAL**.
 
-Vitess offers managed, online schema migrations, via [gh-ost](https://github.com/github/gh-ost) and [pt-online-schema-change](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html). As a quick breakdown:
+Vitess offers managed, online schema migrations, via [gh-ost](https://github.com/github/gh-ost) and [pt-online-schema-change](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html) for `ALTER TABLE` statements, and via [table lifecycle](../../../reference/features/table-lifecycle/) for `DROP TABLE` statements. As a quick breakdown:
 
 - Using the standard MySQL `CREATE TABLE`, `ALTER TABLE` and `DROP TABLE` syntax.
 - With either `@@ddl_strategy` session variable set, or `-ddl_strategy` command line flag. 
@@ -16,7 +16,7 @@ Vitess offers managed, online schema migrations, via [gh-ost](https://github.com
 - Tablets will independently run schema migrations:
   - `ALTER TABLE` statements run via `gh-ost` or `pt-online-schema-change`.
   - `CREATE TABLE` statements run directly.
-  - `DROP TABLE` statements run directly (WIP for lazy `DROP TABLE`).
+  - `DROP TABLE` statements run [safely and lazily](../../../reference/features/table-lifecycle/).
 - Vitess provides the user a mechanism to view migration status, cancel or retry migrations, based on the job ID.
 
 ## Syntax
@@ -54,11 +54,11 @@ How the migration is executed depends on your `ddl_strategy` configuration, and 
 
 ### CREATE TABLE
 
-Use the standard MySQL `CREATE TABLE` syntax. The query goes through the same [#migration-flow-and-states](migration flow) as `ALTER TABLE` does. The tablets eventually run the query directly on the MySQL backends.
+Use the standard MySQL `CREATE TABLE` syntax. The query goes through the same [migration flow](#migration-flow-and-states) as `ALTER TABLE` does. The tablets eventually run the query directly on the MySQL backends.
 
 ### DROP TABLE
 
-Use the standard MySQL `DROP TABLE` syntax. The query goes through the same [#migration-flow-and-states](migration flow) as `ALTER TABLE` does. The tablets eventually run the query directly on the MySQL backends.
+Use the standard MySQL `DROP TABLE` syntax. The query goes through the same [migration flow](#migration-flow-and-states) as `ALTER TABLE` does. Tables are not immediately dropped. Instead, they are renamed into special names, recognizable by the table lifecycle mechanism, then to slowly and safely transition through lifecycle states into finally getting dropped.
 
 ### Statement transformations
 
@@ -175,7 +175,10 @@ We highlight how Vitess manages migrations internally, and explain what states a
 - For `CREATE TABLE` statements:
   - Tablet runs the statement directly on the MySQL backend
 - For `DROP TABLE` statements:
-  - Tablet runs the statement directly on the MySQL backend (WIP for lazy drops)
+  - A multi-table `DROP TABLE` statement is converted to multiple single-table `DROP TABLE` statements
+  - Each `DROP TABLE` is internally replaced with a `RENAME TABLE`
+  - Table is renamed into special name, identified by the [Table Lifecycle](../../../reference/features/table-lifecycle/) mechanism
+  - As result, a single `DROP TABLE` statement may generate multiple distinct migrations with distinct migration UUIDs.
 
 By way of illustration, suppose a migration is now in `running` state, and is expected to keep on running for the next few hours. The user may initiate a new `ALTER TABLE...` statement. It will persist in global `topo`. `vtctld` will pick it up and advertise it to the relevant tablets. Each will persist the migration request in `queued` state. None will run the migration yet, since another migration is already in progress. In due time, and when the executing migration completes (whether successfully or not), and assuming no other migrations are `queued`, the `primary` tablets, each in its own good time, will execute the new migration. 
 


### PR DESCRIPTION
Documenting changes in https://github.com/vitessio/vitess/pull/7221, which is already merged.

This PR documents the new `DROP TABLE` behavior when `ddl_strategy` is an online strategy.
