### PR TITLE
Warn against usage of INSTANT DDL on materialization sources

### DIFF
--- a/content/en/docs/reference/vreplication/materialize.md
+++ b/content/en/docs/reference/vreplication/materialize.md
@@ -17,6 +17,10 @@ can be copies, aggregations or views. The target tables are kept in sync in near
 
 You can specify multiple tables to materialize using the json_spec parameter.
 
+{{< warning >}}
+Be careful to avoid using the `INSTANT ADD COLUMN` feature in [MySQL 8.0+](https://mysqlserverteam.com/mysql-8-0-innodb-now-supports-instant-add-column/) and [MariaDB 10.3+](https://mariadb.com/kb/en/instant-add-column-for-innodb/) with materialization source tables as this can cause the vreplication based materialization workflow to break.
+{{< /warning >}}
+
 ### Parameters
 
 


### PR DESCRIPTION
[INSTANT DDL](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html) (just add column today) in [MySQL 8.0+](https://mysqlserverteam.com/mysql-8-0-innodb-now-supports-instant-add-column/) and [MariaDB10.3+](https://mariadb.com/kb/en/instant-add-column-for-innodb/) can be used when it only requires a _metadata_ change. This means that there's not a new object/table id generated within InnoDB as we're not changing the table[space] at that level in the typical way (where you replace the old table[space] with the new one). 

The table id is used to identify the storage engine (InnoDB) object we are making row changes to in MySQL [row based replication](https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_binlog_format) -- the table id having been mapped to a database object (in InnoDB) via a [`TABLE_MAP` event](https://dev.mysql.com/doc/internals/en/table-map-event.html)  (the columns are also referenced by index in the associated [`ROWS_EVENT` event](https://dev.mysql.com/doc/internals/en/rows-event.html) which is why column order matters). This is important because SQL statements are not actually used in row based replication but rather lower level binary messages between the Binlog and InnoDB server components.

Currently VReplication assumes that the table id will change on all schema changes (DDL) so this can cause materialization workflows to break.

Signed-off-by: Matt Lord <mattalord@gmail.com>