### PR TITLE
Rewrite expand.html partial to use details element

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -237,3 +237,6 @@ h1, h2, h3, h4, h5, h6
     height: $navbar-anchor-offset
     visibility: hidden
     pointer-events: none
+
+details summary
+  cursor: pointer

--- a/content/en/docs/reference/vreplication/faq.md
+++ b/content/en/docs/reference/vreplication/faq.md
@@ -3,9 +3,8 @@ title: VReplication FAQ
 description: Common issues/questions while operating VReplication workflows.
 weight: 400
 ---
-{{< expand
-`What mysql permissions are needed by VReplication`
-"fas fa-angle-double-right" "fas fa-angle-double-up" >}}
+
+{{< expand `What mysql permissions are needed by VReplication?`>}}
 <pre>
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE, 
   REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES,
@@ -13,25 +12,23 @@ GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, FILE,
   SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER
   ON *.* TO 'vt_filtered'@'localhost';
 </pre>
-
 {{< /expand >}}
 
-{{< expand
-`Why am I seeing io.EOF errors in my workflow`
-"fas fa-angle-double-right" "fas fa-angle-double-up" >}}
-<code>io.EOF</code> errors can be difficult to track down. These are usually caused by an issue at the mysql server. Here are some possible reasons
+{{< expand `Why am I seeing io.EOF errors in my workflow?`>}}
+<p>
+  <code>io.EOF</code> errors can be difficult to track down. These are usually caused by an issue at the mysql server. Here are some possible reasons:
+</p>
+
 <ul>
-<li>GTID is not enabled on the server. VReplication requires <code>GTID=on</code>
-(<code>permissible</code> is <b>not</b> supported)</li>
-<li>Permissions are not setup correctly for the vreplication mysql user</li>
-<li>Row-based replication (RBR) <code>binlog_format=row</code> is not enabled. Statement-based replication (SBR) is <b>not</b> supported by VReplication</li>
-<li>The mysql server is down or not reachable</li>
+  <li>GTID is not enabled on the server. VReplication requires <code>GTID=on</code>
+  (<code>permissible</code> is <b>not</b> supported)</li>
+  <li>Permissions are not setup correctly for the vreplication mysql user</li>
+  <li>Row-based replication (RBR) <code>binlog_format=row</code> is not enabled. Statement-based replication (SBR) is <b>not</b> supported by VReplication</li>
+  <li>The mysql server is down or not reachable</li>
 </ul>
 {{< /expand >}}
 
-{{< expand
-`What GTID-related options do I need to set in my my.cnf?`
-"fas fa-angle-double-right" "fas fa-angle-double-up" >}}
+{{< expand `What GTID-related options do I need to set in my my.cnf?`>}}
 <pre>
 log_bin=1
 binlog_format=ROW
@@ -40,11 +37,7 @@ binlog_row_image=full
 {{< /expand >}}
 
 <!--
-
-{{< expand
-`If I can't turn GTID on, can I run a VReplication workflow using FilePos instead?`
-"fas fa-angle-double-right" "fas fa-angle-double-up" >}}
+{{< expand `If I can't turn GTID on, can I run a VReplication workflow using FilePos instead?`>}}
 To be done
 {{< /expand >}}
-
 -->

--- a/layouts/shortcodes/expand.html
+++ b/layouts/shortcodes/expand.html
@@ -1,11 +1,7 @@
-<!-- File: expand.html -->
-<span class="expand">
-    <span class="expand-label" style="cursor: pointer;color: #f16626; font-size:larger" onclick="$h = $(this);$h.next('div').slideToggle(100,function () {$h.children('i').attr('class',function () {return $h.next('div').is(':visible') ? '{{.Get 2 | default `fas fa-chevron-down`}}' : 'fas fa-{{.Get 1 | default `fas fa-chevron-right`}}';});});">
-        <i class="{{.Get 1 | default `fas fa-chevron-right`}}"></i>
-        {{.Get 0}}
-    </span>
-    <div class="expand-content" style="display: none;">
+<details class="my-2">
+    <summary class="py-2 is-size-5 has-text-weight-semibold">{{.Get 0}}</summary>
+
+    <div class="mt-1 mb-6">
         {{.Inner | safeHTML}}
     </div>
-</span>
-<p></p>
+</details>


### PR DESCRIPTION
This rewrites the expand.html partial to use the browser native `<details>` element. (Easily my favourite HTML element of all time. :sunglasses: Love it so much.)

Here's a before/after to show what it looks like:

<img width="1792" alt="Screen Shot 2021-11-17 at 10 00 34 AM" src="https://user-images.githubusercontent.com/855595/142225101-f30b77d3-d1b9-4542-9e0c-9d0f4b9d9923.png">

<img width="1792" alt="Screen Shot 2021-11-17 at 9 59 47 AM" src="https://user-images.githubusercontent.com/855595/142224978-5ce0f916-c336-4b17-b3e1-08179620f89c.png">


This fixes the regression found by @mattlord (thank you!) from #859, which removed jQuery and broke the inline `onclick` handler in the previous implementation.

One small browser compatibility note: `<details>` is not supported by Internet Explorer, however it fails "open" (the content is displayed but there's no toggle functionality). So, I didn't bother adding a polyfill. Here's what it looks like in IE:

![image](https://user-images.githubusercontent.com/855595/142224695-0a376f09-22f9-44ff-bd79-9148a94382bd.png)
