### PR TITLE
documentation for schema tracking

### DIFF
--- a/content/en/docs/reference/features/schema-tracking.md
+++ b/content/en/docs/reference/features/schema-tracking.md
@@ -1,0 +1,24 @@
+---
+title: Schema Tracking
+weight: 16
+aliases: ['/docs/reference/schema-tracking/']
+---
+
+{{< warning >}}
+This feature is experimental.
+{{< /warning >}}
+
+VTGate does not natively track table schema. Users are allowed to provide an authoritative list of columns through a VSchema which is then used to enhance query planning. If no such list is provided, a set of queries will not be supported by VTGate due to a lack of information on the underlying tables/columns.
+
+The schema tracking functionality alleviates this issue and enable VTGate to plan more queries. When using schema tracking, VTGate keeps an authoritative list of columns on all tables. The following query set can be planned:
+
+* `SELECT *` cross-shard queries that need evaluation at the VTGate level.
+* Queries that are not able to resolve columns dependencies. For instance: queries with no table qualifier in the projection/filter list.
+
+## VTGate
+
+Schema tracking is enabled in VTGate with the flag `-schema_change_signal`. When enabled, VTGate listens for schema changes from VTTablet.
+
+## VTTablet
+
+Schema tracking is enabled in VTTablet with the flag `-queryserver-config-schema-change-signal`. When enabled, VTTablet sends schema changes to VTGate based on an interval that can be modified with the flag `-queryserver-config-schema-change-signal-interval` (defaults to 5 seconds).

--- a/content/en/docs/reference/programs/vtgate.md
+++ b/content/en/docs/reference/programs/vtgate.md
@@ -138,6 +138,7 @@ The following global options apply to `vtgate`:
 | -redact-debug-ui-queries | boolean | redact full queries and bind variables from debug UI |
 | -remote_operation_timeout | duration | time to wait for a remote operation (default 30s) |
 | -retry-count | int | retry count (default 2) |
+| -schema_change_signal | boolean | enable schema tracking |
 | -security_policy | string | the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only) |
 | -service_map | value | comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-vtworker |
 | -sql-max-length-errors | int | truncate queries in error logs to the given length (default unlimited) |

--- a/content/en/docs/reference/programs/vttablet.md
+++ b/content/en/docs/reference/programs/vttablet.md
@@ -247,6 +247,8 @@ The following global options apply to `vttablet`:
 | -queryserver-config-query-pool-waiter-cap | int | query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000) |
 | -queryserver-config-query-timeout | int | query server query timeout (in seconds), this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30) |
 | -queryserver-config-schema-reload-time | int | query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance in seconds. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 1800) |
+| -queryserver-config-schema-change-signal-interval | int | interval used to periodically send schema change updates to vtgate (default 5 seconds) |
+| -queryserver-config-schema-change-signal | boolean | enable schema tracking |
 | -queryserver-config-stream-buffer-size | int | query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768) |
 | -queryserver-config-stream-pool-prefill-parallelism | int | query server stream pool prefill parallelism, a non-zero value will prefill the pool using the specified parallelism |
 | -queryserver-config-stream-pool-size | int | query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200) |


### PR DESCRIPTION
## Description

This pull request documents version one of schema tracking (https://github.com/vitessio/vitess/pull/8074). The new command-line flags and functionality were added to their respective page.

## Related issue(s)

Resolves https://github.com/vitessio/vitess/issues/8329.