### PR TITLE
Upgrade bulma to v0.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo houses the assets used to build the website at https://vitess.io.
 
 ## Running the site locally
 
-To run the website locally, you need to have the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Installing the Hugo version in [netlify.toml](./netlify.toml) is recommended.
+To run the website locally, you need to have the "extended" version of the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Installing the Hugo version in [netlify.toml](./netlify.toml) is recommended.
 
 Once Hugo is installed run the following:
 
@@ -26,3 +26,9 @@ If you'd like to add your logo to the [Who uses Vitess](https://vitess.io/#who-u
 ## Link checking
 
 You can check the site's internal links by running `make check-internal-links` and all links—internal *and* external—by running `make check-all-links`.
+
+## CSS/SASS
+
+The Vitess website uses [Bulma](https://bulma.io/), a CSS (and SASS) framework that provides all kinds of variables, utilities, and components. 
+
+**⚠ If you are running Hugo locally and your .sass file changes are not getting picked up:** make sure you have [installed the "extended" version](https://gohugo.io/getting-started/installing/) of the `hugo` binary. 

--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -14,7 +14,7 @@ html, body
 // Bit of a hacky full-width container override for the docs page,
 // since bulma.io doesn't appear to have a helper for this.
 .navbar-container-docs
-  max-width: 100%
+  max-width: 100% !important
   padding: 0 8px 0 24px
 
 .docs-wrapper

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "devDependencies": {
-    "bulma": "^0.7.3"
-  },
   "dependencies": {
     "yarn": "^1.22.11"
+  },
+  "devDependencies": {
+    "bulma": "^0.9.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"bulma@^0.7.3":
-  "integrity" "sha512-cX98TIn0I6sKba/DhW0FBjtaDpxTelU166pf7ICXpCCuplHWyu6C9LYZmL5PEsnePIeJaiorsTEzzNk3Tsm1hw=="
-  "resolved" "https://registry.npmjs.org/bulma/-/bulma-0.7.5.tgz"
-  "version" "0.7.5"
+"bulma@^0.9.3":
+  "integrity" "sha512-0d7GNW1PY4ud8TWxdNcP6Cc8Bu7MxcntD/RRLGWuiw/s0a9P+XlH/6QoOIrmbj6o8WWJzJYhytiu9nFjTszk1g=="
+  "resolved" "https://registry.npmjs.org/bulma/-/bulma-0.9.3.tgz"
+  "version" "0.9.3"
 
 "yarn@^1.22.11":
   "integrity" "sha512-AWje4bzqO9RUn3sdnM5N8n4ZJ0BqCc/kqFJvpOI5/EVkINXui0yuvU7NDCEF//+WaxHuNay2uOHxA4+tq1P3cg=="


### PR DESCRIPTION
Bulma v0.7.3 is from February 2019 and rather stale. I noticed that we're missing a bunch of useful utilities, like [spacing helpers](https://bulma.io/documentation/helpers/spacing-helpers/).

I verified that none of the [breaking changes](https://github.com/jgthms/bulma/releases) apply to us, and spot-checked a bunch of pages. Everything looks good to me. 