### PR TITLE
grammar changes and reformatting to make the PDF

### DIFF
--- a/content/en/docs/contributing/code-reviews.md
+++ b/content/en/docs/contributing/code-reviews.md
@@ -9,6 +9,7 @@ Moreover, many users deploy directly from the master branch.
 It is very important the changes made by contributors do not break any existing workloads.
 
 In order to avoid disruption, the following concerns need to be kept in mind:
+
 * Does the change affect any external APIs? If so, make sure the change satisfies the [compatibility rules](https://github.com/vitessio/enhancements/blob/master/veps/vep-3.md).
 * Can the change introduce a performance regression? If so, it will be good to measure the impact using benchmarks.
 * If the change is substantial or is a breaking change, you must publish the proposal as an issue with a title like `RFC: Changing behavior of feature xxx`. Following this, sufficient time has to be given for others to give feedback. A breaking change must still satisfy the compatibility rules.
@@ -19,6 +20,7 @@ In order to avoid disruption, the following concerns need to be kept in mind:
 Every GitHub pull request must go through a code review and get approved before it will be merged into the master branch.
 
 Every pull request should meet the following requirements:
+
 * Use the [Pull Request Template](https://github.com/vitessio/vitess/blob/master/.github/pull_request_template.md)
 * Adhere to the [Go coding guidelines](https://golang.org/doc/effective_go.html) and watch out for these [common errors](https://github.com/golang/go/wiki/CodeReviewComments).
 * Contain a description message that is as detailed as possible. Here is a great example https://github.com/vitessio/vitess/pull/6543.
@@ -48,6 +50,7 @@ While you are fixing the bug, it's valuable if you take the time to step back an
 It's often possible to infer that other similar problems in this or other parts of the code base can be prevented.
 
 Some additional points to keep in mind:
+
 *   Does this change match an existing design / bug?
 *   Is this change going to log too much? (Error logs should only happen when
     the component is in bad shape, not because of bad transient state or bad

--- a/content/en/docs/design-docs/build-and-process/pr-convention.md
+++ b/content/en/docs/design-docs/build-and-process/pr-convention.md
@@ -18,6 +18,7 @@ There's a clear need of improving GitHub naming conventions for the following se
 The most problematic area we see is the Pull Request Naming Convention hence we'd like to come up with guidelines and once agreed by maintainers provide a Template that will help streamline the above areas.
 
 For Issue Templates please refer to this [section](https://github.com/vitessio/vitess/tree/master/.github/ISSUE_TEMPLATE).
+
 ### Solution
 
 The suggested solution would be creating general guidelines for this naming convention update.
@@ -67,7 +68,8 @@ Example:
 - Each paragraph capitalized
 - Example and/or Reproduce steps
 
-```Overview of the Issue
+```
+Overview of the Issue
 The query sent down from VTGate to Vttablet does not replace the where clause of the information schema queries for table_schema = 'keyspace' to table_schema = 'databasename'
 
 Reproduction Steps

--- a/content/en/docs/design-docs/query-serving/replicatx.md
+++ b/content/en/docs/design-docs/query-serving/replicatx.md
@@ -8,6 +8,7 @@ weight: 1
 Vitess currently supports transactions through vtgate only on MASTER tablets. We would like to extend transaction support to REPLICA (or other tablet types).
 
 ### Use Case(s)
+
 * Consistent reads
 * Sqoop integration
 

--- a/content/en/docs/design-docs/query-serving/set-stmt.md
+++ b/content/en/docs/design-docs/query-serving/set-stmt.md
@@ -31,6 +31,7 @@ Reserve Pool
 VTTablet will have a new pool named reserved pool. Connections in the reserved pool are tied to a specific session and are closed when the session is closed.
 
 QueryService interface changes:
+
 * ReserveExecute: Reserve a connection, execute the set statements, and the query.
 * ReserveBeginExecute: Reserve a connection, execute the set statements, move the reserve connection to active transaction pool and execute begin and the query.
 * ReserveRelease: This closes the reserved connection and also rollback the transaction if it is in an open state.
@@ -46,31 +47,31 @@ A connection with the vttablet is reserved when a query is sent from the client 
 Storing the changed setting in the session enables VTGate to apply settings to any new connection that is opened with different shards.
 
 State | Reserved | Transaction | Recorded SETs
--- | -- | -- | --
-clear | F | F | F
-remember-sets | F | F | T
-reserved | T | F | T
-inTx | F | T | F
-reserved-inTx | T | T | T
+| -- | -- | -- | -- |
+|clear | F | F | F |
+|remember-sets | F | F | T |
+|reserved | T | F | T |
+|inTx | F | T | F |
+|reserved-inTx | T | T | T |
 
 From State | Query | Vtgate Action | API on tablet | To State
--- | -- | -- | -- | --
-clear | SET system var | Record statement | No call | remember-sets
-remember-sets | SET system var | Record statement | No call | remember-sets
-reserved | SET system var | Record statement | Execute | reserved
-inTx | SET system var | Record statement | ReserveExecute | reserved-inTx
-reserved-inTx | SET system var | Record statement | Execute | reserved-inTx
-remember-sets | Query |   | ReserveExecute | reserved
-reserved | Query |   | Execute | reserved
-reserved-inTx | Query |   | Execute | reserved-inTx
-remember-sets | Begin + Query |   | ReserveBeginExecute | reserved-inTx
-reserved | Begin + Query |   | BeginExecute | reserved-inTx
-remember-sets | Commit/Rollback | No-op | No call | remember-sets
-reserved | Commit/Rollback | No-op | No call | reserved
-reserved-inTx | Commit/Rollback |   | Commit/Rollback | reserved
-remember-sets | Close Connection | Close Session | No call | clear
-reserved | Close Connection | Close Session | ReserveRelease | clear
-reserved-inTx | Close Connection | Close Session | ReserveRelease | clear
+| -- | -- | -- | -- | -- |
+| clear | SET system var | Record statement | No call | remember-sets |
+| remember-sets | SET system var | Record statement | No call | remember-sets |
+| reserved | SET system var | Record statement | Execute | reserved |
+| inTx | SET system var | Record statement | ReserveExecute | reserved-inTx |
+| reserved-inTx | SET system var | Record statement | Execute | reserved-inTx |
+| remember-sets | Query |   | ReserveExecute | reserved |
+| reserved | Query |   | Execute | reserved |
+| reserved-inTx | Query |   | Execute | reserved-inTx |
+| remember-sets | Begin + Query |   | ReserveBeginExecute | reserved-inTx |
+| reserved | Begin + Query |   | BeginExecute | reserved-inTx |
+| remember-sets | Commit/Rollback | No-op | No call | remember-sets |
+| reserved | Commit/Rollback | No-op | No call | reserved |
+| reserved-inTx | Commit/Rollback |   | Commit/Rollback | reserved |
+| remember-sets | Close Connection | Close Session | No call | clear |
+| reserved | Close Connection | Close Session | ReserveRelease | clear |
+| reserved-inTx | Close Connection | Close Session | ReserveRelease | clear |
 
 ## Release Plan
 The release plan would be to update vttablet < vtctl < vtgate in this particular order.

--- a/content/en/docs/design-docs/vttablet/component-ts.md
+++ b/content/en/docs/design-docs/vttablet/component-ts.md
@@ -8,60 +8,75 @@ weight: 1
 As Vitess adoption expands, several feature requests have been popping up that will benefit from multiple instances of TabletServer (or its sub-components) co-existing within the same process.
 
 The following features drive this refactor, in order of priority:
+
 * Multi-schema
 * VTShovel: multiple data import sources for vreplication
 * VTDirect: allow VTGate to directly send queries to mysql
 
 Beyond these features, componentizing TabletServer will make the vitess architecture more flexible. There are many places in the code where we instantiate a QueryService. All those places can now explore the benefit of instantiating a TabletServer or its sub-components.
+
 # Features
 This section describes the use cases and their features. An important prerequisite: In order to retain backward compatibility, the new features should not cause existing behavior to be affected.
+
 ## Multi-schema
 There has been a steady inflow of enquiries about use cases where a mysql instance has a large number of schemas (1000+). We currently support multi-schema by requiring the user to launch one vttablet process per schema. This, however, does not scale for the number of schemas we are beginning to see.
 
 To enable this, we need the ability for a single vttablet to host multiple TabletServers. Requirements are:
+
 * Grouped or consolidated Stats (/debug/vars).
 * Segregated or consolidated HTTP endpoints, like (/debug/status), with sub-page links working.
 * A better way to specify flags: the existing approach of command line flags may not scale.
 * A tablet manager that can represent multiple tablet ids.
 
 Other parts of TabletServer have already been modified to point at a shared mysql instance due to work done by @deepthi in #4727, and other related changes.
+
 ## VTShovel
 VTShovel is a data migration feature that extends VReplication to allow a user to specify an external mysql as the source. This can be used to import data and also keep the targets up-to-date as the source is written to.
 
 VTShovel currently has two limitations:
+
 * It supports only one external source per vttablet. The need for multiple sources was voiced as a requirement by one of the adopters.
 * It does not support VDiff, which also requires multiple sources.
 
 If the TabletServer refactor is architected correctly, VTShovel should inherit the multi-instance ability without any major impact. In particular:
+
 * Leverage the flags refactor to support more than one external source.
 * Observability features implemented for multi-schema like stats and HTTP endpoints should naturally extend to vtshovel.
 * VDiff should work.
+
 ## VTDirect
 The excessive use of CPU due to gRPC continues to be a concern among some adopters. Additionally, Vitess is now being deployed against externally managed databases like RDS and CloudSQL. Such users are reluctant to pay the latency cost of the extra hop.
 
 VTDirect is the ability of VTGate to directly send queries to the mysql instances.
 
 This feature adds the following requirements over the previous ones:
+
 * Some features of TabletServer (like sequences) should be disabled or redirected to an actual vttablet.
 * TabletServers can have a life-cycle as tablets are added and removed from the topo. The variables and end-points need to reflect these changes.
 
 In previous discussions, alternate approaches that did not require a TabletServer refactor were suggested. Given that the TabletServer refactor brings us much closer to this feature, we’ll need to re-evaluate our options for the best approach. This will be a separate RFC.
+
 # Requirements
 This section describes the requirements dictated by the features.
+
 ## Stats
 Stats (/debug/vars) should be reported in such a way that the variables from each TabletServer can be differentiated. Idiomatic usage of vitess expects the monitoring tool to add the tablet id as a dimension when combining variables coming from different vttablets. Therefore, every TabletServer should be changed to add this dimension to its exported variables.
 
 On the flip side, this may result in an extremely large number of variables to be exported. If so, it may be better to consolidate them. There is no right answer; We have to support both options.
+
 ### Other options considered
 We could have each TabletServer export a brand new set of variables by appending the tablet id to the root variable name. However, this would make it very hard for monitoring tools because they are not very good at dealing with dynamic variable names.
+
 ## HTTP endpoints
 A TabletServer exports a variety of http endpoints. In general, it makes sense to have each TabletServer export a separate set of endpoints within the current process. However, in cases where the performance of the underlying mysql is concerned, it may be beneficial to consolidate certain pages.
 
 We’ll start with a separate set of pages, with each set prefixed by the tablet id. For example, what was previously `/debug/consolidations` will now become `/cell-100/debug/consolidations`.
+
 ### Other options considered
 We could keep the existing set of endpoints unchanged, and have each TabletServer add its section. But this would make it hard to troubleshoot problems related to a specific TabletServer.
 
 The best-case scenario would be the “why not both” option: the original set of pages continue to exist and provide a summary from all the tablet servers. This can still be implemented as an enhancement.
+
 ## Command line flags
 Extending the command line flags to be able to specify parameters for a thousand tablet servers is not going to be practical.
 
@@ -70,12 +85,16 @@ Using config files is a better option. To prevent verbosity, we can use a hierar
 The input file format could be yaml. Also, this is a good opportunity for us to come up with better names.
 
 Since the config option is more powerful and flexible, specifying that file in the command line will supersede all legacy flags.
+
 ### Other options considered
 These configs could be hosted in the topo. This is actually viable. There are two reasons why this option takes a backseat:
+
 * We currently don’t have good tooling for managing data in the topo. VTCtld is currently the only way, and people have found it inadequate sometimes.
 * There are mechanisms to secure config files, which will allow it to contain secrets like the mysql passwords. This will not be possible in the case of topos.
+
 # Design
 We propose to address the above requirements with the following design elements.
+
 ## Dimension Dropper
 The dimension dropper will be a new feature of the stats package. Its purpose is to remove specific dimensions from any multi-dimensional variable.
 
@@ -86,12 +105,14 @@ In the case of the TabletServer, specifying `TabletID` in the list of dropped di
 The reason for this approach is that there are already other use cases where the number of exported variables is excessive. This allows us to address those use cases also.
 
 It’s possible that this feature is too broad. For example, one may not want to drop the `Keyspace` dimension from all variables. If we encounter such use cases, it should be relatively easy to extend this feature to accommodate more specific rules.
+
 ## Exporter
 The exporter will be a new feature that will layer between TabletServer and the singleton APIs: stats and http. It will allow you to create exporters that are either anonymous or named.
 
 An anonymous exporter will behave as if you invoked the stats and http directly. Open issue: we’ll need to see if we want to protect from panics due to duplicate registrations.
 
 A named exporter will perform consolidations or segregations depending on the situation:
+
 * In the case of a stats variable, it will create a common underlying variable, and will update the dimension that matches the name of the exporter.
 * In the case of http, it will export the end point under a new URL rooted from the name of the exporter.
 
@@ -102,6 +123,7 @@ A prototype of this implementation (aka embedder) is present in the vtdirect bra
 There is no need for the exporter to provide the option to consolidate without the name because the dimension dropper can cover that functionality.
 
 It’s possible to achieve backward compatibility for stats by creating an exporter with a name (tablet id), and then dropping that dimension in stats. However, it’ll work only for stats and not for the http endpoints. For this reason, we need to support explicit code paths for the anonymous exporters. Plus, it makes things more explicit.
+
 ## Config loader
 The TabletServer already has most, if not all, of its input flags consolidated into a `Config` struct under tabletenv. The existing flags initialize a `DefaultConfig` global variable. If the command line specifies a newly defined flag, like `-tablet_config=’filename.yaml’`, then we can branch off into code that reads the yaml file and initializes the configs from there.
 
@@ -112,14 +134,17 @@ This is an opportunity for us to rename the members of the Config struct to use 
 The most popular yaml reader seems to be https://github.com/go-yaml/yaml. We’ll start with that and iterate forward.
 
 The dbconfigs data structure will also be folded into the `Config`. This is because each tablet could potentially have different credentials.
+
 ### Bonus points
 Given that vitess uses protos everywhere, we could look at standardizing on a generic way to convert yaml to and from protos. This will allow us to look at converting all formats to yaml. If this sounds viable, we can convert the `Config` struct to be generated from a proto, and then have yaml tags that can convert into it. This will future-proof us in case we decide to go this route.
 
 On the initial search, there is no standard way to do this conversion. It would be nice if protos supported this natively as they do for json. We do have the option of using this code to build our own yaml to proto converter: https://github.com/golang/protobuf/blob/master/jsonpb/jsonpb.go.
+
 ## TabletManager
 The TabletManager change will put everything together for the multi-schema feature.
 
 The ActionAgent data structure will be changed to support multiple tablet servers:
+
 * QueryServiceControl will become a list (or map)
 * UpdateStream will be deleted (deprecated)
 * TabletAlias, VREngine, _tablet and _blacklistedTables will be added to the QueryServiceControl list
@@ -129,6 +154,7 @@ All other members of TabletManager seem unaffected.
 The tablet manager API will be extended for cases where requests are specific to a tablet id. For example, `GetSchema` will now require the tablet id as an additional parameter. For legacy support: if tablet id is empty, then we redirect the request to the only tablet.
 
 Note: VREngine’s queries are actually tablet agnostic. The user is expected to restrict their queries to the dbname of the tablet. This is not a good user experience. We should tighten up the query analyzer of vrengine to add dbname as an additional constraint or fill in the correct value as needed.
+
 ## VReplication
 VReplication should have a relatively easy change. We already have a field named external mysql. This can be a key into the tablet id Config, which can then be used to pull the mysql credentials needed to connect to the external mysql.
 

--- a/content/en/docs/design-docs/vttablet/rbr.md
+++ b/content/en/docs/design-docs/vttablet/rbr.md
@@ -33,6 +33,7 @@ Most plan ids were specific to SBR. After the refactor, the total number of plan
 
 ## Schema
 These changes greatly reduce our dependence on the schema. We only need to know the following info from a table:
+
 * Field info
 * PK columns
 * Table comments

--- a/content/en/docs/design-docs/vttablet/tablet-params.md
+++ b/content/en/docs/design-docs/vttablet/tablet-params.md
@@ -8,12 +8,14 @@ weight: 1
 This issue is an expansion of #5791, and covers the details of how we’ll use yaml to implement a hierarchy of parameters for initializing and customizing TabletServer components within a process.
 
 Using the yaml approach, we intend to solve the following problems:
+
 * Multiple tablet servers need to exist within a process.
 * Badly named command line parameters: The new yaml specifications will have simpler and easier to remember parameter names.
 * Sections for improved readability.
 * Unreasonable default values: The new specs will introduce a simplified approach that will save the user from tweaking too many variables without knowing their consequences.
 * Repetition: If multiple TabletServers have to share the same parameter values, they should not be repeated.
 * Backward compatibility: The system must be backward compatible.
+
 ## Proposed Approach
 We will introduce two new command-line options that will be specified like this:
 ```
@@ -160,6 +162,7 @@ There are also other global parameters. VTTablet has a total of 405 flags. We ma
 
 ## Implementation
 We'll use the unified tabletenv.TabletConfig data structure to load defaults as well as tablet-specific values. The following changes will be made:
+
 * TabletConfig will be changed to match the above specifications.
 * The existing flags will be changed to update the values in a global TabletConfig.
 * In case of type mismatch (like time.Duration vs a "Seconds" variable), an extra step will be performed after parsing to convert the flag variables into TabletConfig members.

--- a/content/en/docs/design-docs/vttablet/tm-model.md
+++ b/content/en/docs/design-docs/vttablet/tm-model.md
@@ -36,6 +36,7 @@ In the case of flows that designate who the master is, the topo is the authority
 ### Exception 2: VTTablet startup
 
 When a vttablet starts up, it will treat the following info from the topo as authoritative:
+
 * Keyspace
 * Shard
 * Tablet Type

--- a/content/en/docs/pdfs/_index.md
+++ b/content/en/docs/pdfs/_index.md
@@ -9,6 +9,7 @@ The Vitess Documentation currently posted should reflect the most recent code.
 
 To view a PDF of the state of the Vitess Documentation on the date of the general availability release for previous versions please follow the links below:
 
+- [Vitess Docs 9.0 on January 26, 2021](https://drive.google.com/file/d/18xPfVl-OpKX6QtjEUwFY_dU93Y-ZDPav/view?usp=sharing)
 - [Vitess Docs 8.0 on October 27, 2020](https://drive.google.com/file/d/1SMnw19uYYFl9vqYsbc67jIC-8VObfiwh/view?usp=sharing)
 - [Vitess Docs 7.0 on July 28, 2020](https://drive.google.com/file/d/1Uu5JU-tOzElRbLSnOS2ZaTE8BOI6DAWG/view?usp=sharing)
 - [Vitess Docs 6.0 on April 29, 2020](https://drive.google.com/file/d/1b3EwRxYc3uBfnCKDvMhLXWEZenvDYX2u/view?usp=sharing)

--- a/content/en/docs/reference/features/schema-routing-rules.md
+++ b/content/en/docs/reference/features/schema-routing-rules.md
@@ -44,6 +44,7 @@ Routing rules can be specified using JSON format. Here's an example:
 ```
 
 The above JSON specifies the following rules:
+
 * If you sent a query accessing `t` for an `rdonly` instance, then it would be sent to table `t` in the `target` keyspace.
 * If you sent a query accessing `target.t` for anything other than `rdonly`, it would be sent `t` in the `source` keyspace.
 * If you sent a query accessing `t` without any qualification, it would be sent to `t` in the `source` keyspace.

--- a/content/en/docs/reference/features/vindexes.md
+++ b/content/en/docs/reference/features/vindexes.md
@@ -67,6 +67,7 @@ Vitess allows for the transparent population of these lookup table rows by assig
 Consistent lookup vindexes use an alternate approach that makes use of careful locking and transaction sequences to guarantee consistency without using 2PC. This gives the best of both worlds, with the benefit of a consistent cross-shard vindex without paying the price of 2PC.
 
 There are currently two vindex types in Vitess for consistent lookup:
+
 * `consistent_lookup_unique`
 * `consistent_lookup`
 
@@ -118,11 +119,11 @@ However, it is generally not recommended to use a Lookup Vindex as a Primary Vin
 Vindexes have costs. For routing a query, the applicable Vindex with the lowest cost is chosen. The current general costs for the different Vindex Types are as follows:
 
 Vindex Type | Cost
------------ | ----
-Identity | 0
-Functional | 1
-Lookup Unique | 10
-Lookup NonUnique | 20
+| ----------- | ---- |
+| Identity | 0 |
+| Functional | 1 |
+| Lookup Unique | 10 |
+| Lookup NonUnique | 20 |
 
 #### Select
 
@@ -148,24 +149,24 @@ If the table owns lookup vindexes, then the rows to be deleted are first read an
 
 Vitess provides the following predefined Vindexes:
 
-Name | Type | Description | Primary | Reversible | Cost | Data types |
----- | ---- | ----------- | ------- | ---------- | ---- | ---------- |
-binary | Functional Unique | Identity | Yes | Yes | 0 | Any |
-binary\_md5 | Functional Unique | MD5 hash | Yes | No | 1 | Any |
-consistent\_lookup | Lookup NonUnique | Lookup table non-unique values | No | No | 20 | Any |
-consistent\_lookup\_unique | Lookup Unique | Lookup table unique values | If unowned | No | 10 | Any |
-hash | Functional Unique | DES null-key hash | Yes | Yes | 1 | 64 bit or smaller numeric or equivalent type |
-lookup | Lookup NonUnique | Lookup table non-unique values | No | No | 20 | Any |
-lookup\_unique | Lookup Unique | Lookup table unique values | If unowned | No | 10 | Any |
-null | Functional Unique | Always map to keyspace ID 0 | Yes | No | 100 | Any |
-numeric | Functional Unique | Identity | Yes | Yes | 0 | 64 bit or smaller numeric or equivalent type |
-numeric\_static\_map | Functional Unique | JSON file statically mapping input string values to keyspace IDs | Yes | No | 1 | Any |
-region\_experimental | Functional Unique | Multi-column prefix-based hash for use in geo-partitioning | Yes | No | 1 | String and numeric type |
-region\_json | Functional Unique | Multi-column prefix-based hash combined with a JSON map for key-to-region mapping, for use in geo-partitioning | Yes | No | 1 | String and numeric type |
-reverse\_bits | Functional Unique | Bit reversal | Yes | Yes | 1 | 64 bit or smaller numeric or equivalent type |
-unicode\_loose\_md5 | Functional Unique | Case-insensitive (UCA level 1) MD5 hash | Yes | No | 1 | String or binary types |
-unicode\_loose\_xxhash | Functional Unique | Case-insensitive (UCA level 1) xxHash64 hash | Yes | No | 1 | String or binary types |
-xxhash | Functional Unique | xxHash64 hash | Yes | No | 1 | Any |
+| Name | Type | Description | Primary | Reversible | Cost | Data types |
+| :--------------------- | ---- | ----------------------- | ------- | ---------- | ---- | ---------- |
+| binary | Functional Unique | Identity | Yes | Yes | 0 | Any |
+| binary\_md5 | Functional Unique | MD5 hash | Yes | No | 1 | Any |
+| consistent\_lookup | Lookup NonUnique | Lookup table non-unique values | No | No | 20 | Any |
+| consistent\_lookup\_unique | Lookup Unique | Lookup table unique values | If unowned | No | 10 | Any |
+| hash | Functional Unique | DES null-key hash | Yes | Yes | 1 | 64 bit or smaller numeric or equivalent type |
+| lookup | Lookup NonUnique | Lookup table non-unique values | No | No | 20 | Any |
+| lookup\_unique | Lookup Unique | Lookup table unique values | If unowned | No | 10 | Any |
+| null | Functional Unique | Always map to keyspace ID 0 | Yes | No | 100 | Any |
+| numeric | Functional Unique | Identity | Yes | Yes | 0 | 64 bit or smaller numeric or equivalent type |
+| numeric\_static\_map | Functional Unique | JSON file statically mapping input string values to keyspace IDs | Yes | No | 1 | Any |
+| region\_experimental | Functional Unique | Multi-column prefix-based hash for use in geo-partitioning | Yes | No | 1 | String and numeric type |
+| region\_json | Functional Unique | Multi-column prefix-based hash combined with a JSON map for key-to-region mapping, for use in geo-partitioning | Yes | No | 1 | String and numeric type |
+| reverse\_bits | Functional Unique | Bit reversal | Yes | Yes | 1 | 64 bit or smaller numeric or equivalent type |
+| unicode\_loose\_md5 | Functional Unique | Case-insensitive (UCA level 1) MD5 hash | Yes | No | 1 | String or binary types |
+| unicode\_loose\_xxhash | Functional Unique | Case-insensitive (UCA level 1) xxHash64 hash | Yes | No | 1 | String or binary types |
+| xxhash | Functional Unique | xxHash64 hash | Yes | No | 1 | Any |
 
 Consistent lookup vindexes, as described above, are a new category of Vindexes that are meant to replace the existing lookup Vindexes implementation. For the time being, they have a different name to allow for users to switch back and forth.
 
@@ -175,9 +176,9 @@ Custom Vindexes can also be created as needed. At the moment there is no formal 
 \
 There are also the following legacy (deprecated) Vindexes. **Do not use these**:
 
-Name | Type | Primary | Reversible | Cost
----- | ---- | ------- | ---------- | ----
-lookup\_hash | Lookup NonUnique | No | No | 20
-lookup\_hash\_unique | Lookup Unique | If unowned | No | 10
-lookup\_unicodeloosemd5\_hash | Lookup NonUnique | No | No | 20
-lookup\_unicodeloosemd5\_hash\_unique | Lookup Unique | If unowned | No | 10
+| Name | Type | Primary | Reversible | Cost |
+| ---- | ---- | ------- | ---------- | ---- |
+| lookup\_hash | Lookup NonUnique | No | No | 20 |
+| lookup\_hash\_unique | Lookup Unique | If unowned | No | 10 |
+| lookup\_unicodeloosemd5\_hash | Lookup NonUnique | No | No | 20 |
+| lookup\_unicodeloosemd5\_hash\_unique | Lookup Unique | If unowned | No | 10 |

--- a/content/en/docs/reference/features/vschema.md
+++ b/content/en/docs/reference/features/vschema.md
@@ -78,6 +78,7 @@ The configuration of your VSchema reflects the desired sharding configuration fo
 ### Commands
 
 You can use the following commands for maintaining the VSchema:
+
 * `GetVSchema <keyspace>`
 * `ApplyVSchema {-vschema=<vschema> || -vschema_file=<vschema file> || -sql=<sql> || -sql_file=<sql file>} [-cells=c1,c2,...] [-skip_rebuild] [-dry-run] <keyspace>`
 * `RebuildVSchemaGraph [-cells=c1,c2,...]`
@@ -264,6 +265,7 @@ Currently, these steps have to be currently performed manually. However, extende
 ### The columns field
 
 For a table, you can specify an additional columns field. This can be used for two purposes:
+
 * Specifying that a column contains text. If so, the VTGate planner can rewrite queries to leverage mysql’s collation where possible.
 * If the full list of columns is specified, then VTGate can resolve columns to their tables where needed, and also authoritative expand column lists, like in the case of a `select *` or `insert` statements with no column list.
 
@@ -366,5 +368,6 @@ If the `to_tables` have special characters that need escaping, you can use the m
 ### Commands
 
 You can use the following commands to maintain routing rules:
+
 * `GetRoutingRules`
 * `ApplyRoutingRules {-rules=<rules> || -rules_file=<rules_file>} [-cells=c1,c2,...] [-skip_rebuild] [-dry-run]`

--- a/content/en/docs/reference/programs/mysqlctl.md
+++ b/content/en/docs/reference/programs/mysqlctl.md
@@ -81,7 +81,7 @@ mysqlctl -tablet_uid 101 -alsologtostderr shutdown
 The following global parameters apply to `mysqlctl`:
 
 | Name | Type | Definition |
-| :-------- | :--------- | :--------- |
+| :-------------------------------- | :--------- | :--------- |
 | alsologtostderr | boolean | log to standard error as well as files |
 | app_idle_timeout | duration | Idle timeout for app connections (default 1m0s) |
 | app_pool_size | int | Size of the connection pool for app connections (default 40) |

--- a/content/en/docs/reference/vreplication/materialize.md
+++ b/content/en/docs/reference/vreplication/materialize.md
@@ -51,5 +51,6 @@ Once you decide on your materialization requirements, you need to initiate a VRe
 
 There are special commands to perform common materialization tasks and you should prefer them
 to using Materialize directly.
+
 * If you just want to copy tables to a different keyspace use [MoveTables](../movetables).
 * If you want to change sharding strategies use [Reshard](../reshard) instead

--- a/content/en/docs/reference/vreplication/movetables.md
+++ b/content/en/docs/reference/vreplication/movetables.md
@@ -89,6 +89,7 @@ _Either_
   Example: `MoveTables -workflow=commerce2customer commerce customer customer,corder`
 
 _Or_
+
 * the JSON table section of the vschema for associated tables
   * if target keyspace is sharded AND
   * tables being moved are not yet present in the target's vschema
@@ -148,4 +149,5 @@ See [user guide](../../../../../docs/user-guides/migration/move-tables/) which d
 in the Vitess repo.
 
 #### More Reading
+
 * [MoveTables in practice](../../../../../docs/concepts/move-tables/)

--- a/content/en/docs/reference/vreplication/v2/create.md
+++ b/content/en/docs/reference/vreplication/v2/create.md
@@ -47,6 +47,7 @@ _Either_
   Example: `MoveTables -source=commerce -tables=customer,corder Create customer.commerce2customer`
 
 _Or_
+
 * the JSON table section of the vschema for associated tables
   * if target keyspace is sharded AND
   * tables being moved are not yet present in the target's vschema

--- a/content/en/docs/reference/vreplication/v2/movetables.md
+++ b/content/en/docs/reference/vreplication/v2/movetables.md
@@ -77,4 +77,5 @@ as preparation for sharding your tables.
 See [user guide](../../../../../docs/user-guides/migration/move-tables/) which describes how MoveTables works in the local example provided in the Vitess repo.
 
 #### More Reading
+
 * [MoveTables in practice](../../../../../docs/concepts/move-tables/)

--- a/content/en/docs/reference/vreplication/vdiff.md
+++ b/content/en/docs/reference/vreplication/vdiff.md
@@ -73,6 +73,7 @@ Summary for customer: {ProcessedRows:11 MatchingRows:11 MismatchedRows:0 ExtraRo
 ```
 
 ### Notes
+
  * You can follow the progress of the command by tailing the vtctld logs
  * VDiff can take very long (hours/days) for huge tables, so this needs to be taken into account. If VDiff
  takes more than an hour and you use vtctlclient then it will hit the grpc/http default timeout of 1 hour. 

--- a/content/en/docs/user-guides/configuration-advanced/user-management.md
+++ b/content/en/docs/user-guides/configuration-advanced/user-management.md
@@ -167,5 +167,6 @@ be used for authorization/ACL enforcement.
 
 Other than the static authentication file method above, other authentication
 mechanisms are also provided:
+
  * [LDAP-based authentication](../ldap_auth)
  * TLS client certificate-based authentication

--- a/content/en/docs/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/user-guides/configuration-basic/planning.md
@@ -35,6 +35,7 @@ Resources for other servers like the toposerver, vtctld and vtorc are minimal. T
 ## Environment variables
 
 Setting up a few environment variables upfront will improve the manageability of the system:
+
 * `VTDATAROOT`: Setting up this value will make Vitess create the MySQL data files under this directory. Other Vitess binaries will also use this variable to locate such files as needed. If not specified, the default value is `/vt`. Typically, no other files get stored under this directory. However, many idiomatic deployments tend to reuse this as root directory for other purposes like log files, etc.
 * `VT_MYSQL_ROOT`: Informs Vitess about where to find the `mysqld` binary. If this is not specified, Vitess will try to find `mysqld` in the current `PATH`.
 

--- a/content/en/docs/user-guides/configuration-basic/troubleshooting.md
+++ b/content/en/docs/user-guides/configuration-basic/troubleshooting.md
@@ -22,6 +22,7 @@ The first step to troubleshooting is to have an established baseline. It is reco
 ## Query Serving
 
 Most of the focus of Vitess monitoring centers around the cost of a query. Although not always true, we use the following rules of thumb to get a rough estimate:
+
 * In MySQL, the time taken by a query roughly translates to its actual cost. More often than not, the limiting factor is the number of disk IOPS.
 * In Vitess components, the payload contributes to the cost. The limiting factor is most often the CPU, followed by memory.
 * The cost of parsing and analyzing the input query has started to become significant. This is typically driven by the size and complexity of the query.
@@ -123,6 +124,7 @@ If the data has diverged, you have to make a decision about which one is authori
 A number of reasons can cause a vtgate to not send queries to a replica vttablet. The first step is to visit the `/debug/status` page of vtgate and look at the `Health Check Cache` section.
 
 If the vttablet entry is present, but is color coded red and displays an error message, it means that vtgate is seeing the vttablet as unhealthy. Once you fix the error that causes the problem, traffic should resume to the vttablet. There can be many reasons for the unhealthiness:
+
 * vttablet may not be reachable: troubleshoot connectivity from the vtgate machine to the vttablet, make sure firewall rules allow access, ports are reachable, etc.
 * vttablet is reporting itself as unhealthy: Fix the root cause. For example, the MySQL may be lagging too much, or vttablet may have trouble connecting to the MySQL instance, etc.
 

--- a/content/en/docs/user-guides/configuration-basic/vtgate.md
+++ b/content/en/docs/user-guides/configuration-basic/vtgate.md
@@ -72,6 +72,7 @@ Here are the contents of an example file that shows the ability to specify MySQL
 For those who wish to use the Java or Go grpc clients to vtgate, you must also configure `grpc_port` and specify the service map as `service_map='grpc-vtgateservice'`. Note that the `VStream` feature is only available via grpc.
 
 You can also set the following flags to control load-balancing for replicas:
+
 * `discovery_high_replication_lag_minimum_serving`: If the replication lag of a vttablet exceeds this value, vtgate will treat it as unhealthy and will not send queries to it. This value is meant to match vttablet’s `unhealthy_threshold` value.
 * `discovery_low_replication_lag`: If a single vttablet lags beyond this value, vtgate will not send it any queries. However, if too many replicas exceed this threshold, then vtgate will send queries to the ones that have the least lag. A weighted average algorithm is used to exclude the outliers. This value is meant to match vttablet’s `degraded_threshold` value.
 

--- a/content/en/docs/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/user-guides/configuration-basic/vttablet-mysql.md
@@ -122,13 +122,14 @@ When starting vttablet, the following additional flag must be specified:
 ## Starting vttablet
 
 VTTablet should be brought up on the same machine as the MySQL instance. It needs the following flags:
+
 * <topo_flags> and <backup_flags>.
 * `cell`: the cell in which vttablet is being brought up. Example: `cell1`.
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
 * `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
-* `port`, `grpc_port`, and `-service_map ‘grpc-queryservice,grpc-tabletmanager’`
+* `port`, `grpc_port`, and `-service_map` ‘grpc-queryservice,grpc-tabletmanager’`
 
 There are some additional parameters that we recommend setting:
 

--- a/content/en/docs/user-guides/vschema-guide/advanced-vschema.md
+++ b/content/en/docs/user-guides/vschema-guide/advanced-vschema.md
@@ -9,7 +9,7 @@ With the exception of Multi-Column Vindexes, advanced VSchema Properties do not 
 
 Multi-Column Vindexes are useful in the following two use cases:
 
-* Grouping customers by their regions so they can be hosted in specific geographical locations. This may be required for compliance, and also to achieve better performance.
+* Grouping customers by their regions so they can be hosted in specific geographical locations. This may be required for compliance and also to achieve better performance.
 * For a multi-tenant system, grouping all rows of a tenant in a separate set of shards. This limits the fan out of queries if searching only for rows that are related to a single tenant.
 
 In both cases the leading column is the region or tenant, and is used to form the first few bits of the `keyspace_id`. The second column is used for the bits that follow. Since Vitess shards by keyrange, this approach will naturally group all rows of a region or tenant within the same shard, or within a group of consecutive shards. Since each shard is its own MySQL cluster, these can then be deployed to different regions as needed.
@@ -28,7 +28,7 @@ The downside of this approach is that it is harder to migrate an id to a differe
 
 ## Reference Tables
 
-Sharded databases often need the ability to join their tables with smaller “reference” tables. For example, the `product` table could be seen as a reference table. Other use cases are tables that map static information like zipcode to city, etc.
+Sharded databases often need the ability to join their tables with smaller “reference” tables. For example, the `product` table could be seen as a reference table. Other use cases are tables that map static information like zip code to city, etc.
 
 Joining against these tables across keyspaces results in cross-shard joins that may not be very efficient or fast.
 

--- a/content/en/docs/user-guides/vschema-guide/lookup-as-primary.md
+++ b/content/en/docs/user-guides/vschema-guide/lookup-as-primary.md
@@ -76,7 +76,7 @@ In Vitess, it is insufficient for a table to only have a Lookup Vindex. This is 
 
 To overcome this limitation, we must add a column with a non-lookup vindex, also known as Functional Vindex to the table. By rule, the Primary Vindex computes the keyspace id of the row. This means that the value of the column should also be such that it yields the same keyspace id.
 
-A Reversible Vindex is one that can back-compute the column value from a given keyspace id. If such a vindex is used for this new column, then Vitess will automatically perform this work and fill the correct value for it. The list of vindex properties, like Functional, Reversible, etc. are listed in the [Vindexes Reference](../../../reference/features/vindexes).
+A Reversible Vindex is one that can back-compute the column value from a given keyspace id. If such a vindex is used for this new column, then Vitess will automatically perform this work and fill in the correct value for it. The list of vindex properties, like Functional, Reversible, etc. are listed in the [Vindexes Reference](../../../reference/features/vindexes).
 
 In other words, adding a column with a vindex that is both Functional and Reversible allows Vitess to auto-fill the values, thereby avoiding any impact to the application logic.
 

--- a/content/en/docs/user-guides/vschema-guide/overview.md
+++ b/content/en/docs/user-guides/vschema-guide/overview.md
@@ -25,7 +25,7 @@ The demo models a set of tables that are similar to those presented in the [Gett
 
 Note that the demo brings up a test process called vtcombo (instead of a real Vitess cluster), which is functionally equivalent to all the components of Vitess, but within a single process.
 
-You can also use the demo app to follow along the steps of this user guide. If so, you can start by emptying out the files under `schema/product` and `schema/customer`, and incrementally making the changes presented in the steps that follow.
+You can also use the demo app to follow the steps of this user guide. If so, you can start by emptying out the files under `schema/product` and `schema/customer`, and incrementally making the changes presented in the steps that follow.
 
 ### VSchema DDL
 

--- a/content/en/docs/user-guides/vschema-guide/sequences.md
+++ b/content/en/docs/user-guides/vschema-guide/sequences.md
@@ -15,6 +15,7 @@ insert into customer_seq(id, next_id, cache) values(0, 1, 3);
 Note the special comment `vitess_sequence`. This instructs vttablet that this is a special table.
 
 The table needs to be pre-populated with a single row where:
+
 * `id` must always be 0
 * `next_id` should be set to the next (starting) value of the sequence
 * `cache` is the number of values to cache before updating the table for the next value. This value should be set to a fairly large number like 1000. We have set the value to `3` mainly to demonstrate how the feature works.

--- a/content/en/docs/user-guides/vschema-guide/sharded.md
+++ b/content/en/docs/user-guides/vschema-guide/sharded.md
@@ -10,6 +10,7 @@ A sharded keyspace allows you to split a large database into smaller parts by di
 * The sharding function is pluggable, allowing for user-defined sharding schemes.
 
 Vitess provides many predefined vindex types. The most popular ones are:
+
 * `hash`: for numbers
 * `unicode_loose_md5`: for text columns
 * `binary_md5`: for binary columns
@@ -42,6 +43,7 @@ In the VSchema, we need to designate which column should be the Primary Vindex, 
 ```
 
 In the above section, we are instantiating a vindex named `hash` from the vindex type `hash`. Such instantiations are listed in the `vindexes` section of the vschema. The tables are expected to refer to the instantiated name. There are a few reasons why this additional level of indirection is necessary:
+
 * As we will see later, vindexes can be instantiated with different input parameters. In such cases, they have to have their own distinct names.
 * Vindexes can be shared by tables, and this has special meaning. We will cover this in a later section.
 * Vindexes can also be referenced as if they were tables and can be used to compute the keyspace id for a given input.

--- a/content/en/docs/user-guides/vschema-guide/sharded.md
+++ b/content/en/docs/user-guides/vschema-guide/sharded.md
@@ -62,7 +62,7 @@ The DDL creates the `hash` vindex under the `vindexes` section, the `customer` t
 Every sharded table must have a Primary Vindex. A Primary Vindex must be instantiated from a vindex type that is Unique. `hash`, `unicode_loose_md5` and `binary_md5` are unique vindex types.
 {{< /info >}}
 
-The demo brings up the customer as two shards: `-80` and `80-`. For a `hash` vindex, input values of 1, 2 and 3 fall in the `-80` range, and 4 falls in the `80-` range. Restarting the demo with the updated configs should allow you to perform the following:
+The demo brings up the `customer` table as two shards: `-80` and `80-`. For a `hash` vindex, input values of 1, 2 and 3 fall in the `-80` range, and 4 falls in the `80-` range. Restarting the demo with the updated configs should allow you to perform the following:
 
 ```text
 mysql> insert into customer(customer_id,uname) values(1,'alice'),(4,'dan');
@@ -91,7 +91,7 @@ mysql> select * from customer;
 
 You will notice that we used a special shard targeting construct: `use customer:-80`. Vitess allows you to use this hidden database name to bypass its routing logic and directly send queries to a specific shard. Using this construct, we are able to verify that the rows went to different shards.
 
-At the time of insert, the Primary Vindex is used to compute and assign a keyspace id to each row. This keyspace id gets used to decide where the row will be stored. Although a keyspace id is not explicitly stored anywhere, it must be seen as an unchanging property of that row, as if there was an invisible column for it.
+At the time of insert, the Primary Vindex is used to compute and assign a keyspace id to each row. This keyspace id gets used to decide where the row will be stored. Although a keyspace id is not explicitly stored anywhere, it must be seen as an unchanging property of that row; as if there was an invisible column for it.
 
 Consequently, you cannot make changes to a row that can cause the keyspace id to change. Such a change will be supported in the future through a shard move operation. Trying to change the value of a Primary Vindex results in an error:
 

--- a/content/en/docs/user-guides/vschema-guide/sharding-guidelines.md
+++ b/content/en/docs/user-guides/vschema-guide/sharding-guidelines.md
@@ -10,7 +10,7 @@ The following guidelines are not set in stone. They mainly establish a framework
 There was a time when sharding used to be a line that one should avoid crossing for as long as possible. However, with Vitess considerably reducing the pain of sharding, we can look at leveraging some of its benefits much sooner than when a machine runs out of capacity:
 
 * Smaller blast radius: If a shard goes down, the outage affects a smaller percentage of the users.
-* Improved resource utilization: It is difficult to pack large instances of servers efficiently across machines. It is much easier to utilize the capacity of the existing hardware if the shard sizes were relatively small. Orchestration systems like Kubernetes further facilitate such utilization.
+* Improved resource utilization: It is difficult to pack large instances of servers efficiently across machines. It is much easier to utilize the capacity of the existing hardware if the shard sizes are relatively small. Orchestration systems like Kubernetes further facilitate such utilization.
 * Reduced contention: MySQL itself runs a lot better when instance sizes are small. There is less internal contention, replicas tend to keep up more easily with their master, etc.
 * Improved maintenance: Operations like schema deployment can happen in parallel across all shards and finish much sooner than usual.
 
@@ -74,6 +74,6 @@ In such cases, the [MoveTables](../../migration/move-tables) feature can be used
 
 Essentially, Vitess removes the fear of making the wrong sharding decision because you can always change your mind later.
 
-### Thumb Rule
+### Rule of Thumb
 
 Although a Vitess shard can grow to many terabytes, we have seen that 250GB is the sweet spot. If your data size approaches this limit, it is time to think about splitting your data.

--- a/content/en/docs/user-guides/vschema-guide/shared-vindexes.md
+++ b/content/en/docs/user-guides/vschema-guide/shared-vindexes.md
@@ -164,6 +164,7 @@ If a table has strong relationships with multiple other tables, and if performan
 ### Enforcing Uniqueness
 
 To enforce global uniqueness for a row in a sharded table, you have to have:
+
 * A Unique Vindex on the column
 * A Unique constraint at the MySQL level
 

--- a/content/en/docs/user-guides/vschema-guide/unique-lookup.md
+++ b/content/en/docs/user-guides/vschema-guide/unique-lookup.md
@@ -111,6 +111,7 @@ Creating a lookup vindex after the main table already contains rows does not aut
 ### Checklist
 
 Creating a unique lookup Vindex is an elaborate process. It is good to use the following checklist if this is done manually:
+
 * Create the lookup table as sharded or unsharded. Make the `from` column the primary key.
 * Create a VSchema entry for the lookup table. If sharded, assign a Primary Vindex for the `from` column.
 * Create the lookup vindex in the VSchema of the sharded keyspace:

--- a/content/en/docs/user-guides/vschema-guide/unsharded.md
+++ b/content/en/docs/user-guides/vschema-guide/unsharded.md
@@ -33,7 +33,7 @@ alter vschema add table product.product;
 ```
 
 {{< info >}}
-If `product` is the only keyspace in the cluster, a vschema is unnecessary. Vitess treats single keyspace clusters as a special case and optimistically forwards all queries to that keyspace even if there is no table metadata present in the vschema. But it is best practice to provide a full vschema to avoid future complications.
+If `product` is the only keyspace in the cluster, a vschema is unnecessary. Vitess treats single keyspace clusters as a special case and optimistically forwards all queries to that keyspace even if there is no table metadata present in the vschema. But it is a best practice to provide a full vschema to avoid future complications.
 {{< /info >}}
 
 Bringing up the cluster will allow you to access the `product` table. You can now insert rows into the table:


### PR DESCRIPTION
This PR does a few things:

* Reformats a bit of new content in the .md files so that I can easily convert them to PDFs (e.g. adding additional spaces so the PDF processor correctly identifies headers and bullet points)
*  Fixes a few issues with grammar
* Adds in the new v9.0 PDF link 