### PR TITLE
Added Gen4 and V3 compatibility doc

### DIFF
--- a/content/en/docs/reference/compatibility/gen4-and-v3-compatibility.md
+++ b/content/en/docs/reference/compatibility/gen4-and-v3-compatibility.md
@@ -1,0 +1,17 @@
+---
+title: Gen4 and V3 Compatibility
+weight: 2
+aliases: ['/docs/reference/gen4-against-v3/', '/docs/reference/gen4-and-v3-compatibility/']
+---
+
+The latest version of the Vitess query planner, `Gen4`, changes most of the planner's internals.
+To ensure `Gen4` produces plans that, once executed, give us the same results as what `V3` would do, we have developed
+a small test tool that runs queries using both `Gen4` and `V3` planners and compare their results. If the results we got are different
+from the two planners, the query will fail and the difference will be printed in VTGate's logs as a warning.
+
+This tool is enabled by the use of a new planner: `Gen4CompareV3`, to use it, we must start VTGate with the `-planner_version` 
+flag set to `Gen4CompareV3`. Once set, new queries will be tested against both `Gen4` and `V3`.
+
+{{< warning >}}
+This new planner should only be used for testing purposes.
+{{< /warning >}}


### PR DESCRIPTION
This pull request adds the documentation related to the compatibility between the Gen4 and V3 planners.