### PR TITLE
Articles: add prev/next navigation links and use full viewport

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -65,7 +65,7 @@ html, body
   &:hover
     background: rgba(255, 255, 255, 0.05)
 
-.docs-navlist li.active > a 
+.docs-navlist li.active > a
   color: $tan
 
 .navlist-caret
@@ -93,7 +93,7 @@ li.expanded > a > .navlist-caret
 
     .content
       +desktop
-        width: 80%
+        width: 100%
 
       p a, li a
         font-weight: 700

--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -166,7 +166,13 @@ li.expanded > a > .navlist-caret
 
 // used atm in vreplication commands reference
 .cmd
-  padding: 10px;
-  margin-left: 30px;
-  background-color: #f7f7f7;
-  margin-bottom: 10px;
+  padding: 10px
+  margin-left: 30px
+  background-color: #f7f7f7
+  margin-bottom: 10px
+
+// used to display text in prev/next navigation buttons for articles
+.limit-text
+  overflow: hidden
+  text-overflow: ellipsis
+  white-space: nowrap

--- a/layouts/partials/docs/article.html
+++ b/layouts/partials/docs/article.html
@@ -3,5 +3,8 @@
 
   <div class="content">
     {{ .Content }}
+    <hr style="margin-top:2rem;margin-bottom:2rem;border:none;border-top: 0.1rem solid darkgrey;width:100%;"/>
+    {{ partial "docs/next-prev-navigation.html" . }}
   </div>
+
 </article>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -4,7 +4,7 @@
 {{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
 <header class="docs-header">
   {{/* Hide breadcrumbs on mobile since bulma.io doesn't handle overflows nicely for long crumbs */}}
-  <nav class="breadcrumb is-hidden-touch" aria-label="breacrumbs">
+  <nav class="breadcrumb is-hidden-touch" aria-label="breadcrumbs">
     <ul>
       {{ template "breadcrumbnav" (dict "p1" . "p2" .) }}
     </ul>
@@ -12,13 +12,13 @@
     {{/* See: https://gohugo.io/content-management/sections/#example-breadcrumb-navigation */}}
     {{ define "breadcrumbnav" }}
       {{ $isCurrentPage := eq .p1 .p2 }}
-      
+
       {{ if .p1.Parent }}
         {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 )  }}
       {{ else if not .p1.IsHome }}
         {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
       {{end}}
-      
+
       {{/* No breadcrumb for root URL since we already have the logo */}}
       {{ if not .p1.IsHome }}
         {{/* No breadcrumb if the current page is the first and only breadcrumb */}}
@@ -87,4 +87,6 @@
       </div>
     </div>
   </div>
+  {{ partial "docs/next-prev-navigation.html" . }}
+
 </header>

--- a/layouts/partials/docs/next-prev-navigation.html
+++ b/layouts/partials/docs/next-prev-navigation.html
@@ -1,0 +1,20 @@
+
+    {{ if or (.PrevInSection) (.NextInSection) }}
+    <div>
+
+    <div style="float:left;">
+      {{ if .NextInSection }}
+          <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile" href={{ .NextInSection.Permalink }}>
+            <b class="has-text-orange"><<</b>&nbsp;
+      {{ .NextInSection.Name }}</a>
+      {{ end }}
+    </div>
+
+    <div style="float:right">
+       {{ if .PrevInSection }}
+            <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile" href={{ .PrevInSection.Permalink }}>{{ .PrevInSection.Name }}&nbsp;<b class="has-text-orange">>></b></a>
+       {{ end }}
+
+    </div>
+    <div style="clear:both;"/>
+    {{ end }}

--- a/layouts/partials/docs/next-prev-navigation.html
+++ b/layouts/partials/docs/next-prev-navigation.html
@@ -1,20 +1,27 @@
 
     {{ if or (.PrevInSection) (.NextInSection) }}
-    <div>
+    <div style="padding:0;display=inline-block">
 
-    <div style="float:left;">
       {{ if .NextInSection }}
-          <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile" href={{ .NextInSection.Permalink }}>
+        <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile;" style="max-width:50%;float:left" href={{.NextInSection.Permalink }}>
             <b class="has-text-orange"><<</b>&nbsp;
-      {{ .NextInSection.Name }}</a>
+          <span class="limit-text">
+            {{ .NextInSection.Name }}
+          </span>
+        </a>
+
       {{ end }}
-    </div>
 
-    <div style="float:right">
-       {{ if .PrevInSection }}
-            <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile" href={{ .PrevInSection.Permalink }}>{{ .PrevInSection.Name }}&nbsp;<b class="has-text-orange">>></b></a>
-       {{ end }}
+      {{ if .PrevInSection }}
+        <a class="button has-background-black has-text-grey-light is-size-6 is-size-6-mobile;" style="max-width:50%;float:right" href={{.PrevInSection.Permalink }}>
 
+          <span class="limit-text">
+            {{ .PrevInSection.Name }}
+          </span>
+            &nbsp;<b class="has-text-orange">>></b>
+
+        </a>
+      {{ end }}
     </div>
     <div style="clear:both;"/>
     {{ end }}


### PR DESCRIPTION
1. Add prev/next buttons for navigating between articles in a section

Currently to go to the next section you need to click explicitly on the next link in the left navbar. However some sections, like the user-guides, are written as a single "e-book" which should be read in sequence. So navigation buttons to traverse though them should help.

2.  Articles use full viewport
 
At the moment articles only use 80% of the viewport, resulting in  white space on the right. It is unsure why this was done. I changed it to 100% to see what breaks, but am unable to find anything. So have not changed it to 100%.

![nav1](https://user-images.githubusercontent.com/57520317/105631943-376a3000-5e51-11eb-8e45-1a930779fc0a.png)

![nav2](https://user-images.githubusercontent.com/57520317/105631945-3802c680-5e51-11eb-8533-5922bb7b0f7c.png)
