### PR TITLE
added .bashrc and in troubleshoot added @@vitess_version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ resources/
 bin/
 tmp/
 .idea
+
+# File generated when running npm install 
+package-lock.json

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -23,7 +23,16 @@ sudo tar -C /usr/local -xzf go1.15.6.linux-amd64.tar.gz
 
 Make sure to add go to your bashrc:
 ```
+# Additions to ~/.bashrc file
+
+# Add go PATH
 export PATH=$PATH:/usr/local/go/bin
+
+# Add GOROOT
+export GOROOT=/usr/local/go/
+
+# Add GOPATH
+export GOPATH=/home/<user>/go
 ```
 
 ### Packages from CentOS repos
@@ -69,8 +78,8 @@ Set environment variables that Vitess will require. It is recommended to put the
 ```
 # Additions to ~/.bashrc file
 
-# Add go PATH
-export PATH=$PATH:/usr/local/go/bin
+#VTDATAROOT
+export VTDATAROOT=/tmp/vtdataroot
 
 # Vitess binaries
 export PATH=~/vitess/bin:${PATH}

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -23,7 +23,16 @@ sudo tar -C /usr/local -xzf go1.15.6.linux-amd64.tar.gz
 
 Make sure to add go to your bashrc:
 ```
+# Additions to ~/.bashrc file
+
+# Add go PATH
 export PATH=$PATH:/usr/local/go/bin
+
+# Add GOROOT
+export GOROOT=/usr/local/go/
+
+# Add GOPATH
+export GOPATH=/home/<user>/go
 ```
 
 ### Packages from apt repos
@@ -82,8 +91,8 @@ Set environment variables that Vitess will require. It is recommended to put the
 ```
 # Additions to ~/.bashrc file
 
-# Add go PATH
-export PATH=$PATH:/usr/local/go/bin
+#VTDATAROOT
+export VTDATAROOT=/tmp/vtdataroot
 
 # Vitess binaries
 export PATH=~/vitess/bin:${PATH}

--- a/content/en/docs/troubleshoot/_index.md
+++ b/content/en/docs/troubleshoot/_index.md
@@ -13,3 +13,8 @@ When an alert fires, you have the following sources of information to perform yo
 * Graphs
 * Diagnostic URLs
 * Log files
+
+### Find Vitess build running 
+```
+select @@vitess_version;
+```


### PR DESCRIPTION
Signed-off-by: Akilan <me@akilan.io>

## Reason 
- All go variables should be added to the .bashrc once go is installed. 
- VTDATAROOT Path not set 
- Added new command (select from @@vitess_version). In the troubleshoot guide. 