### PR TITLE
Clarify 'online' strategy supports ETA and progress

### DIFF
--- a/content/en/docs/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/user-guides/schema-changes/ddl-strategies.md
@@ -166,7 +166,7 @@ There are pros and cons to using any of the strategies. Some notable differences
   - `gh-ost`, `online` do not support foreign keys
   - `pt-osc` has support for foreign keys (may apply collateral blocking operations)
 - **Trackable**: able to determine migration state (`ready`, `running`, `complete` etc)
-  - `gh-ost` also makes available _progress %_ and _ETA seconds_
+  - `online` and `gh-ost` strategies also makes available _progress %_ and _ETA seconds_
 - **Declarative**: support `-declarative` flag
 - **Revertible**: `online` strategy supports [revertible](../revertible-migrations/) `ALTER` statements (or `ALTER`s implied by `-declarative` migrations). All managed strategies supports revertible `CREATE` and `DROP`.
 - **Recoverable**: an `online` migration interrupted by planned/unplanned failover, [automatically resumes](../recoverable-migrations/) work from point of interruption. `gh-ost` and `pt-osc` will not resume after failover, but Vitess will automatically retry the migration (by marking the migration as failed and by initiating a `RETRY`), exactly once for any migration.


### PR DESCRIPTION
Fixes https://github.com/vitessio/website/issues/863, clarifying `online` migrations have ETA and progress indication, as per https://github.com/vitessio/vitess/pull/8015