### PR TITLE
New Design Docs Section: initially contains RFCs copied over from vitess issues

### DIFF
--- a/content/en/docs/design-docs/_index.md
+++ b/content/en/docs/design-docs/_index.md
@@ -1,0 +1,6 @@
+---
+title: Design Docs
+description: Collection of design docs for some sections of Vitess
+weight: 6
+aliases: ['/docs/design/']
+---

--- a/content/en/docs/design-docs/build-and-process/_index.md
+++ b/content/en/docs/design-docs/build-and-process/_index.md
@@ -1,0 +1,6 @@
+---
+title: Build And Process
+description: Design docs related to the build framework and our development process
+weight: 4
+aliases: ['/docs/design/build/']
+---

--- a/content/en/docs/design-docs/build-and-process/pr-convention.md
+++ b/content/en/docs/design-docs/build-and-process/pr-convention.md
@@ -1,0 +1,91 @@
+---
+title: PR Naming Conventions
+description: A naming convention for GitHub pull requests
+weight: 1
+---
+
+### Background
+
+There's a clear need of improving GitHub naming conventions for the following sections.
+
+- Pull Request Naming
+- Branch Naming
+- Commit Message Naming
+- Tag Naming
+
+### Feature
+
+The most problematic area we see is the Pull Request Naming Convention hence we'd like to come up with guidelines and once agreed by maintainers provide a Template that will help streamline the above areas.
+
+For Issue Templates please refer to this [section](https://github.com/vitessio/vitess/tree/master/.github/ISSUE_TEMPLATE).
+### Solution
+
+The suggested solution would be creating general guidelines for this naming convention update.
+
+- Category [Area of Vitess Subject e.g. VReplication, VTgate, ...)
+- Label for [BugFix, Feature, Enhancement]
+- Short and descriptive summary
+- End with corresponding ticket/story id (e.g., GitHub issue, etc.)
+- Should be capitalized and written in imperative present tense
+- Not end with a period
+
+## Consists of five parts:
+
+* Category
+  * VTGate / MySQL compatibility
+  * OLAP
+  * System
+  * VReplication
+  * VTtablet
+  * VTorc
+  * PITR
+  * Examples
+  * Docs
+  * Build
+  * Other
+
+* Label
+  * BugFix
+  * Feature
+  * Enhancement
+  * Backport
+
+* Title: Short informative summary of the pull request
+* #[Issue_ID]
+* Description: More detailed explanatory text describing the PR for the reviewer
+
+Suggested Format:
+[Category ] [Label] Description #[Ticket_ID]
+Example:
+```[VTGate] [BugFix] - Fix where clause in information schema with correct database name #6599```
+
+## Description:
+
+- Separated with a blank line from the subject
+- Explain what, why, etc.
+- Max 72 chars
+- Each paragraph capitalized
+- Example and/or Reproduce steps
+
+```Overview of the Issue
+The query sent down from VTGate to Vttablet does not replace the where clause of the information schema queries for table_schema = 'keyspace' to table_schema = 'databasename'
+
+Reproduction Steps
+Steps to reproduce this issue, for example:
+
+Deploy the following vschema:
+
+{
+  "sharded": false,
+  "tables": {
+  }
+}
+```
+
+### Other Suggestions
+
+* Making the first two parts of the PR/Issue to use GitHub labels.
+* How to write good pull requests via GitHub templates [link](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/about-issue-and-pull-request-templates)
+
+### Call for feedback
+We're looking for the community's feedback on the above suggestions/flow. Thank you for taking the time to read and respond!

--- a/content/en/docs/design-docs/query-serving/_index.md
+++ b/content/en/docs/design-docs/query-serving/_index.md
@@ -1,0 +1,6 @@
+---
+title: Query Serving
+description: Query Serving related design docs
+weight: 1
+aliases: ['/docs/design/query-serving/']
+---

--- a/content/en/docs/design-docs/query-serving/clookup-vindex.md
+++ b/content/en/docs/design-docs/query-serving/clookup-vindex.md
@@ -1,0 +1,77 @@
+---
+title: Consistent lookup vindexes
+description:
+weight: 1
+---
+## Problem
+Vitess supports the concept of a lookup vindex, or what is also commonly known as a cross-shard index. It's implemented as a mysql table that maps a column value to the keyspace id. This is usually needed when someone needs to efficiently find a row using a where clause that does not contain the primary vindex.
+
+This lookup table can be sharded or unsharded. No matter which option one chooses, the lookup row is most likely not going to be in the same shard as the keyspace id it points to.
+
+Vitess allows the transparent population of these rows by assigning an owner table, which is the main table that requires this lookup. When a row is inserted into the main table, the lookup row for it is created in the lookup table. The lookup row is also deleted on a delete of the main row. These essentially result in distributed transactions, which require 2PC to guarantee atomicity.
+
+There have been requests to see if we can avoid 2PC and find a solution that could still give the same guarantees. This proposal is for such a solution.
+## Existing solution
+The best existing solution is one where the lookup row is created immediately (autocommited) irrespective of whether the original transaction completes or not. This can generally work if values are not reused by the original table. For example, it’s a perfect use case where the column is an auto-increment. In the worst case, the lookup row will have a dangling reference. A select on such a value will result in an extra lookup on the target shard, but will result in no rows being found, as expected.
+
+However, if we want to allow for values to be reused, then the presence of this row will prevent a new row from being created. We cannot confidently overwrite the row because it may be referencing an actual row in the main table.
+
+At the same time, we also cannot allow deletes. This has to do with the order of operations: a delete is currently performed before the main row is deleted. In autocommit mode, this delete will be committed first. If the original transaction is later rolled back, then we have data that is not referenceable from the lookup, which is a more serious problem.
+
+The above use case assumes that we’re dealing with a unique lookup. Similar concerns exist for non-unique lookups also.
+## Approach
+The proposed approach is to extend the existing behavior to better handle the case of a reuse. When we find that a lookup row already exists, we don’t know if it’s dangling or not. But it’s possible to find out: all we have to do is look for the owner row. If it doesn’t exist, then we can conclude that it’s dangling and allow for it to be overwritten. Otherwise, we can return a duplicate key error.
+## Implementation
+Even though the approach looks simple, the implementation gets tricky because of race conditions. For example, if we autocommitted the lookup row. A new insert can immediately find the row, but it could appear as dangling because the main row for the original transaction might not have been created yet. Even if it was created, it might not have been committed.
+
+Similar race conditions exist with various combinations including update and delete operations.
+
+To prevent these race conditions, we have to go through an elaborate sequence of operations, transactions, and row locking as explained below:
+
+### Extend the VTGate transaction model
+The VTGate transaction currently has a Session variable that keeps track of the current transactions it has open with the vttablets. To solve the above problem correctly, we need more fine-grained control over the order in which those transactions are committed. Additionally, even if some operations end up on the same shards, they may have to be in different transactions. To satisfy the needs that a consistent lookup needs, we need to introduce two independent transactions: they would ideally be names as prequel and sequel. However, since `sequel` can be confusing in this context, we’ll call them PreTransaction and PostTransaction. A PreTransaction is always committed first and a PostTransaction is always committed last.
+
+We can now dive into the details of how each vindex operation will utilize the above new features:
+### Create
+The Create will start with a `BeginPreTransaction` (if one is not already started), and insert the lookup row. If it succeeds, we return success.
+
+_Why do we need a separate transaction instead of autocommiting: If a new insert comes in, it will find this row, but won’t find the owner because it has yet to be created. If we tried to lock that row it will succeed with zero rows returned, and make us think that it’s ok for us to update it. If we were in a transaction, the new insert will wait till the PreTransaction is committed, at which time the owner row would have already been created._
+
+If the insert results in a duplicate key error, then it issues a `select for update` for the lookup row as well as the owner. The locking of the owner row is performed using the main transaction (not pre or post). If this select returns a row, then we return a duplicate key error.
+
+_Why do we need to lock the owner row: if a previous operation just committed the PreTransaction and is yet to commit the main transaction, then a simple select of the row will result in a row not found, which will make the current operation think that the row doesn’t exist._
+
+_Why do we need to also lock the lookup row: two inserts could race and try to lock the owner row, and they will both succeed, which will cause them to both try to update the lookup row. This also means that the owner row must be updated using values obtained from the select for update._
+
+If the row is not found, the existing row is updated to point at the new keyspace id and return success. If this operation fails with a dup key error, we return that error also.
+
+In the above sequence when the combined transaction is committed, it’s safe to commit the PreTransaction first. The correct behavior will be observed irrespective of whether the main transaction succeeds or not.
+
+It’s important to note that the most common code path where the insert succeeds is as efficient as it was before. Things are less efficient in the case where a row already exists, but it’s the less common case.
+
+We can also write a watchdog process later that harvests dangling rows.
+### Delete
+The Delete operation will start with a `BeginPostTransaction`. The delete of lookup rows must happen after the main transaction that’s deleting the rows is committed. If the main transaction commits and the PostTransaction fails, we’ll just be in a dangling row situation that we already know how to handle.
+
+The delete operation already selects the owned rows for an update before issuing the delete. So, there are no other corner cases to handle for the delete. Even otherwise, row locks will eventually be obtained when the actual delete is performed.
+### Update
+The update operation is currently implemented as a delete and insert. This means that an update that changes a vindex column will result in three transactions. However, it’s a small price to pay for the consistency gained.
+
+Special case: the case where the update does not change the column must be detected and be converted to a no-op. Otherwise, we’ll end up in an indefinite lock wait because we’ll be trying to change the same row via two different transactions (pre and post).
+## Extending the Vindex API
+Apart from the pre and post-transaction changes, we’ll need to extend the vindex API: A Vindex will export an optional `SetOwnerColumns` function. If present, the vschema builder will call this function at the time of creation and supply the column names of the owner table. This will allow the `Create` to issue the `select for update` to lock the owner row.
+## New vindexes
+In order to remain backward compatible. We’ll implement these new vindexes under different names, likely `consistent_lookup` and `consistent_lookup_unique`.
+## Corner cases to keep in mind
+Non-unique lookups: the above algorithm will work equally well for non-unique lookup. The only change will be the definition of a duplicate key. In the unique case, the `from` rows are the primary key, and in the non-unique case, the entire row is the pk.
+
+Multi-column vindexes: These will also work as long as the primary keys are correctly defined.
+Within a transaction, multiple different rows could be inserted that have owned lookups. This means that the pre and post transactions are full sessions that may themselves open multiple vttablet transactions (ShardSessions).
+
+Commit order within a session: Previously there was an implicit commit order that was dictated by the order in which DMLs were issues. This was instituted as a best-effort attempt to cause the lookup rows to be committed first. Although not guaranteed, this would have been the most common commit order. In the new scheme, since we explicitly control the commit order, there’s no need to follow this implicit order. Instead, we can commit the shard sessions in parallel.
+
+Bulk insert: Vitess supports bulk inserts. This results in a corresponding bulk insert for lookup rows also. If the lookup insert results in a duplicate key error, the algorithm will have to fall back to individual inserts in order to implement the above algorithm for rows that yield dup keys. For simplicity, we may not do bulk insert in the initial implementation.
+## What won’t work
+Autocommit of the main transaction will not work. For the lookup to be consistent, we have to start two transactions, create the rows in both transactions and commit in a specific order. If the lookup transaction was created with the row inserted without a commit, and if the main row is autocommitted, then the commit of the lookup row can later fail, which will result queries returning incorrect results.
+
+The feature should be used only with 2PC disabled. Of course, you don’t need this feature if you’re using 2PC already.

--- a/content/en/docs/design-docs/query-serving/locking-functions.md
+++ b/content/en/docs/design-docs/query-serving/locking-functions.md
@@ -1,0 +1,46 @@
+---
+title: Locking functions
+description:
+weight: 1
+---
+# Locking Functions
+
+Supporting the advisory locking functions in MySQL is important, given that they are used by common applications and frameworks.
+
+## Functions covered
+ * __GET_LOCK()__
+ * __IS_FREE_LOCK()__
+ * __IS_USED_LOCK()__
+ * __RELEASE_ALL_LOCKS()__
+ * __RELEASE_LOCK()__
+
+## Restrictions
+
+Vitess will initially only support locking functions with these limitations:
+ * Can only be used in SELECT queries
+ * The queries can either have only the table `dual`, or have no `FROM` clause.
+
+ ## Functionality
+
+Locking function evaluation will have a simple and consistent routing scheme, making sure all requests happen at the same target. This way, locks will be executed on the same `mysqld`.
+The locking function evaluation always is routed to the first shard in the first keyspace known to the VTGate, sorted alphabetically.
+
+Using any of the locking functions will force the session to use a reserved connection - a dedicated connection to `mysqld` for that session, so that `get_lock()`/`release_lock()` happen on the same connection, and so that `COM_QUIT` releases any lingering locks.
+
+## Examples of valid queries
+
+```
+SELECT GET_LOCK('lock1',10);
+SELECT RELEASE_LOCK('lock1');
+SELECT GET_LOCK('lock1',10), GET_LOCK('lock2',10);
+SELECT RELEASE_ALL_LOCKS()
+SELECT GET_LOCK(@customVariable, 10);
+```
+
+## Examples of queries not supported in the first implementation
+
+```
+SELECT GET_LOCK(user_name,10) FROM users;
+INSERT INTO T (id) VALUES (GET_LOCK('lock2',10));
+DO GET_LOCK('lock1',10);
+```

--- a/content/en/docs/design-docs/query-serving/owned-vindex.md
+++ b/content/en/docs/design-docs/query-serving/owned-vindex.md
@@ -1,0 +1,41 @@
+---
+title: Owned Primary Vindexes
+description:
+weight: 1
+---
+This proposal presents a way to allow for owned lookup vindexes to also be the Primary Vindex.
+
+## Problem statement
+An owned lookup vindex is a vindex for which a mapping is created from the input column value(s) to a keyspace id at the time of insert. This necessarily means that the keyspace id has to be known before this mapping can be created.
+
+This also means that an owned vindex cannot be the primary vindex. This is because the primary vindex is the one that determines the keyspace id of a row based on the input value. The essential thinking is: if one can compute the keyspace id for a row, then there is no need to store a mapping for it.
+
+There are, however, situations where these seemingly contradictory situations can co-exist. Here are two use cases:
+1. I want to generate a random keyspace id at the time of row insertion, but I want to remember it for later.
+2. I want to use multiple column values to compute a keyspace id, but would like to save a mapping from just one column to the computed keyspace id. This way, the lookup can be used in situations where only the mapped column was provided in the where clause. This is an upcoming use case for those who wish to geo-partition their data based on regions.
+
+In the above cases, the vindex is capable of generating a keyspace id, and at the same time, it needs to save that data so that it can be used later when `Map` is called.
+
+## Solution
+In order to support the new use cases, the following changes can be made:
+1. Extend the Vindex API where a vindex can export a `MapNew` function. This function will generate a keyspace ID.
+2. Allow owned lookup vindexes that support the `MapNew`function to be the primary vindex.
+3. If a `MapNew` function exists for the primary vindex, the insert will call it. Otherwise, it will use the regular `Map` function.
+4. If the vindex is owned, then the regular code for an owned vindex is executed, even if it’s the primary vindex. This is because `MapNew` would have returned us the keyspace id for the row.
+
+Why not a `MapAndCreate` function instead?
+A `MapAndCreate` will end up duplicating the work performed by an owned Vindex for the Create part. Having `MapNew` only generate the keyspace id keeps the functionality more orthogonal and composable.
+
+Why do we need a separate `MapNew` function instead of just reusing the `Map` function?
+This is to address the first use case. In the first use case, the `MapNew` function will generate a random keyspace id, whereas the `Map` function will perform the lookup.
+
+## Resharding
+We currently don’t support resharding through a lookup vindex. This is because a vttablet is not able to read from a lookup table that may be distributed across different keyspaces and shards. Also, performing a lookup for each vreplication row may be a performance bottleneck.
+
+For the first use case of random keyspace id generation, there is no recourse; Looking up the keyspace id may be the only way to reshard. However, this is currently only a hypothetical use case. So, there’s no need to solve this problem immediately.
+
+For the second use case, which addresses the geo-partitioning problem, `Map` and `MapNew` have the same implementation. The only difference is that `MapNew` takes multiple columns as input, whereas `Map` takes only one column.
+
+We have always wanted to extend `Map` to accept multiple columns as input. We now have the opportunity to do so. In such cases, a resharding will be able to use `Map` with all column values as input, thereby avoiding the need to read from lookup tables.
+
+The VTGate itself can continue to just send the first column's value for the vindex. However, VReplication can use all column values to allow for `Map` to return efficiently.

--- a/content/en/docs/design-docs/query-serving/replicatx.md
+++ b/content/en/docs/design-docs/query-serving/replicatx.md
@@ -1,0 +1,22 @@
+---
+title: Replica Transactions
+description:
+weight: 1
+---
+
+### Feature Description
+Vitess currently supports transactions through vtgate only on MASTER tablets. We would like to extend transaction support to REPLICA (or other tablet types).
+
+### Use Case(s)
+* Consistent reads
+* Sqoop integration
+
+### Proposed Solution
+- When vtgate chooses a tablet to execute a query on, it should return the tablet alias.
+- tablet alias and transactionID will be stored on the shard session struct.
+- if the session object has a tablet alias set, then the query will target the specific tablet.
+- if the transaction is committed or rolled back, the session should end.
+
+In order to use this feature, a client will need to issue `use @replica` followed by `BEGIN`.
+
+Prerequisite: #5750

--- a/content/en/docs/design-docs/query-serving/set-stmt.md
+++ b/content/en/docs/design-docs/query-serving/set-stmt.md
@@ -1,0 +1,79 @@
+---
+title: Set Statements
+description:
+weight: 1
+---
+
+## Use Case
+There are multiple applications/frameworks that tweak session system variables at the start of the connection to configure the system in specific ways. Some do it for all connections it uses, and some do it only for specific workloads, such as import, installation, etc.
+
+To support these use cases, Vitess needs to allow SET statements to be set on a per-connection basis.
+
+The recommendation is to change the setting at a global level during Vitess tablet setup. When this is done, sessions can use the normal connection pools, which is the most efficient way to operate. However, this design allows for sessions with VTgate changing these system variables and Vitess will make sure that they are set for all connections with MySQL for that session.
+
+## System variable types
+Vitess internally classifies system variables into three types - Ignore, Reserve, and Vitess-aware.
+
+### Ignore modification
+These are the system variables for which Vitess validates the current setting and notify users via warning that settings are either ignored or modification was not allowed. E.g. default_storage_engine, debug, etc.
+
+### Vitess Aware
+These are the system variables for which Vitess needs to change behavior based on the settings. E.g. autocommit, client_found_rows, etc.
+
+### Reserve connection
+These are the system variables that Vitess will send down to the storage engine and modify the settings at the session connection level. E.g. sql_mode, sql_safe_updates, etc.
+
+This document contains the design for this type of system variables.
+
+## Design
+### VTTablet
+Reserve Pool
+VTTablet will have a new pool named reserved pool. Connections in the reserved pool are tied to a specific session and are closed when the session is closed.
+
+QueryService interface changes:
+* ReserveExecute: Reserve a connection, execute the set statements, and the query.
+* ReserveBeginExecute: Reserve a connection, execute the set statements, move the reserve connection to active transaction pool and execute begin and the query.
+* ReserveRelease: This closes the reserved connection and also rollback the transaction if it is in an open state.
+* BeginExecute: ReserveId will be added as a parameter to the request.
+* Execute: ReserveId will be added as a parameter to the request.
+
+Connections that have updated session system variables will at the end of a transaction (Commit/Rollback) be moved to the reserve pool - they can’t be reused by other sessions.
+
+### VTGate
+When a session issues a SET statement to change a system variable, VTGate will compare the provided value with the already configured value. If it differs, it is stored in the session.
+
+A connection with the vttablet is reserved when a query is sent from the client connection. The stored settings are applied first to the reserved connection and then the query is executed.
+Storing the changed setting in the session enables VTGate to apply settings to any new connection that is opened with different shards.
+
+State | Reserved | Transaction | Recorded SETs
+-- | -- | -- | --
+clear | F | F | F
+remember-sets | F | F | T
+reserved | T | F | T
+inTx | F | T | F
+reserved-inTx | T | T | T
+
+From State | Query | Vtgate Action | API on tablet | To State
+-- | -- | -- | -- | --
+clear | SET system var | Record statement | No call | remember-sets
+remember-sets | SET system var | Record statement | No call | remember-sets
+reserved | SET system var | Record statement | Execute | reserved
+inTx | SET system var | Record statement | ReserveExecute | reserved-inTx
+reserved-inTx | SET system var | Record statement | Execute | reserved-inTx
+remember-sets | Query |   | ReserveExecute | reserved
+reserved | Query |   | Execute | reserved
+reserved-inTx | Query |   | Execute | reserved-inTx
+remember-sets | Begin + Query |   | ReserveBeginExecute | reserved-inTx
+reserved | Begin + Query |   | BeginExecute | reserved-inTx
+remember-sets | Commit/Rollback | No-op | No call | remember-sets
+reserved | Commit/Rollback | No-op | No call | reserved
+reserved-inTx | Commit/Rollback |   | Commit/Rollback | reserved
+remember-sets | Close Connection | Close Session | No call | clear
+reserved | Close Connection | Close Session | ReserveRelease | clear
+reserved-inTx | Close Connection | Close Session | ReserveRelease | clear
+
+## Release Plan
+The release plan would be to update vttablet < vtctl < vtgate in this particular order.
+
+## Assumption
+The order of the SET statements is not maintained. Different Vitess shards might see settings being applied in any order.

--- a/content/en/docs/design-docs/vreplication/_index.md
+++ b/content/en/docs/design-docs/vreplication/_index.md
@@ -1,0 +1,6 @@
+---
+title: VReplication
+description: VReplication related design docs
+weight: 3
+aliases: ['/docs/design/vreplication/']
+---

--- a/content/en/docs/design-docs/vreplication/file-pos.md
+++ b/content/en/docs/design-docs/vreplication/file-pos.md
@@ -1,0 +1,46 @@
+---
+title: File:Position based VReplication
+description:
+weight: 1
+---
+
+## Problem Statement
+
+In order to support migration from legacy databases that may not have GTID turned on, there is a need for VReplication to support file:position based tracking.
+
+It is understood that this type of tracking will work only for a single physical mysql source. Replication cannot be automatically resumed from a different source. In the worst case, it is possible to manually figure out the continuation point, and change the VReplication parameters to resume replication from a different source.
+
+Supporting file:position based vreplication will allow for one-time "shoveling" of data from an existing source to a destination. It could also be used to continuously keep the target data up-to-date just like we do for resharding. In this situation, it should also be possible to reverse the replication after a cut-over from legacy to vitess. This will give us the option to rollback a migration should anything go wrong.
+
+## Requirements
+
+The VReplication design is entrenched in using the concept of GTID. So, it will be substantial work to change its DNA to recognize file:position based binlog tracking. However, Vitess has the design elements needed to support multiple GTID formats. This means that we can build a low level abstraction layer that encapsulates a file:position as a GTID. There are situations where this abstraction breaks down. We'll have to handle those corner cases.
+
+### Forcing file:position based tracking
+
+Although not anticipated, it's possible that a user may want to use file:position based tracking even if the source has GTID turned on. This means that file:position based tracking should not be inferred through auto-detection.
+
+An environment variable (like MYSQL_FLAVOR) should not be used because the tracking mode depends on a specific source. Since VReplication can have multiple sources, this should be dictated by the source.
+
+### Current position
+
+In GTID mode, the current position is guaranteed to be at a transaction boundary. But a file:position based binlog can report a position for every event, including stray ones that are not material for replication. In such cases, the mechanism of getting the current position from the source and asking the target to stop at that position should work no matter what that position is.
+
+### Single Source
+
+As mentioned above, only a fixed mysql instance will be supported as source.
+
+## Design
+
+A prototype work was done by PlanetScale for file:position based tracking. This was developed as an "RDS" flavor. This is because RDS did not support GTIDs when this was developed. With PlanetScale's permission, this work will be leveraged to implement the new proposal. The work will be published as part of the Vitess license. The following high level tasks will need to be performed.
+
+* **Rename rdsFlavor->filePosFlavor**: This rename will more accurately represent the functionality.
+* **Flavor as connection parameter**: Since we need to control the flavor on a per-source basis, the best way to achieve this is to extend the `ConnParams` structure to include a `Flavor`. If empty, auto-detection will be used. If specified, the name will map to a registered flavor implementation. This approach will retain backward compatibility.
+* **Track sub-flavor**: Since we want to support file:position based tracking even if GTID is turned on, we need the ability to recognize GTID events. This means that we have to understand MySQL and MariaDB flavors under the covers.
+* **Standardize on when to send GTID**: Currently, the binlog dictates when to report a GTID. In some cases, it's before the next transaction, and sometimes it's within. We'll change the design to report the GTID just before the "COMMIT". This is the point where it's actually useful. Knowing exactly when a GTID will be received will simplify the design of the vplayer.
+* **Introduce Pseudo-GTID**: In order to report positions outside of transaction boundaries, one possibility is to report them as pseudo-GTIDs. Although it's possible to convert them to fake empty transactions, it may be more readable to use a separate category.
+* **Stop Position**: The vplayer currently uses ambiguous rules about how it handles the case where a stop position was exceeded. As part of this change, we'll standardize on: _A stop position is considered to be successfully reached if the new position is greater than or equal to the specified position_. The main motivation for this change is that the possibility of position mismatch is higher in the case of file:pos tracking. We're likely to hit many false positives if we're too strict.
+
+## Future improvements
+
+Once a GTID gets more implicitly associated with saveable events, we can later deprecate GTID as an explicit event. Instead, we can send the GTID as part of the COMMIT or DDL message, which is where it's actually used. This will allow us to tighten some code in vplayer. Without this, the association of GTID with a COMMIT is more ambiguous, and there's extra code to glue them together.

--- a/content/en/docs/design-docs/vreplication/tracker.md
+++ b/content/en/docs/design-docs/vreplication/tracker.md
@@ -1,0 +1,147 @@
+---
+title: Schema Tracker
+description: Tracking schema changes in vstreams
+weight: 1
+---
+
+# Tracking schema changes in vstreams
+
+## Motivation
+
+Currently, vstreams work with a single (the latest) database schema. On every DDL the schema engine reloads the schema from the database engine.
+
+All vstreams on a tablet share a common engine. Vstreams that are lagging might be seeing a newer (and hence incorrect) version of the schema in case ddls were applied in between.
+
+In addition reloading schemas is an expensive operation. If there are multiple vstreams each of them will separately receive a DDL event resulting in multiple reloads for the same DDL.
+
+
+## Goals
+
+1. Provide a mechanism for maintaining versions of the schema
+2. Reduce the number of redundant schema loads
+
+## Model
+
+We add a new schema_version table in _vt with columns, including, the gtid position, the schema as of that position, and the ddl that led to this schema. Inserting into this table generates a Version event in vstream.
+
+## Actors
+
+#### Schema Engine
+
+Schema engine gets the schema from the database and only keeps the last (latest) copy it loaded. It notifies subscribers if the schema changes. It polls for the latest schema at intervals or can be explicitly requested to load the schema.
+
+#### Replication watcher
+
+Replication watcher is a vstream that is started by the tabletserver. It notifies subscribers when it encounters a DDL
+
+#### Version Tracker
+
+Version tracker runs on the master. It subscribes to the replication watcher and inserts a new row into the schema_version table with the latest schema.
+
+#### Version Historian
+
+Version historian runs on both master and replica and handles DDL events. For a given GTID it looks up its cache to check if it has a schema valid for that GTID. If not, on the replica, it looks up the schema_version table. If no schema is found then it provides the latest schema which is updated by subscribing to the schema engine’s change notification.
+
+### Notes
+
+*   Schema Engine is an existing service
+*   Replication Watcher already exists and is used as an optional vstream that the user can run. It doesn’t do anything specific: it is used for the side-effect that a vstream loads the schema on a DDL, to proactively load the latest schema.
+
+
+## Basic Flow for version tracking
+
+### Master
+
+#### Version tracker:
+
+1. When the master comes up the replication watcher (a vstream) is started from the current GTID position. Tracker subscribes to the watcher.
+1. Say, a DDL is applied
+1. The watcher vstream sees the DDL and
+    1. asks the schema engine to reload the schema, also providing the corresponding gtid position
+    2. notifies the tracker  of a schema change
+1. Tracker stores its latest schema into the _vt.schema_version table associated with the given GTID and DDL
+
+
+#### Historian/VStreams:
+
+1. Historian warms its cache from the schema_version table when it loads
+2. When the tracker inserts the latest schema into _vt.schema_version table, the vstream converts it into a (new) Version event
+3. For every Version event the vstream registers it with the Historian
+4. On the Version event, the tracker loads the new row from the _vt.schema_version table
+5. When a vstream needs a new TableMap it asks the Historian for it along with the corresponding GTID.
+6. Historian looks up its cache for a schema version for that GTID. If not present just provides the latest schema it has received from the schema engine.
+
+
+#### Replica
+
+1. Version tracker does not run: the tracker can only store versions on the master since it is writing to the database.
+2. Historian functionality is identical to that on the master.
+
+
+## Flags
+
+### Master
+
+Schema version snapshots are stored only on the master. This is done when the Replication Watcher gets a DDL event resulting in a SchemaUpdated(). There are two independent flows here:
+
+1. Replication Watcher is running
+2. Schema snapshots are saved to _vt.schema_version when SchemaUpdated is called
+
+Point 2 is performed only when the flag TrackSchemaVersions is enabled. This implies that #1 also has to happen when TrackSchemaVersions is enabled independently of the WatchReplication flag
+
+However if the WatchReplication flag is enabled but TrackSchemaVersions is disabled we still need to run the Replication Watcher since the user has requested it, but we should not store schema versions.
+
+So the logic is:
+
+1. WatchReplication==true \
+=> Replication Watcher is running
+
+2. TrackSchemaVersions==false  
+=> SchemaUpdated is a noop
+
+3. TrackSchemaVersions=true  
+=> Replication Watcher is running \
+=> SchemaUpdated is handled
+
+The Historian behavior is identical to that of the replica: of course if versions are not stored in _vt.schema_versions it will always provide the latest version of the scheme.
+
+### Replica
+
+Schema versions are never stored on replicas, so SchemaUpdated is always a Noop. Versions are provided as appropriate by the historian. The historian provides the latest schema if there is no appropriate version.
+
+So the logic is:
+
+1. WatchReplication==true \
+=> Replication Watcher is running
+
+2. TrackSchemaVersions==false || true  //noop \
+=> Historian tries to get appropriate schema version
+
+## Caveat
+
+Only best-effort versioning can be provided due to races between DDLs and DMLs. Some examples below:
+
+### Situation 1
+
+If multiple DDLs are applied in a quick sequence we can end up with the following binlog.
+
+T1: DDL 1 on table1
+
+T2: DDL 2 on table1
+
+T3: Version Event DDL1 // gets written because of the time taken by tracker processing DDL1
+
+T4: DML1 on table1
+
+T5: Version Event DDL2 // gets written AFTER DML1
+
+So now on the replica, at T4, the version historian will incorrectly provide the schema from T1 after DDL1 was applied.
+
+### Situation 2
+
+If version tracking is turned off on the master for some time, correct versions may not be available to the historian which will always return the latest schema. This might result in an incorrect schema when a vstream is processing events in the past.
+
+#### Possible new features around this functionality
+
+*   Schema tracking vstream client for notifications of all ddls
+*   Raw history of schema changes for auditing, root cause analysis, etc.

--- a/content/en/docs/design-docs/vreplication/vscopy.md
+++ b/content/en/docs/design-docs/vreplication/vscopy.md
@@ -1,0 +1,134 @@
+---
+title: VStream Copy
+description: Streaming events from the beginning
+weight: 1
+---
+
+## VStream Copy
+
+### Allow vstreams to stream entire databases or tables
+
+## Motivation
+
+Currently, the vstream API streams events starting either from the current position of the binlog or from a position specified by the client. The VStream Copy feature adds support to send all events starting from the first position of the binlog.
+
+A naive extension of the current mechanism is to stream from the starting position. However, this is impractical for any database/table of a reasonable size. We will extend VStream to make use of the bulk copy based mechanism similar to vreplication streams, used in MoveTables or Reshard sharding workflows.
+
+Note that with vstream copy the client vstream will not faithfully reproduce the events from the binlog. The aim is to be eventually (and rapidly) consistent with the current database snapshot. This improves performance since we will be merging multiple row updates into a single transaction.
+Once we have caught up (i.e. the replication lag is small) binlog events will again be directly streamed similar to the current implementation.
+
+### Current API
+
+Clients create vstreams by grpc-ing to VTGate using the Vstream API call. In golang:
+
+```
+conn, _ := 	VTGate.Dial(ctx, "localhost:15991")
+// tabletType is one of replica/master/rdonly, filter,vgtid: see below
+reader, _ := 	VStream(ctx, tabletType, vgtid, filter)
+e, _  := 	reader.Recv() //receive VEvents in a loop until io.EOF
+```
+
+It is possible for network errors to occur or for the client process to fail. In addition, the vstreamer itself might fail at VTGate or VTTablet. Thus, VTGate needs to send state frequently allowing VTGate to be stateless and clients to recover properly from failures.
+
+Also, while creating the stream the client can specify multiple shards and/or keyspaces from which to stream events.
+
+The vgtid structure facilitates both: determining the stream sources and maintaining state. vgtid is a list of tuples: (keyspace, shard, gtid). When a stream is created, gtid can either be “current” or a valid binlog position at which the vstream starts streaming events.
+
+Some examples:
+```
+// stream from current position from two shards
+vgtid := &binlogdatapb.VGtid{
+         		ShardGtids: []*binlogdatapb.ShardGtid{{
+         			Keyspace: "ks",
+         			Shard:    "-40",
+         			Gtid:     "current",
+         		},{
+         			Keyspace: "ks",
+         			Shard:    "80-c0",
+         			Gtid:     "current",
+         		}}
+         }
+
+// stream from specific position from all shards in keyspace ks
+vgtid := &binlogdatapb.VGtid{
+         		ShardGtids: []*binlogdatapb.ShardGtid{{
+         			Keyspace: "ks",
+         			Gtid:     "MariaDB/0-41983-20",
+                }}
+         }
+
+// stream from current position from all keyspaces
+vgtid := &binlogdatapb.VGtid{
+         		ShardGtids: []*binlogdatapb.ShardGtid{{
+         			Gtid:     "current",
+                }}
+         }
+```
+
+The data streamed is sourced from the list of keyspace/shards after applying the specified filter.
+
+To achieve this VTGate sends a vgtid event whenever it encounters a gtid event with the current vgtid state at VTGate. Thus if the stream is broken, for any reason, the client needs to simply create a new vstream using the last vgtid that it received.
+
+
+## Architecture/Design
+
+During a copy there will two distinct phases:
+
+1. Copy phase: where the vstreamer is sending row data in bulk using the primary key to “paginate” the table
+1. Replication phase: once copying is completed and going forward we only stream events
+
+The copy phase is nuanced: we copy a batch of rows until a particular PK using a consistent snapshot. However, once the copy is completed the binlog position would have moved possibly containing updates to the rows already transmitted.
+Hence we need to perform a “catchup” where we play the events up to the current position. We can only send updates to rows that we have already sent to the stream.
+
+After the catchup, we send the next batch of rows and perform the related catchup. This copy-catchup loop continues until all tables are copied, after which it is business as usual and events are streamed as they appear in the binlog.
+
+### API Changes for VStream Copy
+
+To use VStream Copy you just need to pass an empty string as the position.
+The only other change is in the vgtid structure. It now becomes a list of
+
+`(keyspace, shard, gtid,[]LastTablePK)`
+
+While the copy is in progress, the LastPK list contains the last seen primary key for each table in that shard. Once the copy is completed and we are replicating the stream this parameter will be nil.
+
+Note that the vgtid is opaque to the consumer of the vstream API once the vstream starts and the ongoing state does not need to be interpreted on the client.
+
+To start a VStream Copy user is expected to provide an empty gtid along with a list of tables to copy
+ (essentially a LastTablePK list with a nil PK for each). Some examples
+ (see https://github.com/vitessio/contrib/blob/master/vstream_client/vstream_client.go for a sample client):
+
+```
+// vstream copy two tables table from two shards
+filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "t2",
+            Filter: "select id, val from t2",
+		},{
+			Match: "t1",
+            Filter: "select * from t1",
+        }},
+	}
+vgtid := &binlogdatapb.VGtid{
+         		ShardGtids: []*binlogdatapb.ShardGtid{{
+         			Keyspace: "ks",
+         			Shard:    "-40",
+         			Gtid:     "",
+         		},{
+         			Keyspace: "ks",
+         			Shard:    "80-c0",
+         			Gtid:     "",
+         		}}
+         }
+
+// stream the entire database: vstream copy from all tables in all keyspaces
+filter := &binlogdatapb.Filter{
+		Rules: []*binlogdatapb.Rule{{
+			Match: "/.*/",
+		}},
+	}
+vgtid := &binlogdatapb.VGtid{
+         		ShardGtids: []*binlogdatapb.ShardGtid{{
+         			Gtid:     "",
+                }}
+         }
+```

--- a/content/en/docs/design-docs/vttablet/_index.md
+++ b/content/en/docs/design-docs/vttablet/_index.md
@@ -1,0 +1,6 @@
+---
+title: VTTablet
+description: VTTablet Related Documents
+weight: 2
+aliases: ['/docs/design/misc/']
+---

--- a/content/en/docs/design-docs/vttablet/component-ts.md
+++ b/content/en/docs/design-docs/vttablet/component-ts.md
@@ -1,0 +1,135 @@
+---
+title: Componentizing TabletServer
+description:
+weight: 1
+---
+
+# Introduction
+As Vitess adoption expands, several feature requests have been popping up that will benefit from multiple instances of TabletServer (or its sub-components) co-existing within the same process.
+
+The following features drive this refactor, in order of priority:
+* Multi-schema
+* VTShovel: multiple data import sources for vreplication
+* VTDirect: allow VTGate to directly send queries to mysql
+
+Beyond these features, componentizing TabletServer will make the vitess architecture more flexible. There are many places in the code where we instantiate a QueryService. All those places can now explore the benefit of instantiating a TabletServer or its sub-components.
+# Features
+This section describes the use cases and their features. An important prerequisite: In order to retain backward compatibility, the new features should not cause existing behavior to be affected.
+## Multi-schema
+There has been a steady inflow of enquiries about use cases where a mysql instance has a large number of schemas (1000+). We currently support multi-schema by requiring the user to launch one vttablet process per schema. This, however, does not scale for the number of schemas we are beginning to see.
+
+To enable this, we need the ability for a single vttablet to host multiple TabletServers. Requirements are:
+* Grouped or consolidated Stats (/debug/vars).
+* Segregated or consolidated HTTP endpoints, like (/debug/status), with sub-page links working.
+* A better way to specify flags: the existing approach of command line flags may not scale.
+* A tablet manager that can represent multiple tablet ids.
+
+Other parts of TabletServer have already been modified to point at a shared mysql instance due to work done by @deepthi in #4727, and other related changes.
+## VTShovel
+VTShovel is a data migration feature that extends VReplication to allow a user to specify an external mysql as the source. This can be used to import data and also keep the targets up-to-date as the source is written to.
+
+VTShovel currently has two limitations:
+* It supports only one external source per vttablet. The need for multiple sources was voiced as a requirement by one of the adopters.
+* It does not support VDiff, which also requires multiple sources.
+
+If the TabletServer refactor is architected correctly, VTShovel should inherit the multi-instance ability without any major impact. In particular:
+* Leverage the flags refactor to support more than one external source.
+* Observability features implemented for multi-schema like stats and HTTP endpoints should naturally extend to vtshovel.
+* VDiff should work.
+## VTDirect
+The excessive use of CPU due to gRPC continues to be a concern among some adopters. Additionally, Vitess is now being deployed against externally managed databases like RDS and CloudSQL. Such users are reluctant to pay the latency cost of the extra hop.
+
+VTDirect is the ability of VTGate to directly send queries to the mysql instances.
+
+This feature adds the following requirements over the previous ones:
+* Some features of TabletServer (like sequences) should be disabled or redirected to an actual vttablet.
+* TabletServers can have a life-cycle as tablets are added and removed from the topo. The variables and end-points need to reflect these changes.
+
+In previous discussions, alternate approaches that did not require a TabletServer refactor were suggested. Given that the TabletServer refactor brings us much closer to this feature, we’ll need to re-evaluate our options for the best approach. This will be a separate RFC.
+# Requirements
+This section describes the requirements dictated by the features.
+## Stats
+Stats (/debug/vars) should be reported in such a way that the variables from each TabletServer can be differentiated. Idiomatic usage of vitess expects the monitoring tool to add the tablet id as a dimension when combining variables coming from different vttablets. Therefore, every TabletServer should be changed to add this dimension to its exported variables.
+
+On the flip side, this may result in an extremely large number of variables to be exported. If so, it may be better to consolidate them. There is no right answer; We have to support both options.
+### Other options considered
+We could have each TabletServer export a brand new set of variables by appending the tablet id to the root variable name. However, this would make it very hard for monitoring tools because they are not very good at dealing with dynamic variable names.
+## HTTP endpoints
+A TabletServer exports a variety of http endpoints. In general, it makes sense to have each TabletServer export a separate set of endpoints within the current process. However, in cases where the performance of the underlying mysql is concerned, it may be beneficial to consolidate certain pages.
+
+We’ll start with a separate set of pages, with each set prefixed by the tablet id. For example, what was previously `/debug/consolidations` will now become `/cell-100/debug/consolidations`.
+### Other options considered
+We could keep the existing set of endpoints unchanged, and have each TabletServer add its section. But this would make it hard to troubleshoot problems related to a specific TabletServer.
+
+The best-case scenario would be the “why not both” option: the original set of pages continue to exist and provide a summary from all the tablet servers. This can still be implemented as an enhancement.
+## Command line flags
+Extending the command line flags to be able to specify parameters for a thousand tablet servers is not going to be practical.
+
+Using config files is a better option. To prevent verbosity, we can use a hierarchy where the root config specifies initial values for the flags, and the TabletServer specific configs can inherit and override the original ones.
+
+The input file format could be yaml. Also, this is a good opportunity for us to come up with better names.
+
+Since the config option is more powerful and flexible, specifying that file in the command line will supersede all legacy flags.
+### Other options considered
+These configs could be hosted in the topo. This is actually viable. There are two reasons why this option takes a backseat:
+* We currently don’t have good tooling for managing data in the topo. VTCtld is currently the only way, and people have found it inadequate sometimes.
+* There are mechanisms to secure config files, which will allow it to contain secrets like the mysql passwords. This will not be possible in the case of topos.
+# Design
+We propose to address the above requirements with the following design elements.
+## Dimension Dropper
+The dimension dropper will be a new feature of the stats package. Its purpose is to remove specific dimensions from any multi-dimensional variable.
+
+We’ll introduce a new command-line flag that takes a list of labels as input, like `-drop_dimensions=’Keyspace,ShardName’`. The stats package will then remove that dimension from any variable that refers to it.
+
+In the case of the TabletServer, specifying `TabletID` in the list of dropped dimensions will have the effect of all TabletServers incrementing a common counter instead of different ones under their own tablet id.
+
+The reason for this approach is that there are already other use cases where the number of exported variables is excessive. This allows us to address those use cases also.
+
+It’s possible that this feature is too broad. For example, one may not want to drop the `Keyspace` dimension from all variables. If we encounter such use cases, it should be relatively easy to extend this feature to accommodate more specific rules.
+## Exporter
+The exporter will be a new feature that will layer between TabletServer and the singleton APIs: stats and http. It will allow you to create exporters that are either anonymous or named.
+
+An anonymous exporter will behave as if you invoked the stats and http directly. Open issue: we’ll need to see if we want to protect from panics due to duplicate registrations.
+
+A named exporter will perform consolidations or segregations depending on the situation:
+* In the case of a stats variable, it will create a common underlying variable, and will update the dimension that matches the name of the exporter.
+* In the case of http, it will export the end point under a new URL rooted from the name of the exporter.
+
+Currently, the connection pools have a different name based mechanism to export different stats. The exporter functionality should support this prefixing, which will eliminate the boiler-plate code in those components.
+
+A prototype of this implementation (aka embedder) is present in the vtdirect branch. This needs to be cleaned up and ported to the latest code.
+
+There is no need for the exporter to provide the option to consolidate without the name because the dimension dropper can cover that functionality.
+
+It’s possible to achieve backward compatibility for stats by creating an exporter with a name (tablet id), and then dropping that dimension in stats. However, it’ll work only for stats and not for the http endpoints. For this reason, we need to support explicit code paths for the anonymous exporters. Plus, it makes things more explicit.
+## Config loader
+The TabletServer already has most, if not all, of its input flags consolidated into a `Config` struct under tabletenv. The existing flags initialize a `DefaultConfig` global variable. If the command line specifies a newly defined flag, like `-tablet_config=’filename.yaml’`, then we can branch off into code that reads the yaml file and initializes the configs from there.
+
+The code will load the global part of the yaml into a “global” Config. For each tablet specific config, the global config will be copied first, and then the tablet specific overrides will be overwritten into the copied values.
+
+This is an opportunity for us to rename the members of the Config struct to use better names and data types. The yaml tags will have to match these new names.
+
+The most popular yaml reader seems to be https://github.com/go-yaml/yaml. We’ll start with that and iterate forward.
+
+The dbconfigs data structure will also be folded into the `Config`. This is because each tablet could potentially have different credentials.
+### Bonus points
+Given that vitess uses protos everywhere, we could look at standardizing on a generic way to convert yaml to and from protos. This will allow us to look at converting all formats to yaml. If this sounds viable, we can convert the `Config` struct to be generated from a proto, and then have yaml tags that can convert into it. This will future-proof us in case we decide to go this route.
+
+On the initial search, there is no standard way to do this conversion. It would be nice if protos supported this natively as they do for json. We do have the option of using this code to build our own yaml to proto converter: https://github.com/golang/protobuf/blob/master/jsonpb/jsonpb.go.
+## TabletManager
+The TabletManager change will put everything together for the multi-schema feature.
+
+The ActionAgent data structure will be changed to support multiple tablet servers:
+* QueryServiceControl will become a list (or map)
+* UpdateStream will be deleted (deprecated)
+* TabletAlias, VREngine, _tablet and _blacklistedTables will be added to the QueryServiceControl list
+
+All other members of TabletManager seem unaffected.
+
+The tablet manager API will be extended for cases where requests are specific to a tablet id. For example, `GetSchema` will now require the tablet id as an additional parameter. For legacy support: if tablet id is empty, then we redirect the request to the only tablet.
+
+Note: VREngine’s queries are actually tablet agnostic. The user is expected to restrict their queries to the dbname of the tablet. This is not a good user experience. We should tighten up the query analyzer of vrengine to add dbname as an additional constraint or fill in the correct value as needed.
+## VReplication
+VReplication should have a relatively easy change. We already have a field named external mysql. This can be a key into the tablet id Config, which can then be used to pull the mysql credentials needed to connect to the external mysql.
+
+The multi-instance capabilities of VStreamer will naturally extend to support all the observability features we’ll add to it.

--- a/content/en/docs/design-docs/vttablet/fast-transitions.md
+++ b/content/en/docs/design-docs/vttablet/fast-transitions.md
@@ -1,0 +1,27 @@
+---
+title: Fast vttablet state transitions
+description: Fast and reliable vttablet state transitions
+weight: 1
+---
+
+This issue is in response to #6645. When vttablet transitions from master to non-master, the following problems can occur under different circumstances:
+* When a query is killed, it may take a long time for mysql to return the error if it has to do a lot of cleanup. This can delay a vttablet transition. Just closing the pools is not enough because the tablet shutdown also waits for all executing goroutines to return.
+* It is possible that the query timeout is much greater than the transaction timeout. In such cases, the query timeout must be reduced to match the transaction timeout. Otherwise, a running query can hold a transaction hostage and prevent a vttablet from transitioning.
+* The `transaction_shutdown_grace_period` must acquire a new meaning. It should be renamed to `shutdown_grace_period`, and must also apply to queries that are exceeding this time limit. This limit applies to all queries: streaming, oltp read, reserved, and in_transaction.
+* The transaction shutdown code "waits for empty", but reserved connections (not in a transaction) are now part of this pool and will prevent the pool from going empty until they timeout. We need to close them more proactively during a shutdown.
+* The transition from master to non-master uses the immediate flag. This should wait for transactions to complete. Fortunately, due to how PRS works, that code path is not used. We instead use the "dont_serve" code path. But this needs to be fixed for future-proofing.
+
+Many approaches were discussed in #6645. Those approaches are all non-viable because they don't address all of the above concerns.
+
+To fix all these problems, some refactoring will need to be done. Here's the proposal:
+* The query killer (DBConn.Kill) will be changed to proactively close the connection. This will cause the execution to return immediately, thereby addressing the problem where slow kills delay a shutdown.
+* Change the query execution to use the minimum of the transaction timeout and query timeout, but only if the request is part of a transaction.
+* Build a list of all currently active queries by extending StreamQueryList. During a shutdown, the state manager will use this list to kill all active queries if shutdown_grace_period is hit. This, along with the Kill change, will cause all those executes to immediately return and the connections will be returned to their respective pools.
+* tx_engine/tx_pool: Will now have two modes during shutdown:
+  * "kill_reserved" will cause all reserved connections to be closed. If a reserved connection is returned to the pool during this state, it will also be closed. This will be the initial shutdown state until the shutdown grace period is hit.
+  * "kill_all" will cause all reserved and transaction connections to be closed. We enter this state after the shutdown grace period is hit. While in this state, the state manager would have killed all currently executing queries. As these connections are returned to the pool, we just close them. This will cause the tx pool to close in a timely manner.
+* Fix transition to not be immediate (dead code).
+
+During a previous code review, I also found a (rare) race condition in tx_engine, which I forgot to document. I'll redo the analysis and fix the race if it's trivial.
+
+The most important guarantee of this change is that a shutdown will not take longer than the shutdown_grace_period if it was specified.

--- a/content/en/docs/design-docs/vttablet/rbr.md
+++ b/content/en/docs/design-docs/vttablet/rbr.md
@@ -1,0 +1,40 @@
+---
+title: VTTablet with RBR mode
+description: Updating parameters without restarting a process
+weight: 1
+---
+## Summary
+The deprecation of SBR will result in a fundamental change in how vttablet works. The most significant one is that vttablet does not need to compute which rows will be affected by a DML. Dropping this requirement allows us to rethink the implementation of its various features. Some of these changes will not be fully backward compatible. Here are the details:
+
+## Pass-through DMLs
+Most DMLs can be just passed through.
+
+There is, however, one valuable feature that we want to preserve: the ability to limit the number of rows a DML affects. In SBR mode, this was achieved as a side-effect of the fact that we had to run a “subquery” to identify all affected rows, which allowed us to count them and return an error if they exceeded the limit. We lose this ability in pass-through mode.
+
+Instead of continuing to issue the subquery, the new proposal is to add a LIMIT clause to the DML itself. Then, if “RowsAffected” was greater than the limit, we return an error. The one downside of this implementation is that such a failure will leave the DML partially executed. This means that vttablet will have to force a rollback of the transaction. In most use cases, the application is expected to rollback the transaction on such an error. Therefore, this sounds like a reasonable trade-off for the level of simplicity achieved. There is also the added benefit of avoiding the extra roundtrip for the subquery.
+
+This change has a subtle interaction with the “found rows” flag, which reports affected rows differently. This just means that users of this flag may have to set their limits differently.
+
+The explicit pass-through mode flag `queryserver-config-passthrough-dmls` will continue to behave as is. In the new context, its meaning will change to: “do not limit affected rows”.
+
+We believe that inserts of a large number of rows are usually intentional. Therefore, limits will only be applied to updates and deletes.
+
+## Autocommits
+With most DMLs being pass-through, we can now resurrect autocommit behavior in vttablet. This means that a transactionless DML can be treated as autocommit. In the case where a limit has to be enforced, vttablet can open a transaction, and then rollback if the limit is exceeded.
+
+## Sequences
+Sequences will continue their existing behavior: normal statements will continue to be sent to mysql. If a `select next…` is received, the sequence specific functionality will be triggered.
+
+## Messages
+Messages are undergoing a significant overhaul as seen in #5913. Tracking of row changes has been changed to use VStreamer, which allows for any DML to be executed on those tables. Inserts remain an exception because columns like `time_created` and `time_scheduled` have to be populated by vttablet in order to maintain backward compatibility.
+
+## Plan IDs
+Most plan ids were specific to SBR. After the refactor, the total number of plans will be greatly reduced, and we’ll likely generate a new set of ids.
+
+## Schema
+These changes greatly reduce our dependence on the schema. We only need to know the following info from a table:
+* Field info
+* PK columns
+* Table comments
+
+VTTablet also gathered table statistics from `information schema`. However, we don’t think anyone is using them. So, it may be better to stop reporting them. If anyone still needs them, please speak up now.

--- a/content/en/docs/design-docs/vttablet/rt-params-change.md
+++ b/content/en/docs/design-docs/vttablet/rt-params-change.md
@@ -1,0 +1,31 @@
+---
+title: Real-time parameter change
+description: Updating parameters without restarting a process
+weight: 1
+---
+
+## Problem Statement
+
+Vitess Components currently disallow changing of configuration parameters while a process is running. There are a few reasons why this was not allowed:
+
+* The command line used to launch the process will cease to be an authoritative source.
+* It is difficult to audit any values that were changed in real-time or keep track of history if changes were made multiple times.
+* If a process is restarted for any reason, the changes will be reverted.
+
+However, if there is an ongoing high severity incident, it may be beneficial to allow human operators to make temporary changes to a system. This, of course, comes with the caveat that they will eventually revert the changes or make them permanent by deploying the binaries with the new flags.
+
+## Proposal
+
+Given that this should be generally discouraged as common practice, these capabilities should not be made openly available. For example, you should not be able to make such changes using SQL statements.
+
+We’ll export a `/debug/env` endpoint from vttablet, protected by `ADMIN` access. The URL will display the current values of the various parameters and will allow you to modify and submit any of those.
+
+Values like connection pool sizes, query timeouts, query consolidation settings, etc. will be changeable. We’ll iterate on this list as more use cases arise. The initial list will be in an upcoming PR.
+
+## Other options considered
+
+SET Statements: These would be issued via VTGate. The problem with this approach is that the commands would be too widely available. Also, VTGate doesn’t allow targeting of specific tablets.
+
+vtctld ExecuteFetchAsDba SET statements: This could be made to work. However, this is currently implemented as a pass-through in tablet manager. Significant changes will be needed to parse the statements and make them do other things.
+
+vtcltd alternate command, like `SetTabletEnv`: This could be made to work. However, it is a lot more work than what is proposed, and may not be worth it for a feature that is meant to be used so rarely. We still have the option of implementing this if the need arises in the future.

--- a/content/en/docs/design-docs/vttablet/tablet-params.md
+++ b/content/en/docs/design-docs/vttablet/tablet-params.md
@@ -1,0 +1,170 @@
+---
+title: VTTablet YAML configuration
+description: Tabletserver YAML parameters
+weight: 1
+---
+
+## Background
+This issue is an expansion of #5791, and covers the details of how we’ll use yaml to implement a hierarchy of parameters for initializing and customizing TabletServer components within a process.
+
+Using the yaml approach, we intend to solve the following problems:
+* Multiple tablet servers need to exist within a process.
+* Badly named command line parameters: The new yaml specifications will have simpler and easier to remember parameter names.
+* Sections for improved readability.
+* Unreasonable default values: The new specs will introduce a simplified approach that will save the user from tweaking too many variables without knowing their consequences.
+* Repetition: If multiple TabletServers have to share the same parameter values, they should not be repeated.
+* Backward compatibility: The system must be backward compatible.
+## Proposed Approach
+We will introduce two new command-line options that will be specified like this:
+```
+-defaults=defaults.yaml -tablets=tablets.yaml
+```
+
+The defaults option allows the user to specify the default settings for all tablets. The “tablets” option allows the user to specify tablet specific options.
+
+We’ll provide predefined “defaults” files that people can use as starting points. We’ll start with something simple like small.yaml, medium.yaml, and large.yaml.
+
+### Protobuf
+We explored the use of protobufs for converting to and from yaml. However, the protobuf JSON implementation, which was required to correctly parse enums, was unable to preserve the original values for sub-objects. This was a showstopper for making defaults work.
+
+The existing `tabletenv.TabletConfig` data structure will be converted into a struct with the new names and appropriate JSON tags.
+
+## Detailed specification
+The following section lists all the properties that can be specified in a yaml file along with the existing defaults.
+
+During implementation, we’ll need to decide between creating a universal protobuf that represents this structure vs converting the original one into something more usable.
+
+Convention used: same as the one followed by kubernetes, and we’ll be making use of https://github.com/kubernetes-sigs/yaml for the implementation.
+
+Note that certain properties (like tabletID) are only applicable to tablet-specific files.
+
+```
+tabletID: zone-1234
+
+init:
+  dbName:            # init_db_name_override
+  keyspace:          # init_keyspace
+  shard:             # init_shard
+  tabletType:        # init_tablet_type
+  timeoutSeconds: 60 # init_timeout
+
+db:
+  socket:     # db_socket
+  host:       # db_host
+  port: 0     # db_port
+  charSet:    # db_charset
+  flags: 0    # db_flags
+  flavor:     # db_flavor
+  sslCa:      # db_ssl_ca
+  sslCaPath:  # db_ssl_ca_path
+  sslCert:    # db_ssl_cert
+  sslKey:     # db_ssl_key
+  serverName: # db_server_name
+  connectTimeoutMilliseconds: 0 # db_connect_timeout_ms
+  app:
+    user: vt_app      # db_app_user
+    password:         # db_app_password
+    useSsl: true      # db_app_use_ssl
+    preferSocket: true
+  dba:
+    user: vt_dba      # db_dba_user
+    password:         # db_dba_password
+    useSsl: true      # db_dba_use_ssl
+    preferSocket: true
+  filtered:
+    user: vt_filtered # db_filtered_user
+    password:         # db_filtered_password
+    useSsl: true      # db_filtered_use_ssl
+    preferSocket: true
+  repl:
+    user: vt_repl     # db_repl_user
+    password:         # db_repl_password
+    useSsl: true      # db_repl_use_ssl
+    preferSocket: true
+  appdebug:
+    user: vt_appdebug # db_appdebug_user
+    password:         # db_appdebug_password
+    useSsl: true      # db_appdebug_use_ssl
+    preferSocket: true
+  allprivs:
+    user: vt_allprivs # db_allprivs_user
+    password:         # db_allprivs_password
+    useSsl: true      # db_allprivs_use_ssl
+    preferSocket: true
+
+oltpReadPool:
+  size: 16                 # queryserver-config-pool-size
+  timeoutSeconds: 0        # queryserver-config-query-pool-timeout
+  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout
+  prefillParallelism: 0    # queryserver-config-pool-prefill-parallelism
+  maxWaiters: 50000        # queryserver-config-query-pool-waiter-cap
+
+olapReadPool:
+  size: 200                # queryserver-config-stream-pool-size
+  timeoutSeconds: 0        # queryserver-config-query-pool-timeout
+  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout
+  prefillParallelism: 0    # queryserver-config-stream-pool-prefill-parallelism
+  maxWaiters: 0
+
+txPool:
+  size: 20                 # queryserver-config-transaction-cap
+  timeoutSeconds: 1        # queryserver-config-txpool-timeout
+  idleTimeoutSeconds: 1800 # queryserver-config-idle-timeout
+  prefillParallelism: 0    # queryserver-config-transaction-prefill-parallelism
+  maxWaiters: 50000        # queryserver-config-txpool-waiter-cap
+
+oltp:
+  queryTimeoutSeconds: 30 # queryserver-config-query-timeout
+  txTimeoutSeconds: 30    # queryserver-config-transaction-timeout
+  maxRows: 10000          # queryserver-config-max-result-size
+  warnRows: 0             # queryserver-config-warn-result-size
+
+hotRowProtection:
+  mode: disable|dryRun|enable # enable_hot_row_protection, enable_hot_row_protection_dry_run
+  # Default value is same as txPool.size.
+  maxQueueSize: 20            # hot_row_protection_max_queue_size
+  maxGlobalQueueSize: 1000    # hot_row_protection_max_global_queue_size
+  maxConcurrency: 5           # hot_row_protection_concurrent_transactions
+
+consolidator: enable|disable|notOnMaster # enable-consolidator, enable-consolidator-replicas
+heartbeatIntervalMilliseconds: 0         # heartbeat_enable, heartbeat_interval
+shutdownGracePeriodSeconds: 0            # transaction_shutdown_grace_period
+passthroughDML: false                    # queryserver-config-passthrough-dmls
+streamBufferSize: 32768                  # queryserver-config-stream-buffer-size
+queryCacheSize: 5000                     # queryserver-config-query-cache-size
+schemaReloadIntervalSeconds: 1800        # queryserver-config-schema-reload-time
+watchReplication: false                  # watch_replication_stream
+terseErrors: false                       # queryserver-config-terse-errors
+messagePostponeParallelism: 4            # queryserver-config-message-postpone-cap
+cacheResultFields: true                  # enable-query-plan-field-caching
+
+
+# The following flags are currently not supported.
+# enforce_strict_trans_tables
+# queryserver-config-strict-table-acl
+# queryserver-config-enable-table-acl-dry-run
+# queryserver-config-acl-exempt-acl
+# enable-tx-throttler
+# tx-throttler-config
+# tx-throttler-healthcheck-cells
+# enable_transaction_limit
+# enable_transaction_limit_dry_run
+# transaction_limit_per_user
+# transaction_limit_by_username
+# transaction_limit_by_principal
+# transaction_limit_by_component
+# transaction_limit_by_subcomponent
+```
+
+There are also other global parameters. VTTablet has a total of 405 flags. We may have to later move some of them into these yamls.
+
+## Implementation
+We'll use the unified tabletenv.TabletConfig data structure to load defaults as well as tablet-specific values. The following changes will be made:
+* TabletConfig will be changed to match the above specifications.
+* The existing flags will be changed to update the values in a global TabletConfig.
+* In case of type mismatch (like time.Duration vs a "Seconds" variable), an extra step will be performed after parsing to convert the flag variables into TabletConfig members.
+* The code will be changed to honor the new TabletConfig members.
+* After the flag.Parse step, a copy of the global Config will be used as input to load the defaults file. This means that any command line flags that are not overridden in the yaml files will be preserved. This behavior is needed to support backward compatibility in case we decide to move more flags into the yaml.
+* For each tablet entry, we create a copy of the result TabletConfig and read the tablet yaml into those, which will set the tablet-specific values. This will then be used to instantiate a TabletServer.
+
+The exact format of the tablets.yaml file is not fully finalized. Our options are to allow a list of files where each is for a single tablet, or, to require only one file containing a dictionary of tablet-specific overrides.

--- a/content/en/docs/design-docs/vttablet/tm-model.md
+++ b/content/en/docs/design-docs/vttablet/tm-model.md
@@ -1,0 +1,62 @@
+---
+title: The tabletmanager model
+description: 
+weight: 1
+---
+## Background
+
+The current tabletmanager model treats the tablet record as authoritative. The tabletmanager polls the tablet record and reacts to changes there. There are also calls sprayed around the code that invoke “RefreshTablet” or “RefreshState”, after they update the tablet record.
+
+This model is not representative of how we currently operate vitess. There is actually no benefit to updating the tablet record and expecting the tablet to refresh itself. In fact, the approach is fragile because we’re unnecessarily bringing additional components in our chain of action, thereby increasing the chances of failure.
+
+We should instead change our model to say that the tablet process is the authoritative source of its current state. It publishes it to the tablet record, which is then used for discovery.
+
+## Details
+
+### While vttablet is up
+
+Every flow that needs to change something about a tablet directly issues an rpc request to it. The tablet will immediately execute the request, and will perform a best-effort action to update the tablet record, and will continue to retry until it succeeds.
+
+The main advantage of this approach is that the request will succeed with a single round trip to the tablet. If the request fails, we treat it as a failure. If the request succeeds, but the tablet fails to update its record, we still succeed. The tablet record will eventually be updated.
+
+### If vttablet is down or is unreachable
+
+If vttablet is unreachable, we fail the operation. This failure mode is no worse than us not being able to update a tablet record.
+
+Essentially, we generally assume that the tablet record may not be in sync with the vttablet. This has always been the case, and our code has to deal with this already.
+
+### Refresh State
+
+Refresh state will continue to exist as an API, but it’s only for refreshing against state changes in the global topo.
+
+### Exception 1: Mastership
+
+In the case of flows that designate who the master is, the topo is the authority. For such requests, the tablet will first try to update its record, and only then succeed. This is required because of how the new mastership redesign works.
+
+### Exception 2: VTTablet startup
+
+When a vttablet starts up, it will treat the following info from the topo as authoritative:
+* Keyspace
+* Shard
+* Tablet Type
+* DBName
+
+As an additional precaution, if this info does not match the init parameters, we should exit.
+
+We can also consider the following: If the tablet type is master, we can force a sync against the shard record before we confirm ourselves to be the master.
+
+## Advantages
+
+The main advantage of this approach is that a vttablet becomes the authoritative owner of a tablet record. This will greatly reduce its complexity because it doesn’t have to continuously poll it, and it does not have to deal with possibly unexpected or invalid changes in the tablet record.
+
+Since it can assume that nobody else is modifying the record, the vttablet can freely update the tablet record with its local copy without worrying about synchronizing with the existing info.
+
+This will also simplify many flows because they will all become a single request instead of being two requests (change record and refresh).
+
+Load on topos will be reduced because the tablets don’t poll anymore.
+
+## Transition
+
+We’ll first change all call sites to a single round-trip to the tablets. The tabletmanager will continue to update the tablet record and rely on its existing poller.
+
+This change will mean that the tabletmanager has become the sole owner of its tablet record. At this point, we can switch its behavior to non-polling.


### PR DESCRIPTION

This PR copies over a bunch of RFCs which were created as issues in the vitess repo. Those issues were chosen which are fairly recent and completed. I cut/pasted the subject of those issues with some minor fixes suggested by grammarly.

* A new Design Docs section has been added
* Sub-categories created are: Query Serving, VTTablet, VReplication and Build and Process








Signed-off-by: Rohit Nayak <rohit@planetscale.com>