### PR TITLE
add information about schema tracking acl user

### DIFF
--- a/content/en/docs/reference/features/schema-tracking.md
+++ b/content/en/docs/reference/features/schema-tracking.md
@@ -18,6 +18,8 @@ The schema tracking functionality alleviates this issue and enable VTGate to pla
 ## VTGate
 
 Schema tracking is enabled in VTGate with the flag `-schema_change_signal`. When enabled, VTGate listens for schema changes from VTTablet.
+A change triggers a fetch query on vttablet on internal _vt schema.
+If the Table ACL is enabled, then an exempted/allowed username needs to be passed to VTGate with flag `-schema_change_signal_user`.
 
 ## VTTablet
 


### PR DESCRIPTION
Update the Schema tracking page with new flag required to be passed by user to make schema tracking work when ACL is enabled.