### PR TITLE
GitHub Workflow: 'master' branch renamed as 'main'

### DIFF
--- a/content/en/docs/contributing/code-reviews.md
+++ b/content/en/docs/contributing/code-reviews.md
@@ -5,23 +5,23 @@ title: Coding Standards
 ## Backwards Compatibility
 
 Vitess is being used to power many mission-critical production workloads at very large scale. 
-Moreover, many users deploy directly from the master branch. 
+Moreover, many users deploy directly from the main branch. 
 It is very important the changes made by contributors do not break any existing workloads.
 
 In order to avoid disruption, the following concerns need to be kept in mind:
 
-* Does the change affect any external APIs? If so, make sure the change satisfies the [compatibility rules](https://github.com/vitessio/enhancements/blob/master/veps/vep-3.md).
+* Does the change affect any external APIs? If so, make sure the change satisfies the [compatibility rules](https://github.com/vitessio/enhancements/blob/main/veps/vep-3.md).
 * Can the change introduce a performance regression? If so, it will be good to measure the impact using benchmarks.
 * If the change is substantial or is a breaking change, you must publish the proposal as an issue with a title like `RFC: Changing behavior of feature xxx`. Following this, sufficient time has to be given for others to give feedback. A breaking change must still satisfy the compatibility rules.
 * New features that affect existing behavior must be introduced "behind a flag". Users will then be encouraged to enable them, but will have the option to fallback to the old behavior if issues are found.
 
 ## What does a good PR look like?
 
-Every GitHub pull request must go through a code review and get approved before it will be merged into the master branch.
+Every GitHub pull request must go through a code review and get approved before it will be merged into the main branch.
 
 Every pull request should meet the following requirements:
 
-* Use the [Pull Request Template](https://github.com/vitessio/vitess/blob/master/.github/pull_request_template.md)
+* Use the [Pull Request Template](https://github.com/vitessio/vitess/blob/main/.github/pull_request_template.md)
 * Adhere to the [Go coding guidelines](https://golang.org/doc/effective_go.html) and watch out for these [common errors](https://github.com/golang/go/wiki/CodeReviewComments).
 * Contain a description message that is as detailed as possible. Here is a great example https://github.com/vitessio/vitess/pull/6543.
 * Pass all CI tests that run on PRs.

--- a/content/en/docs/contributing/github-workflow.md
+++ b/content/en/docs/contributing/github-workflow.md
@@ -38,28 +38,28 @@ upstream        git@github.com:vitessio/vitess.git (fetch)
 upstream        git@github.com:vitessio/vitess.git (push)
 ```
 
-Now to sync your local `master` branch, do this:
+Now to sync your local `main` branch, do this:
 
 ```
-$ git checkout master
-(master) $ git pull upstream master
+$ git checkout main
+(main) $ git pull upstream main
 ```
 
-Note: In the example output above we prefixed the prompt with `(master)` to
-stress the fact that the command must be run from the branch `master`.
+Note: In the example output above we prefixed the prompt with `(main)` to
+stress the fact that the command must be run from the branch `main`.
 
-You can omit the `upstream master` from the `git pull` command when you let your
-`master` branch always track the main `vitessio/vitess` repository. To achieve
+You can omit the `upstream main` from the `git pull` command when you let your
+`main` branch always track the main `vitessio/vitess` repository. To achieve
 this, run this command once:
 
 ```
-(master) $ git branch --set-upstream-to=upstream/master
+(main) $ git branch --set-upstream-to=upstream/main
 ```
 
-Now the following command syncs your local `master` branch as well:
+Now the following command syncs your local `main` branch as well:
 
 ```
-(master) $ git pull
+(main) $ git pull
 ```
 
 ## Topic Branches
@@ -67,9 +67,9 @@ Now the following command syncs your local `master` branch as well:
 Before you start working on changes, create a topic branch:
 
 ```
-$ git checkout master
-(master) $ git pull
-(master) $ git checkout -b new-feature
+$ git checkout main
+(main) $ git pull
+(main) $ git checkout -b new-feature
 (new-feature) $ # You are now in the new-feature branch.
 ```
 
@@ -131,7 +131,7 @@ $ git checkout new-feature
 (new-feature) $ git push
 ```
 
-That is because a pull request always mirrors all commits from your topic branch which are not in the master branch.
+That is because a pull request always mirrors all commits from your topic branch which are not in the `main` branch.
 
 Once your pull request is merged:
 


### PR DESCRIPTION
We have moved from `master` branch to `main` branch. This updates the docs to reflect that change.