### PR TITLE
Add /docs footer with "last modified" date and "Edit this page" GitHub link

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -23,6 +23,7 @@ $family-sans-serif: 'Open Sans', sans-serif
 
 $orange: $vitess-orange
 
+// Bulma variable overrides
 $primary: $orange
 $link: $cncf-dark-blue
 $navbar-burger-color: $primary
@@ -30,6 +31,7 @@ $navbar-dropdown-arrow: $primary !important
 $navbar-dropdown-radius: none
 $input-radius: 0
 $input-shadow: none
+$footer-background-color: $white
 
 @import "bulma/sass/utilities/derived-variables"
 

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,7 @@
 baseURL = "https://vitess.io"
 canonifyurls = true
 disableKinds = ["taxonomy", "taxonomyTerm"]
+enableGitInfo = true
 googleAnalytics = "UA-163836834-1"
 enableRobotsTXT = true
 
@@ -117,4 +118,3 @@ icon = "magic"
 
 [markup.goldmark.renderer]
 unsafe = true
-

--- a/layouts/docs/section.html
+++ b/layouts/docs/section.html
@@ -30,6 +30,8 @@
       </div>
     
     </article>
+    
+    {{ partial "docs/footer.html" . }}
   </div>
 </div>
 {{ end }}

--- a/layouts/docs/single.html
+++ b/layouts/docs/single.html
@@ -11,6 +11,7 @@ The Vitess Docs | {{ .Title }}
   <div class="docs-article">
     {{ partial "navbar.html" . }}
     {{ partial "docs/article.html" . }}
+    {{ partial "docs/footer.html" . }}
   </div>
 
   {{ partial "docs/toc.html" . }}

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -1,0 +1,14 @@
+{{ $path         := .File.Path }}
+{{ $language     := .Language }}
+{{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
+
+<footer class="footer">
+  <div class="container has-text-centered">
+    <a class="button" href="{{ $editUrl }}" rel="noopener noreferrer" target="_blank">
+      <span class="icon">
+        <i class="fab fa-github"></i>
+      </span>
+      <span>Edit this page</span>
+    </a>
+  </div>
+</footer>

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -10,5 +10,7 @@
       </span>
       <span>Edit this page</span>
     </a>
+
+    <p class="is-size-7 mt-2">Last updated {{ .Lastmod.Format "January 2, 2006" }}.</p>
   </div>
 </footer>

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -11,6 +11,6 @@
       <span>Edit this page</span>
     </a>
 
-    <p class="is-size-7 mt-2">Last updated {{ .Lastmod.Format "January 2, 2006" }}.</p>
+    <p class="is-size-7 mt-2">Last updated {{ .Lastmod.Format "January 2, 2006" }}</p>
   </div>
 </footer>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -1,7 +1,5 @@
 {{ $docsSections := where site.Sections "Section" "docs" }}
-{{ $path         := .File.Path }}
-{{ $language     := .Language }}
-{{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
+
 <header class="docs-header">
   {{/* Hide breadcrumbs on mobile since bulma.io doesn't handle overflows nicely for long crumbs */}}
   <nav class="breadcrumb is-hidden-touch" aria-label="breadcrumbs">
@@ -42,15 +40,6 @@
   {{ end }}
 
   <div class="buttons">
-    <a class="button is-dark" href="{{ $editUrl }}">
-      <span class="icon">
-        <i class="fab fa-github"></i>
-      </span>
-      <span>
-        Edit
-      </span>
-    </a>
-
     <div class="dropdown is-hoverable is-hidden-desktop">
       <div class="dropdown-trigger">
         <button class="button is-primary" aria-haspopup="true" aria-controls="docs-menu">


### PR DESCRIPTION
For all /docs pages, both "single" and "section" layouts, this adds a footer that holds: 

- A link to the page's corresponding file on GitHub. Previously, this link was at the top of the articles. I think moving it to the bottom streamlines the page content; only a small fraction of readers are going to want to edit the page. 

- 🆕 The "last modified" date of the file. From the [documentation](https://gohugo.io/variables/page/), "If lastmod [in the content's front matter] is not set, and .GitInfo feature is enabled, .GitInfo.AuthorDate will be used instead."

One thing I'd like to do is make sure the footer stays anchored at the bottom of the viewport, especially for short pages. That'll take some moderately messy refactoring, so I'd rather do it in a separate PR. 

Before:
![image](https://user-images.githubusercontent.com/855595/139599857-6b0ae3f8-5c1b-4234-8506-cba15dcba390.png)

After: 
![image](https://user-images.githubusercontent.com/855595/139599854-e61a96c5-eb52-4c29-8ef0-210825544d32.png)
