### PR TITLE
Fix navbar layout bug on /docs for mobile

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -11,21 +11,11 @@ html, body
 =h-center
   justify-content: center
 
-// Bit of a hacky full-width container override for the docs page,
-// since bulma.io doesn't appear to have a helper for this.
-.navbar-container-docs
-  max-width: 100% !important
-  padding: 0 8px 0 24px
-
 .docs-wrapper
   +flex
   flex-direction: row
   height: calc(100vh - #{$navbar-height})
   align-items: stretch
-
-.docs-navbar
-  position: sticky
-  top: 0
 
 .docs-sidebar
   +flex

--- a/assets/sass/navbar.sass
+++ b/assets/sass/navbar.sass
@@ -1,28 +1,28 @@
-// Bit of a hacky full-width container override for the docs page,
-// since bulma.io doesn't appear to have a helper for this.
-.navbar-container-docs
-  max-width: 100% !important
-  padding: 0 8px 0 24px
+.navbar
+  +until($navbar-breakpoint)
+    #search-bar
+      display: block
 
-+until($navbar-breakpoint)
-  #search-bar
-    display: block
+    .algolia-autocomplete
+      // Fixes for the DocSearch widget to prevent clipping on mobile.
+      display: block !important
 
-  .algolia-autocomplete
-    // Fixes for the DocSearch widget to prevent clipping on mobile.
-    display: block !important
+      .ds-dropdown-menu
+        max-width: 100vw !important
+        min-width: fit-content !important
 
-    .ds-dropdown-menu
-      max-width: 100vw !important
-      min-width: fit-content !important
+  +from($navbar-breakpoint)
+    // Bit of a hacky full-width container override for the docs page,
+    // since bulma.io doesn't appear to have a helper for this.
+    .navbar-container-docs
+      max-width: 100% !important
+      padding: 0 8px 0 24px
+      
+    // On mobile (and by default), the search input is displayed at the top of the menu,
+    // whereas on desktop, it's displayed at the right side of the menu bar (i.e., flex-end)
+    .navbar-menu
+      flex-direction: row-reverse
 
-+from($navbar-breakpoint)
-	// On mobile (and by default), the search input is displayed at the top of the menu,
-	// whereas on desktop, it's displayed at the right side of the menu bar (i.e., flex-end)
-	.navbar-menu
-		flex-direction: row-reverse
-
-	// Cuddle up the search input + social icons for the full-width navbar  	
-	.navbar-item-search
-		padding-left: 0
-	
+    // Cuddle up the search input + social icons for the full-width navbar  	
+    .navbar-item-search
+      padding-left: 0

--- a/assets/sass/navbar.sass
+++ b/assets/sass/navbar.sass
@@ -1,0 +1,28 @@
+// Bit of a hacky full-width container override for the docs page,
+// since bulma.io doesn't appear to have a helper for this.
+.navbar-container-docs
+  max-width: 100% !important
+  padding: 0 8px 0 24px
+
++until($navbar-breakpoint)
+  #search-bar
+    display: block
+
+  .algolia-autocomplete
+    // Fixes for the DocSearch widget to prevent clipping on mobile.
+    display: block !important
+
+    .ds-dropdown-menu
+      max-width: 100vw !important
+      min-width: fit-content !important
+
++from($navbar-breakpoint)
+	// On mobile (and by default), the search input is displayed at the top of the menu,
+	// whereas on desktop, it's displayed at the right side of the menu bar (i.e., flex-end)
+	.navbar-menu
+		flex-direction: row-reverse
+
+	// Cuddle up the search input + social icons for the full-width navbar  	
+	.navbar-item-search
+		padding-left: 0
+	

--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -39,6 +39,7 @@ $colors: mergeColorMaps(("stack-overflow-orange": ($stack-overflow-orange, $whit
 @import "bulma/bulma"
 
 @import "docs"
+@import "navbar"
 
 figure
   img
@@ -193,28 +194,6 @@ figure
   &.is-active
     position: fixed
 
-+until($navbar-breakpoint)
-  #search-bar
-    display: block
-
-  .algolia-autocomplete
-    // Fixes for the DocSearch widget to prevent clipping on mobile.
-    display: block !important
-
-    .ds-dropdown-menu
-      max-width: 100vw !important
-      min-width: fit-content !important
-
-+from($navbar-breakpoint)
-	// On mobile (and by default), the search input is displayed at the top of the menu,
-	// whereas on desktop, it's displayed at the right side of the menu bar (i.e., flex-end)
-	.navbar-menu
-		flex-direction: row-reverse
-
-	// Cuddle up the search input + social icons for the full-width navbar  	
-	.navbar-item-search
-		padding-left: 0
-	
 .header-link
   color: $dark
   opacity: 0.3 


### PR DESCRIPTION
Fixes #856

- Fixes layout bug by adding `.navbar-container-docs`'s full-width + bespoke padding to navbar container on desktop only
- Consolidates navbar styles into `navbar.sass` 

Branch (with the fix) vs. prod (without):

![image](https://user-images.githubusercontent.com/855595/139592036-cff72378-501c-46f7-b5ae-2894b31aa494.png)
