### PR TITLE
Documenting Recoverable, failover agnostic migrations

### DIFF
--- a/content/en/docs/design-docs/online-ddl/scheduler.md
+++ b/content/en/docs/design-docs/online-ddl/scheduler.md
@@ -48,7 +48,7 @@ A migration can be in any one of these states:
 
 - `queued`: a migration is submitted
 - `ready`: a migration is picked from the queue to run
-- `running`: a migration was started. It is periodically tested to be alive.
+- `running`: a migration was started. It is periodically tested to be making progress.
 - `complete`: a migration completed successfully
 - `failed`: a migration started running and failed due to whatever reason
 - `cancelled`: a _pending_ migration was cancelled

--- a/content/en/docs/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/user-guides/schema-changes/ddl-strategies.md
@@ -168,6 +168,6 @@ There are pros and cons to using any of the strategies. Some notable differences
 - **Trackable**: able to determine migration state (`ready`, `running`, `complete` etc)
   - `gh-ost` also makes available _progress %_ and _ETA seconds_
 - **Declarative**: support `-declarative` flag
-- **Revertible**: `online` strategy supports revertible `ALTER` statements (or `ALTER`s implied by `-declarative` migrations). All managed strategies supports revertible `CREATE` and `ALTER`.
-- **Recoverable**: an `online` migration interrupted by planned/unplanned failover, automatically resumes work from point of interruption. `gh-ost` and `pt-osc` will not resume after failover, but Vitess will automatically retry the migration (by marking the migration as failed and by initiating a `RETRY`), no more than once for any migration.
+- **Revertible**: `online` strategy supports [revertible](../revertible-migrations/) `ALTER` statements (or `ALTER`s implied by `-declarative` migrations). All managed strategies supports revertible `CREATE` and `ALTER`.
+- **Recoverable**: an `online` migration interrupted by planned/unplanned failover, [automatically resumes](../recoverable-migrations/) work from point of interruption. `gh-ost` and `pt-osc` will not resume after failover, but Vitess will automatically retry the migration (by marking the migration as failed and by initiating a `RETRY`), no more than once for any migration.
 - **Traffic**: `online` migration cut-over uses Vitess specific blocking of traffic, and is therefore only safe when write traffic to the tables runs entirely through Vitess/VTGate. `gh-ost` and `pt-osc` use generic MySQL blocking/locking mechanisms, and it is safe to run some write traffic on the migrated table outside Vitess.

--- a/content/en/docs/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/user-guides/schema-changes/ddl-strategies.md
@@ -59,7 +59,7 @@ VReplication migrations enjoy the general features of VReplication:
 - Seamless integration with Vitess.
 - Seamless use of the throttler mechanism.
 - Visibility into internal working and status of VReplication.
-- Agnostic to planned reparenting and to unplanned failovers. A migration will resume from point of interruption shortly after a new primary is instated.
+- Agnostic to planned reparenting and to unplanned failovers. A migration will resume from point of interruption shortly after a new primary is available.
 
 VReplication migrations further:
 
@@ -168,6 +168,6 @@ There are pros and cons to using any of the strategies. Some notable differences
 - **Trackable**: able to determine migration state (`ready`, `running`, `complete` etc)
   - `gh-ost` also makes available _progress %_ and _ETA seconds_
 - **Declarative**: support `-declarative` flag
-- **Revertible**: `online` strategy supports [revertible](../revertible-migrations/) `ALTER` statements (or `ALTER`s implied by `-declarative` migrations). All managed strategies supports revertible `CREATE` and `ALTER`.
-- **Recoverable**: an `online` migration interrupted by planned/unplanned failover, [automatically resumes](../recoverable-migrations/) work from point of interruption. `gh-ost` and `pt-osc` will not resume after failover, but Vitess will automatically retry the migration (by marking the migration as failed and by initiating a `RETRY`), no more than once for any migration.
+- **Revertible**: `online` strategy supports [revertible](../revertible-migrations/) `ALTER` statements (or `ALTER`s implied by `-declarative` migrations). All managed strategies supports revertible `CREATE` and `DROP`.
+- **Recoverable**: an `online` migration interrupted by planned/unplanned failover, [automatically resumes](../recoverable-migrations/) work from point of interruption. `gh-ost` and `pt-osc` will not resume after failover, but Vitess will automatically retry the migration (by marking the migration as failed and by initiating a `RETRY`), exactly once for any migration.
 - **Traffic**: `online` migration cut-over uses Vitess specific blocking of traffic, and is therefore only safe when write traffic to the tables runs entirely through Vitess/VTGate. `gh-ost` and `pt-osc` use generic MySQL blocking/locking mechanisms, and it is safe to run some write traffic on the migrated table outside Vitess.

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -142,7 +142,7 @@ A migration can be in any one of these states:
 
 - `queued`: a migration is submitted
 - `ready`: a migration is picked from the queue to run
-- `running`: a migration was started. It is periodically tested to be alive.
+- `running`: a migration was started. It is periodically tested to be making progress.
 - `complete`: a migration completed successfully
 - `failed`: a migration started running and failed due to whatever reason
 - `cancelled`: a _pending_ migration was cancelled
