### PR TITLE
Update vreplication commands with recently added flags

### DIFF
--- a/content/en/docs/reference/vreplication/dropsources.md
+++ b/content/en/docs/reference/vreplication/dropsources.md
@@ -7,7 +7,7 @@ weight: 60
 ### Command
 
 ```
-DropSources  [-dry_run] [-rename_tables] <keyspace.workflow>
+DropSources  [-dry_run] [-rename_tables] [-keep_data] <keyspace.workflow>
 ```
 
 ### Description
@@ -40,6 +40,16 @@ using the template _&lt;tableName&gt;_old, the same scheme followed by pt-osc
 <div class="cmd">
 You can do a dry run where no actual action is taken but the command logs all the actions that would be taken
 by SwitchReads.
+</div>
+
+#### -keep_data
+**optional**\
+**default** false
+
+<div class="cmd">
+
+Usually, the source data (tables or shards) are deleted by Complete. If this flag is used, for MoveTables, source tables will not be deleted, for Reshard, source shards will not be dropped.
+
 </div>
 
 #### keyspace.workflow

--- a/content/en/docs/reference/vreplication/materialize.md
+++ b/content/en/docs/reference/vreplication/materialize.md
@@ -1,13 +1,13 @@
 ---
 title: Materialize
-description: 
+description:
 weight: 70
 ---
 
 ### Command
 
 ```
-Materialize <json_spec>
+Materialize [-cells=<cells>] [-tablet_types=<source_tablet_types>] <json_spec>
 ```
 
 ### Description
@@ -16,8 +16,40 @@ Materialize is a low level vreplication API that allows for generalized material
 can be copies, aggregations or views. The target tables are kept in sync in near-realtime.
 
 You can specify multiple tables to materialize using the json_spec parameter.
-  
+
 ### Parameters
+
+
+#### -cells
+**optional**\
+**default** local cell
+
+<div class="cmd">
+
+A comma-separated list of cell names or cell aliases. This list is used by VReplication to determine which
+cells should be used to pick a tablet for selecting data from the source keyspace.<br><br>
+
+###### Uses
+
+* Improve performance by using picking a tablet in cells in network proximity with the target
+* To reduce bandwidth costs by skipping cells that are in different availability zones
+* Select cells where replica lags are lower
+</div>
+
+#### -tablet_types
+**optional**\
+**default** replica
+
+<div class="cmd">
+
+A comma-separated list of tablet types that are used while picking a tablet for sourcing data.
+One or more from MASTER, REPLICA, RDONLY.<br><br>
+
+###### Uses
+
+* To reduce the load on master tablets by using REPLICAs or RDONLYs
+* Reducing lags by pointing to MASTER
+</div>
 
 #### JSON spec details
 <div class="cmd">
@@ -44,9 +76,9 @@ You can specify multiple tables to materialize using the json_spec parameter.
 
 #### Example
 ```
-Materialize '{"workflow": "product_sales", "source_keyspace": "commerce", "target_keyspace": "customer", 
-    "table_settings": [{"target_table": "sales_by_sku", 
-    "source_expression": "select sku, count(*), sum(price) from corder group by order_id"}], 
+Materialize '{"workflow": "product_sales", "source_keyspace": "commerce", "target_keyspace": "customer",
+    "table_settings": [{"target_table": "sales_by_sku",
+    "source_expression": "select sku, count(*), sum(price) from corder group by order_id"}],
     "cell": "zone1", "tablet_types": "REPLICA"}'
 ```
 

--- a/content/en/docs/reference/vreplication/movetables.md
+++ b/content/en/docs/reference/vreplication/movetables.md
@@ -8,7 +8,8 @@ weight: 10
 
 ```
 MoveTables  [-cells=<cells>] [-tablet_types=<source_tablet_types>] -workflow=<workflow>
-            [-all] [-exclude=<tables>] <source_keyspace> <target_keyspace> <table_specs>
+            [-all] [-exclude=<tables>]  [-auto_start] [-stop_after_copy]
+            <source_keyspace> <target_keyspace> <table_specs>
 ```
 
 ### Description
