### PR TITLE
Clarify that transaction_mode can be overridden at session level

### DIFF
--- a/content/en/docs/reference/features/two-phase-commit.md
+++ b/content/en/docs/reference/features/two-phase-commit.md
@@ -24,13 +24,13 @@ Guaranteeing ACID Isolation is very contentious and has high costs. Providing it
 
 ### Configuring VTGate
 
-The atomicity policy is controlled by the `transaction_mode` flag. The default value is multi, and will set it in multi-database mode. This is the same as the previous legacy behavior.
+The atomicity policy is controlled by the `transaction_mode` flag. The default value is `multi` and will set all transactions to multi-database mode.
 
 To enforce single-database transactions, the VTGates can be started by specifying `transaction_mode=single`.
 
 To enable 2PC, the VTGates need to be started with `transaction_mode=twopc`. The VTTablets will require additional flags, which will be explained below.
 
-The VTGate `transaction_mode` flag decides what to allow. The application can independently request a specific atomicity for each transaction. The request will be honored by VTGate only if it does not exceed what is allowed by the `transaction_mode`. For example, `transaction_mode=single` will only allow single-db transactions. On the other hand, `transaction_mode=twopc` will allow all three levels of atomicity.
+The VTGate `transaction_mode` flag decides what to allow by default. The application can then override that global default for an individual transaction using `SET transaction_mode="<mode>";` when necessary or appropriate.
 
 ## Driver APIs
 

--- a/content/en/docs/reference/programs/vtgate.md
+++ b/content/en/docs/reference/programs/vtgate.md
@@ -182,7 +182,7 @@ The following global options apply to `vtgate`:
 | -topo_zk_tls_key | string | the key to use to connect to the zk topo server, enables TLS |
 | -tracer | string | tracing service to use (default "noop") |
 | -tracing-sampling-rate | float | sampling rate for the probabilistic jaeger sampler (default 0.1) |
-| -transaction_mode | string | SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI") |
+| -transaction_mode | string | the default transaction mode -- SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI");  this can be overridden at the session level when needed using `SET transaction_mode="<mode>";`|
 | -v | value | log level for V logs |
 | -version | boolean | print binary version |
 | -vmodule | value | comma-separated list of pattern=N settings for file-filtered logging |


### PR DESCRIPTION
This behavior was changed in Vitess 6.0+ via: https://github.com/vitessio/vitess/pull/6049

Since [5.0](https://github.com/vitessio/vitess/releases/tag/v5.0.0) and older is now well outside of [the official window of support](https://github.com/vitessio/enhancements/blob/main/veps/vep-1.md#versioning-and-release-cadence), I think we can avoid having to add a note about which version this behavior changed in.

Signed-off-by: Matt Lord <mattalord@gmail.com>