### PR TITLE
Modifying running locally instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,21 @@ This repo houses the assets used to build the website at https://vitess.io.
 
 To run the website locally, you need to have the "extended" version of the [Hugo](https://gohugo.io) static site generator installed (installation instructions [here](https://gohugo.io/getting-started/installing/)). Installing the Hugo version in [netlify.toml](./netlify.toml) is recommended.
 
-Once Hugo is installed run the following:
+Once Hugo is installed you will need to install `npm` or `yarn` and fetch the dependencies in the git directory:
+
+```bash
+cd website
+npm install
+```
+
+or
+
+```bash
+cd website
+yarn
+```
+
+You are now ready to startup the hugo server:
 
 ```bash
 hugo server --buildDrafts --buildFuture
@@ -14,10 +28,6 @@ hugo server --buildDrafts --buildFuture
 
 This starts Hugo in local mode. You can see access the site at http://localhost:1313.
 
-You will also need to either:
-
-- install `npm` and run `npm install` or,
-- install and run `yarn`
 
 ## Adding a user logo
 


### PR DESCRIPTION
Instructions were not clear that `npm` or `yarn` had to be run previous to running `hugo`. This change ensures dependencies are fetched before hugo is ran. 