### PR TITLE
Adjust VReplication V1 and V2 Workflow Related Command Docs

### DIFF
--- a/content/en/docs/reference/programs/vtctl/_index.md
+++ b/content/en/docs/reference/programs/vtctl/_index.md
@@ -75,9 +75,11 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [SetKeyspaceServedFrom](../vtctl/keyspaces#setkeyspaceservedfrom) | `SetKeyspaceServedFrom  [-source=<source keyspace name>] [-remove] [-cells=c1,c2,...] <keyspace name> <tablet type>` |
 | [RebuildKeyspaceGraph](../vtctl/keyspaces#rebuildkeyspacegraph) | `RebuildKeyspaceGraph  [-cells=c1,c2,...] <keyspace> ...` |
 | [ValidateKeyspace](../vtctl/keyspaces#validatekeyspace) | `ValidateKeyspace  [-ping-tablets] <keyspace name>` |
-| [Reshard](../vtctl/keyspaces#reshard) | `Reshard  [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>` |
-| [MoveTables](../vtctl/keyspaces#movetables) | `MoveTables  [-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>` |
-| [DropSources](../vtctl/keyspaces#dropsources) | `DropSources  [-dry_run] <keyspace.workflow>` |
+| [Reshard (v1)](../../vreplication/v1/reshard) | `Reshard  -v1 [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>` |
+| [Reshard (v2)](../../vreplication/v2/reshard) | `Reshard <options> <action> <workflow identifier>` |
+| [MoveTables (v1)](../../vreplication/v1/movetables) | `MoveTables  -v1 [-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>` |
+| [MoveTables (v2)](../../vreplication/v2/movetables) | `MoveTables  <options> <action> <workflow identifier>` |
+| [DropSources](../../vreplication/v1/dropsources) | `DropSources  [-dry_run] <keyspace.workflow>` |
 | [CreateLookupVindex](../vtctl/keyspaces#createLookupvindex) | `CreateLookupVindex  [-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>` |
 | [ExternalizeVindex](../vtctl/keyspaces#externalizevindex) | `ExternalizeVindex  <keyspace>.<vindex>` |
 | [Materialize](../vtctl/keyspaces#materialize) | `Materialize  <json_spec>, example : '{"workflow": "aaa", "source_keyspace": "source", "target_keyspace": "target", "table_settings": [{"target_table": "customer", "source_expression": "select * from customer", "create_ddl": "copy"}]}'` |
@@ -86,8 +88,8 @@ aliases: ['/docs/reference/vitess-api/','/docs/reference/vtctl/']
 | [VDiff](../vtctl/keyspaces#VDiff) | `VDiff  [-source_cell=<cell>] [-target_cell=<cell>] [-tablet_types=replica] [-filtered_replication_wait_time=30s] <keyspace.workflow>` |
 | [MigrateServedTypes](../vtctl/keyspaces#migrateservedtypes) | `MigrateServedTypes  [-cells=c1,c2,...] [-reverse] [-skip-refresh-state] <keyspace/shard> <served tablet type>` |
 | [MigrateServedFrom](../vtctl/keyspaces#migrateservedfrom) | `MigrateServedFrom  [-cells=c1,c2,...] [-reverse] <destination keyspace/shard> <served tablet type>` |
-| [SwitchReads](../vtctl/keyspaces#switchreads) | `SwitchReads  [-cells=c1,c2,...] [-reverse] -tablet_type={replica|rdonly} [-dry-run] <keyspace.workflow>` |
-| [SwitchWrites](../vtctl/keyspaces#switchwrites) | `SwitchWrites  [-filtered_replication_wait_time=30s] [-cancel] [-reverse_replication=false] [-dry-run] <keyspace.workflow>` |
+| [SwitchReads](../../vreplication/v1/switchreads) | `SwitchReads  [-cells=c1,c2,...] [-reverse] -tablet_type={replica|rdonly} [-dry-run] <keyspace.workflow>` |
+| [SwitchWrites](../../vreplication/v1/switchwrites) | `SwitchWrites  [-filtered_replication_wait_time=30s] [-cancel] [-reverse_replication=false] [-dry-run] <keyspace.workflow>` |
 | [CancelResharding](../vtctl/keyspaces#cancelresharding) | `CancelResharding  <keyspace/shard>` |
 | [ShowResharding](../vtctl/keyspaces#showresharding) | `ShowResharding  <keyspace/shard>` |
 | [FindAllShardsInKeyspace](../vtctl/keyspaces#findallshardsinkeyspace) | `FindAllShardsInKeyspace  <keyspace>` |

--- a/content/en/docs/reference/programs/vtctl/keyspaces.md
+++ b/content/en/docs/reference/programs/vtctl/keyspaces.md
@@ -228,16 +228,34 @@ Validates that all nodes reachable from the specified keyspace are consistent.</
 * the <code>&lt;keyspace name&gt;</code> argument is required for the <code>&lt;ValidateKeyspace&gt;</code> command This error occurs if the command is not called with exactly one argument.
 
 
-### Reshard
+### Reshard (v1)
 ```shell
-Reshard  [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>
+Reshard  -v1 [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>
 Start a Resharding process. Example: Reshard -cells='zone1,alias1' -tablet_types='primary,replica,rdonly'  ks.workflow001 '0' '-80,80-'.
 ```
+#### Notes
 
-### MoveTables
+* The <code>v1</code> argument is required in Vitess 11.0 and later
+* This command is part of the [VReplication v1 workflow](../../../vreplication/v1) -- we recommend that you use the [v2 workflow](../../../vreplication/v2) in Vitess 11.0 and later
+
+### Reshard (v2)
 ```shell
-MoveTables  [-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>
+Reshard <options> <action> <workflow identifier>
+```
+
+### MoveTables (v1)
+```shell
+MoveTables  -v1 [-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>
 Move table(s) to another keyspace, table_specs is a list of tables or the tables section of the vschema for the target keyspace. Example: '{"t1":{"column_vindexes": [{"column": "id1", "name": "hash"}]}, "t2":{"column_vindexes": [{"column": "id2", "name": "hash"}]}}'.  In the case of an unsharded target keyspace the vschema for each table may be empty. Example: '{"t1":{}, "t2":{}}'.
+```
+#### Notes
+
+* The <code>v1</code> argument is required in Vitess 11.0 and later
+* This command is part of the [VReplication v1 workflow](../../../vreplication/v1) -- we recommend that you use the [v2 workflow](../../../vreplication/v2) in Vitess 11.0 and later
+
+## MoveTables (v2)
+```shell
+MoveTables <options> <action> <workflow identifier>
 ```
 
 ### DropSources
@@ -245,6 +263,10 @@ Move table(s) to another keyspace, table_specs is a list of tables or the tables
 DropSources  [-dry_run] [-rename_tables] <keyspace.workflow>
 After a MoveTables or Resharding workflow cleanup unused artifacts like source tables, source shards and blacklists.
 ```
+
+#### Notes
+
+* This command is part of the [VReplication v1 workflow](../../../vreplication/v1) -- we recommend that you use the [v2 workflow](../../../vreplication/v2) in Vitess 11.0 and later
 
 ### CreateLookupVindex
 ```shell
@@ -372,11 +394,19 @@ SwitchReads  [-cells=c1,c2,...] [-reverse] -tablet_types={replica|rdonly} [-dry-
 Switch read traffic for the specified workflow.
 ```
 
+#### Notes
+
+* This command is part of the [VReplication v1 workflow](../../../vreplication/v1) -- we recommend that you use the [v2 workflow](../../../vreplication/v2) in Vitess 11.0 and later
+
 ### SwitchWrites
 ```shell
 SwitchWrites  [-timeout=30s] [-cancel] [-reverse] [-reverse_replication=false] -tablet_types={replica|rdonly} [-dry-run] <keyspace.workflow>
 Switch write traffic for the specified workflow.
 ```
+
+#### Notes
+
+* This command is part of the [VReplication v1 workflow](../../../vreplication/v1) -- we recommend that you use the [v2 workflow](../../../vreplication/v2) in Vitess 11.0 and later
 
 ### CancelResharding
 

--- a/content/en/docs/reference/vreplication/v1/_index.md
+++ b/content/en/docs/reference/vreplication/v1/_index.md
@@ -1,5 +1,9 @@
 ---
 title: VReplication V1 Commands
-description: (Deprecated) V1 MoveTables and Reshard vtctld commands
+description: v1 MoveTables and Reshard vtctld commands (**Deprecated**)
 weight: 1000
 ---
+
+{{< info >}}
+Starting with Vitess 11.0 you should use the [VReplication v2 commands](../../vreplication/v2)
+{{< /info >}}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "bulma": "^0.7.3"
+  },
+  "dependencies": {
+    "yarn": "^1.22.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,12 @@
 # yarn lockfile v1
 
 
-bulma@^0.7.3:
-  version "0.7.5"
-  resolved "https://registry.yarnpkg.com/bulma/-/bulma-0.7.5.tgz#35066c37f82c088b68f94450be758fc00a967208"
-  integrity sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw==
+"bulma@^0.7.3":
+  "integrity" "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw=="
+  "resolved" "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz"
+  "version" "0.7.5"
+
+"yarn@^1.22.11":
+  "integrity" "sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg=="
+  "resolved" "https://registry.npmjs.org/yarn/-/yarn-1.22.11.tgz"
+  "version" "1.22.11"


### PR DESCRIPTION
This updates the website docs for v11.0.0 and later to document the new required `-v1` flag for the [VReplication v1 workflow commands](https://vitess.io/docs/reference/vreplication/v1/) which now require it -- `Reshard` and `MoveTables` -- and adds docs for the corresponding [v2 commands](https://vitess.io/docs/reference/vreplication/v2/) in the `vtctl` docs.

This is related to https://github.com/vitessio/vitess/issues/8644
