### PR TITLE
Update CreateLookupIndex docs

### DIFF
--- a/content/en/docs/reference/programs/vtctl/keyspaces.md
+++ b/content/en/docs/reference/programs/vtctl/keyspaces.md
@@ -247,7 +247,7 @@ After a MoveTables or Resharding workflow cleanup unused artifacts like source t
 
 ### CreateLookupVindex
 ```shell
-CreateLookupVindex  [-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>
+CreateLookupVindex  [-cells=<source_cells>] [-continue_after_copy_with_owner=false] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>
 Create and backfill a lookup vindex. the json_spec must contain the vindex and colvindex specs for the new lookup.
 ```
 

--- a/content/en/docs/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/user-guides/configuration-advanced/createlookupvindex.md
@@ -1,7 +1,7 @@
 ---
 title: CreateLookupVindex
 weight: 11
-aliases: ['/docs/user-guides/createlookupvindex/'] 
+aliases: ['/docs/user-guides/createlookupvindex/']
 ---
 
 {{< info >}}
@@ -16,22 +16,28 @@ In this guide, we will walk through the process of using the `CreateLookupVindex
 
 `vtctlclient CreateLookupVindex` has the following syntax:
 
-`CreateLookupVindex  [-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>`
+`CreateLookupVindex  [-cells=<source_cells>] [-continue_after_copy_with_owner=false] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>`
 
  * `<json_spec>`:  Use the lookup Vindex specified in `<json_spec>` along with
 VReplication to populate/backfill the lookup Vindex from the source table.
  * `<keyspace>`:  The Vitess keyspace we are creating the lookup Vindex in.
 The source table is expected to also be in this keyspace.
- * `-tablet-types`:  Provided to specify the shard tablet types 
+ * `-tablet-types`:  Provided to specify the shard tablet types
 (e.g. `MASTER`, `REPLICA`, `RDONLY`) that are acceptable
 as source tablets for the VReplication stream(s) that this command will
 create. If not specified, the tablet type used will default to the value
 of the vttablet `-vreplication_tablet_type` option, which defaults to
 `REPLICA`.
- * `-cell`: By default VReplication streams, such as used by 
-`CreateLookupVindex` will not cross cell boundaries.  If you want the 
-VReplication streams to source their data from tablets in a cell other 
-than the local cell, you can use the `-cell` option to specify this.
+ * `-cells`: By default VReplication streams, such as used by
+`CreateLookupVindex` will not cross cell boundaries.  If you want the
+VReplication streams to source their data from tablets in cells other
+than the local cell, you can use the `-cells` option to specify a
+comma-separated list of cells.
+* `-continue_after_copy_with_owner`: By default, when an owner is provided,
+the VReplication streams will stop after the backfill completes. Set this flag if
+you don't want this to happen. This is useful if, for example,
+the owner table is being migrated from an unsharded keyspace to a sharded keyspace
+using MoveTables.
 
 The `<json_spec>` describes the lookup Vindex to be created, and details about
 the table it is to be created against (on which column, etc.).  However,
@@ -101,7 +107,7 @@ mysql> select * from corder;
 ```
 
 If we look at the VSchema for the `customer.corder` table, we
-will see there is a `hash` index on the `customer_id` table, 
+will see there is a `hash` index on the `customer_id` table,
 and 4 of our 5 rows have ended up on the `-80` shard, and the
 5th row on the `80-` shard:
 
@@ -208,7 +214,7 @@ i.e. now we can see what will happen:
   * VReplication streams will be setup from the master tablets
 `zone1-0000000300` and `zone1-0000000400`; pulling data from the `RDONLY`
 source tablets `zone1-0000000302` and `zone1-0000000402`.
-  * Note that each master tablet will start streams from each source 
+  * Note that each master tablet will start streams from each source
 tablet, for a total of 4 streams in this case.
 
 Lets observe the VReplication streams that got created using the
@@ -216,7 +222,7 @@ Lets observe the VReplication streams that got created using the
 to the first master tablet `zone1-0000000300`:
 
 ```sql
-$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select * from _vt.vreplication" 
+$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select * from _vt.vreplication"
 +----+-------------------+--------------------------------------+---------------------------------------------------+----------+---------------------+---------------------+------+--------------+--------------+-----------------------+---------+---------------------+-------------+
 | id |     workflow      |                source                |                        pos                        | stop_pos |       max_tps       | max_replication_lag | cell | tablet_types | time_updated | transaction_timestamp |  state  |       message       |   db_name   |
 +----+-------------------+--------------------------------------+---------------------------------------------------+----------+---------------------+---------------------+------+--------------+--------------+-----------------------+---------+---------------------+-------------+
@@ -242,7 +248,7 @@ $ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select 
 And now the streams to the second master tablet `zone1-0000000400`:
 
 ```sql
-$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000400 "select * from _vt.vreplication" 
+$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000400 "select * from _vt.vreplication"
 +----+-------------------+--------------------------------------+---------------------------------------------------+----------+---------------------+---------------------+------+--------------+--------------+-----------------------+---------+---------------------+-------------+
 | id |     workflow      |                source                |                        pos                        | stop_pos |       max_tps       | max_replication_lag | cell | tablet_types | time_updated | transaction_timestamp |  state  |       message       |   db_name   |
 +----+-------------------+--------------------------------------+---------------------------------------------------+----------+---------------------+---------------------+------+--------------+--------------+-----------------------+---------+---------------------+-------------+
@@ -265,7 +271,7 @@ $ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000400 "select 
 +----+-------------------+--------------------------------------+---------------------------------------------------+----------+---------------------+---------------------+------+--------------+--------------+-----------------------+---------+---------------------+-------------+
 ```
 
-There is a lot going on in this output, but the most important parts are the 
+There is a lot going on in this output, but the most important parts are the
 `state` and `message` fields which say `Stopped` and `Stopped after copy.`
 for all four the streams.  This means that the VReplication streams finished
 their copying/backfill of the lookup table.
@@ -275,7 +281,7 @@ Note that if the tables were large and the copy was still in progress, the
 the copy by looking at the `_vt.copy_state` table, e.g.:
 
 ```sql
-$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select * from _vt.copy_state" 
+$ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select * from _vt.copy_state"
 +----------+------------+--------+
 | vrepl_id | table_name | lastpk |
 +----------+------------+--------+
@@ -284,7 +290,7 @@ $ vtctlclient -server localhost:15999 VReplicationExec zone1-0000000300 "select 
 
 (In this case this table is empty, because the copy has finished already).
 
-We can verify the result of the backfill by looking at the `customer` 
+We can verify the result of the backfill by looking at the `customer`
 keyspace again in the MySQL client:
 
 ```sql
@@ -325,7 +331,7 @@ mysql> select sku, hex(keyspace_id) from corder_lookup;
 ```
 
 Basically, this shows exactly what we expected.  Now, we have to clean-up
-the artifacts of the backfill. The `ExternalizeVindex` command will delete 
+the artifacts of the backfill. The `ExternalizeVindex` command will delete
 the vreplication streams and also clear the `write_only` flag from the
 vindex indicating that it is not backfilling any more.
 
@@ -347,7 +353,7 @@ mysql> explain format=vitess select * from corder where customer_id = 1;
 ```
 
 Since the above `select` statement is doing a lookup using the primary Vindex
-on the `corder` table, this query does not Scatter (variant is 
+on the `corder` table, this query does not Scatter (variant is
 `SelectEqualUnique`), as expected.  Let's try a scatter query to see what that
 looks like:
 
@@ -435,7 +441,7 @@ mysql> select sku, hex(keyspace_id) from corder_lookup;
 4 rows in set (0.01 sec)
 ```
 
-We deleted a row from the `corder` table, and the matching lookup Vindex row 
+We deleted a row from the `corder` table, and the matching lookup Vindex row
 is gone.
 
 ```sql
@@ -472,4 +478,4 @@ lookup table.
 
 ### ExternalizeVindex
 
-Once the backfill is done, 
+Once the backfill is done,


### PR DESCRIPTION
* Update deprecated `-cell` to `-cells` 
* Added  new flag `-continue_after_copy_with_owner`  (see https://github.com/vitessio/vitess/issues/8571)

Signed-off-by: Rohit Nayak <rohit@planetscale.com>