### PR TITLE
Priority field is required in v11+

### DIFF
--- a/content/en/docs/reference/features/messaging.md
+++ b/content/en/docs/reference/features/messaging.md
@@ -58,9 +58,10 @@ create table my_message(
   time_created bigint,
   time_acked bigint,
   message varchar(128),
+  priority tinyint NOT NULL DEFAULT '0',
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(time_next, epoch)
+  index next_idx(priority, time_next)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 


### PR DESCRIPTION
And shouldn't hurt before v11?

This was added in: https://github.com/vitessio/vitess/commit/47a08131748bc895416c5686b5315782b45e9914

Signed-off-by: Matt Lord <mattalord@gmail.com>