@@ -171,7 +171,7 @@ VReplication based migrations (`ddl_strategy="online"`) are [failover agnostic](
 
 Once the new primary is in place and turns active, it auto-resumes the VReplication stream. The online DDL scheduler assumes ownership of the stream and follows it to completion.
 
-The new primary must be instated within `10 minutes`, or else the migration is considered to be stale and is aborted.
+The new primary must be available within `10 minutes`, or else the migration is considered to be stale and is aborted.
 
 ## Auto retry after failure
 

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -4,7 +4,7 @@ weight: 2
 aliases: ['/docs/user-guides/managed-online-schema-changes/']
 ---
 
-**Note:** this feature is **EXPERIMENTAL**.
+**Note:** `gh-ost` migrations are considered stable. `pt-osc` and `online` migrations are considered **EXPERIMENTAL**.
 
 Vitess offers managed, online schema migrations (aka Online DDL), transparently to the user. Vitess Onine DDL offers:
 
@@ -15,6 +15,7 @@ Vitess offers managed, online schema migrations (aka Online DDL), transparently 
 - Migrations are retry-able
 - Lossless, [revertible migrations](../revertible-migrations/)
 - Support for [declarative migrations](../declarative-migrations/)
+- Support for [failover agnostic migrations](../recoverable-migrations/)
 
 
 As general overview:
@@ -166,7 +167,7 @@ For more about internals of the scheduler and how migration states are controlle
  
 ## Auto resume after failure
 
-VReplication based migrations (`ddl_strategy="online"`) are failover agnostic. They automatically resume after either planned promotion ([PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting)), emergency promotion ([EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting)) or completely external reparenting.
+VReplication based migrations (`ddl_strategy="online"`) are [failover agnostic](../recoverable-migrations/). They automatically resume after either planned promotion ([PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting)), emergency promotion ([EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting)) or completely external reparenting.
 
 Once the new primary is in place and turns active, it auto-resumes the VReplication stream. The online DDL scheduler assumes ownership of the stream and follows it to completion.
 

--- a/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
@@ -21,12 +21,12 @@ Normally, schema migrations are coupled with the original MySQL server they oper
 
 Whether by planned operation or an unplanned failure, an `online` migration's VReplication stream is interrupted while copying/applying data. VReplication's mechanism persists the state of data transfer transactionally with the transfer itself. Any replica will have a _consistent_ state of the migration, even if that replica lags behind the primary.
 
-When a replica tablet is promoted as `primary`, it notices the VReplication stream, which is meant to be active an running. It sets up the connections and processes to resume its work. It is possible that some retries will take place as the stream re-evaluates its source of data.
+When a replica tablet is promoted as `primary`, it notices the VReplication stream, which is meant to be active and running. It sets up the connections and processes to resume its work. It is possible that some retries will take place as the stream re-evaluates its source of data.
 
 The [Online DDL Scheduler](../../../design-docs/online-ddl/scheduler) detects the running stream, and identifies it as having been created by a different tablet. It assumes ownership of the stream and proceeds to follow its progress till completion.
 
 The stream must be no more than `10` minutes stale, otherwise the scheduler marks the migration as failed.
 
-There is no limitation on the number of failovers a `online` migration can survive.
+There is no limitation on the number of failovers an `online` migration can survive.
 
 No user action is required. Immediately after promotion/failover the migration will present as making no progress. It is likely to present progress within 1 or 2 minutes after promotion.

--- a/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
@@ -1,0 +1,32 @@
+---
+title: Recoverable, failover agnostic migrations
+weight: 6
+aliases: ['/docs/user-guides/schema-changes/recoverable-migrations/']
+---
+
+Vitess's [managed schema changes](../managed-online-schema-changes/) offer _failover agnostic_ migrations in `online` strategy (VReplication based).
+
+Normally, schema migrations are coupled with the original MySQL server they operate on. A `gh-ost` or a `pt-online-schema-change`, as well as plain direct migrations, may only complete on the same server where they started. Any form of failover, whether planned or unplanned, either breaks the migration or makes it obsolete.
+
+`online` strategy migrations are agnostic to server promotion. A migration can begin on one `primary` tablet, and complete on another tablet which was promoted as `primary` throughout the migration. In large part this is a direct result of the nature of VReplication. 
+
+`online` migrations will auto-survive:
+
+- A planned failover (via [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting))
+- An emergency reparent ([EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting))
+- An unexpected external reparent
+- As long as no more than `10` minutes pass between failure/demotion of previous `primary` tablet and the promotion of the new `primary` tablet. 
+
+## Behavior and limitations
+
+Whether by planned operation or an unplanned failure, an `online` migration's VReplication stream is interrupted while copying/applying data. VReplication's mechanism persists the state of data transfer transactionally with the transfer itself. Any replica will have a _consistent_ state of the migration, even if that replica lags behind the primary.
+
+When a replica tablet is promoted as `primary`, it notices the VReplication stream, which is meant to be active an running. It sets up the connections and processes to resume its work. It is possible that some retries will take place as the stream re-evaluates its source of data.
+
+The [Online DDL Scheduler](../../../design-docs/online-ddl/scheduler) detects the running stream, and identifies it as having been created by a different tablet. It assumes ownership of the stream and proceeds to follow its progress till completion.
+
+The stream must be no more than `10` minutes stale, otherwise the scheduler marks the migration as failed.
+
+There is no limitation on the number of failovers a `online` migration can survive.
+
+No user action is required. Immediately after promotion/failover the migration will present as making no progress. It is likely to present progress within 1 or 2 minutes after promotion.


### PR DESCRIPTION
The outcome of https://github.com/vitessio/vitess/pull/8603 is that `online` migrations are now failover agnostic and can survive planned or unplanned `primary` promotions.

This updates the docs to point to this new behavior. There's also some cleanup, removing the now deprecated `vtctld`-`topo` flow of schema migrations. 