### PR TITLE
Build docs: Update go version

### DIFF
--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -12,13 +12,13 @@ The following has been verified to work on __CentOS 7__. If you are new to Vites
 
 ## Install Dependencies
 
-### Install Go 1.16+
+### Install Go 1.17+
 
-[Download and install](http://golang.org/doc/install) Golang 1.16. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.17. For example, at writing:
 
 ```
-curl -LO https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+curl -LO https://golang.org/dl/go1.17.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
 ```
 
 Make sure to add go to your bashrc:

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -21,14 +21,19 @@ The following has been verified to work on __macOS Mojave__. If you are new to V
 [Install Homebrew](http://brew.sh/). From here you should be able to install:
 
 ```shell
-brew install go@1.16 automake git curl wget mysql@5.7
+brew install automake git curl wget mysql@5.7
 ```
 
-Add `mysql@5.7` and `go@1.16` to your `PATH`:
+Add `mysql@5.7` to your `PATH`:
 
 ```shell
 echo 'export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"' >> ~/.bash_profile
-echo 'export PATH="/usr/local/opt/go@1.16/bin:$PATH"' >> ~/.bash_profile
+```
+
+[Download and install](http://golang.org/doc/install) Golang 1.17. For example, at writing:
+```shell
+curl -LO https://golang.org/dl/go1.17.darwin-amd64.pkg
+sudo installer -pkg go1.17.darwin-amd64.pkg -target /
 ```
 
 Do not install etcd via brew otherwise it will not be the version that is supported. Let it be installed when running make build.

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -12,13 +12,13 @@ The following has been verified to work on __Ubuntu 19.10__ and __Debian 10__. I
 
 ## Install Dependencies
 
-### Install Go 1.16+
+### Install Go 1.17+
 
-[Download and install](http://golang.org/doc/install) Golang 1.16. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.17. For example, at writing:
 
 ```
-curl -LO https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz
+curl -LO https://dl.google.com/go/go1.17.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.17.linux-amd64.tar.gz
 ```
 
 Make sure to add go to your bashrc:


### PR DESCRIPTION
Bumping the golang version in the build docs after the recent 1.17 changes.

No brew formula for `go@1.17` yet so switched to pkg install. 

Signed-off-by: Gary Edgar <gary@planetscale.com>