### PR TITLE
Clarify Shared Storage Requirement for File Backup Storage

### DIFF
--- a/content/en/docs/reference/features/recovery.md
+++ b/content/en/docs/reference/features/recovery.md
@@ -134,6 +134,10 @@ variety of flags:
  - There are more `-backup_storage_implementation` options like `gcs` and
   others.
 
+{{< warning >}}
+When using the file backup storage engine the backup storage root path must be on shared storage to provide a global view of backups to all vitess components.
+{{< /warning >}}
+
 You will also probably want to use other flags for backup and restore like:
 
  - `-backup_engine_implementation xtrabackup` - Use Percona Xtrabackup to

--- a/content/en/docs/reference/programs/vtctl/_index.md
+++ b/content/en/docs/reference/programs/vtctl/_index.md
@@ -248,7 +248,7 @@ The following global options apply to `vtctl`:
 | -enable_transaction_limit | | If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not. |
 | -enable_transaction_limit_dry_run | | If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced. |
 | -enforce_strict_trans_tables | | If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true)|
-|-file_backup_storage_root | string | root directory for the file backup storage |
+|-file_backup_storage_root | string | root directory for the file backup storage -- this path must be on shared storage to provide a global view of backups to all vitess components |
 | -gcs_backup_storage_bucket | string | Google Cloud Storage bucket to use for backups |
 | -gcs_backup_storage_root | string | root prefix for all backup-related object names |
 | -grpc_auth_mode | string | Which auth plugin implementation to use (eg: static) |

--- a/content/en/docs/reference/programs/vtctld.md
+++ b/content/en/docs/reference/programs/vtctld.md
@@ -25,7 +25,6 @@ vtctld \
  -grpc_port 15999
 ```
 
-
 ## Options
 
 | Name | Type | Definition |
@@ -72,7 +71,7 @@ vtctld \
 | -enable_transaction_limit | boolean | If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not. |
 | -enable_transaction_limit_dry_run | boolean | If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced. |
 | -enforce_strict_trans_tables | boolean | If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true) |
-| -file_backup_storage_root | string | root directory for the file backup storage |
+| -file_backup_storage_root | string | root directory for the file backup storage -- this path must be on shared storage to provide a global view of backups to all vitess components |
 | -gcs_backup_storage_bucket | string | Google Cloud Storage bucket to use for backups |
 | -gcs_backup_storage_root | string | root prefix for all backup-related object names |
 | -grpc_auth_mode | string | Which auth plugin implementation to use (eg: static) |

--- a/content/en/docs/reference/programs/vttablet.md
+++ b/content/en/docs/reference/programs/vttablet.md
@@ -136,7 +136,7 @@ The following global options apply to `vttablet`:
 | -enable_transaction_limit_dry_run |  | If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced. |
 | -enforce-tableacl-config |  | if this flag is true, vttablet will fail to start if a valid tableacl config does not exist |
 | -enforce_strict_trans_tables |  | If true, vttablet requires MySQL to run with STRICT_TRANS_TABLES or STRICT_ALL_TABLES on. It is recommended to not turn this flag off. Otherwise MySQL may alter your supplied values before saving them to the database. (default true) |
-| -file_backup_storage_root | string | root directory for the file backup storage |
+| -file_backup_storage_root | string | root directory for the file backup storage -- this path must be on shared storage to provide a global view of backups to all vitess components |
 | -filecustomrules | string | file based custom rule path |
 | -finalize_external_reparent_timeout | duration | Timeout for the finalize stage of a fast external reparent reconciliation. (default 30s) |
 | -gcs_backup_storage_bucket | string | Google Cloud Storage bucket to use for backups |

--- a/content/en/docs/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/user-guides/configuration-basic/planning.md
@@ -50,6 +50,10 @@ Backups will need to be shared across vttablet instances and multiple cells. You
 -backup_storage_implementation file -file_backup_storage_root <mounted_path_dir>
 ```
 
+{{< warning >}}
+When using the file backup storage engine the backup storage root path must be on shared storage to provide a global view of backups to all vitess components.
+{{< /warning >}}
+
 Please refer to the [Backup and Restore](../../operating-vitess/backup-and-restore) guide for instructions on how to configure other storage options.
 
 To avoid repetition we will use `<backup_flags>` in our examples to signify the above flags.
@@ -58,7 +62,7 @@ To avoid repetition we will use `<backup_flags>` in our examples to signify the 
 
 Vitess servers write to log files, and they are rotated when they reach a maximum size. It’s recommended that you run at INFO level logging. The information printed in the log files can come in handy for troubleshooting. You can limit the disk usage by running cron jobs that periodically purge or archive them.
 
-All Vitess servers accept a `-log_dir` as argument and will create the log files in that specified directory. For example:
+All Vitess servers accept a `-log_dir` argument and will create the log files in that specified directory. For example:
 
 ```text
 -log_dir=${VTDATAROOT}/tmp


### PR DESCRIPTION
Shared storage is necessary for the file backup storage engine to fulfill a property required of all backup storage
engines -- presenting a single unified global view of backups to all vitess components within a cluster.

Signed-off-by: Matt Lord <mattalord@gmail.com>