### PR TITLE
adjusting defaults for -vreplication_tablet_type to PRIMARY,REPLICA

### DIFF
--- a/content/en/docs/reference/programs/vtctl/_index.md
+++ b/content/en/docs/reference/programs/vtctl/_index.md
@@ -412,7 +412,7 @@ The following global options apply to `vtctl`:
 | -vreplication_healthcheck_timeout | duration | healthcheck retry delay (default 1m0s) |
 | -vreplication_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
 | -vreplication_retry_delay | duration | delay before retrying a failed binlog connection (default 5s) |
-| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "REPLICA") |
+| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "PRIMARY,REPLICA") |
 | -vstream_packet_size | int | Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 30000) |
 | -vtctl_healthcheck_retry_delay | duration | delay before retrying a failed healthcheck (default 5s) |
 | -vtctl_healthcheck_timeout | duration | the health check timeout period (default 1m0s) |

--- a/content/en/docs/reference/programs/vtctld.md
+++ b/content/en/docs/reference/programs/vtctld.md
@@ -246,7 +246,7 @@ vtctld \
 | -vreplication_healthcheck_timeout | duration | healthcheck retry delay (default 1m0s) |
 | -vreplication_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
 | -vreplication_retry_delay | duration | delay before retrying a failed binlog connection (default 5s) |
-| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "REPLICA") |
+| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "PRIMARY,REPLICA") |
 | -vstream_packet_size | int | Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 30000) |
 | -vtctl_client_protocol | string | the protocol to use to talk to the vtctl server (default "grpc") |
 | -vtctl_healthcheck_retry_delay | duration | delay before retrying a failed healthcheck (default 5s) |

--- a/content/en/docs/reference/programs/vttablet.md
+++ b/content/en/docs/reference/programs/vttablet.md
@@ -345,7 +345,7 @@ The following global options apply to `vttablet`:
 | -vreplication_healthcheck_timeout | duration | healthcheck retry delay (default 1m0s) |
 | -vreplication_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
 | -vreplication_retry_delay | duration | delay before retrying a failed binlog connection (default 5s) |
-| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "REPLICA") |
+| -vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "PRIMARY,REPLICA") |
 | -vstream_packet_size | int | Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 30000) |
 | -vtctld_addr | string | address of a vtctld instance |
 | -vtgate_protocol | string | how to talk to vtgate (default "grpc") |

--- a/content/en/docs/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/user-guides/configuration-advanced/createlookupvindex.md
@@ -27,7 +27,7 @@ The source table is expected to also be in this keyspace.
 as source tablets for the VReplication stream(s) that this command will
 create. If not specified, the tablet type used will default to the value
 of the vttablet `-vreplication_tablet_type` option, which defaults to
-`REPLICA`.
+`PRIMARY,REPLICA`.
  * `-cells`: By default VReplication streams, such as used by
 `CreateLookupVindex` will not cross cell boundaries.  If you want the
 VReplication streams to source their data from tablets in cells other


### PR DESCRIPTION
the default for vttablet vreplication_tablet_type changed from “REPLICA” to “PRIMARY,REPLICA” in Jan 2021