@@ -116,6 +117,44 @@ If moving all tables, specifies tables to be skipped.
 
 </div>
 
+#### -auto_start
+
+**optional**
+**default** true
+
+<div class="cmd">
+
+Normally the workflow starts immediately after it is created. If this flag is set
+to false then the workflow is in a Stopped state until you explicitly start it.
+
+</div>
+
+###### Uses
+* allows updating the rows in `_vt.vreplication` after MoveTables has setup the
+streams. For example, you can add some filters to specific tables or change the
+projection clause to modify the values on the target. This
+provides an easier way to create simpler Materialize workflows by first using
+MoveTables with auto_start false, updating the BinlogSource as required by your
+Materialize and then start the workflow.
+* changing the `copy_state` and/or `pos` values to restart a broken MoveTables workflow
+from a specific point of time.
+
+#### -stop_after_copy
+
+**optional**
+**default** false
+
+<div class="cmd">
+
+If set, the workflow will stop once the Copy phase has been completed i.e. once
+all tables have been copied and VReplication decides that the lag
+is small enough to start replicating, the workflow state will be set to Stopped.
+
+###### Uses
+* If you just want a consistent snapshot of all the tables you can set this flag. The workflow
+will stop once the copy is done and you can then mark the workflow as `Complete`d
+
+</div>
 
 ### A MoveTables Workflow
 

--- a/content/en/docs/reference/vreplication/v2/create.md
+++ b/content/en/docs/reference/vreplication/v2/create.md
@@ -11,6 +11,7 @@ This documentation is for a new (v2) set of vtctld commands. See [RFC](https://g
 ```
 MoveTables -v2 [-source=<sourceKs>] [-tables=<tableSpecs>] [-cells=<cells>]
   [-tablet_types=<source_tablet_types>] [-all] [-exclude=<tables>]
+   [-auto_start] [-stop_after_copy]
   Create <targetKs.workflow>
 
 Reshard -v2 [-source_shards=<source_shards>] [-target_shards=<target_shards>]
@@ -85,6 +86,45 @@ One or more from MASTER, REPLICA, RDONLY.<br><br>
 * Reducing lags by pointing to MASTER
 </div>
 
+
+#### -auto_start
+
+**optional**
+**default** true
+
+<div class="cmd">
+
+Normally the workflow starts immediately after it is created. If this flag is set
+to false then the workflow is in a Stopped state until you explicitly start it.
+
+</div>
+
+###### Uses
+* allows updating the rows in `_vt.vreplication` after MoveTables has setup the
+streams. For example, you can add some filters to specific tables or change the
+projection clause to modify the values on the target. This
+provides an easier way to create simpler Materialize workflows by first using
+MoveTables with auto_start false, updating the BinlogSource as required by your
+Materialize and then start the workflow.
+* changing the `copy_state` and/or `pos` values to restart a broken MoveTables workflow
+from a specific point of time.
+
+#### -stop_after_copy
+
+**optional**
+**default** false
+
+<div class="cmd">
+
+If set, the workflow will stop once the Copy phase has been completed i.e. once
+all tables have been copied and VReplication decides that the lag
+is small enough to start replicating, the workflow state will be set to Stopped.
+
+###### Uses
+* If you just want a consistent snapshot of all the tables you can set this flag. The workflow
+will stop once the copy is done and you can then mark the workflow as `Complete`d
+
+</div>
 
 #### -all
 **optional** cannot specify `table_specs` if `-all` is specified


### PR DESCRIPTION
Documentation for vreplication commands have not yet been updated for some recently added flags.

*  auto_start and stop_after_complete for MoveTables
*  keep_data for DropSources
* added cells and tablet_types to Materialize

Signed-off-by: Rohit Nayak <rohit@planetscale.com>