### PR TITLE
documenting ddl_strategy flags and migration_context

### DIFF
--- a/content/en/docs/user-guides/schema-changes/audit-and-control.md
+++ b/content/en/docs/user-guides/schema-changes/audit-and-control.md
@@ -1,6 +1,6 @@
 ---
 title: Applying, auditing, and controlling Online DDL
-weight: 5
+weight: 6
 aliases: ['/docs/user-guides/managed-online-schema-changes/audit-and-control']
 ---
 
@@ -60,7 +60,20 @@ You may use `vtctl` or `vtctlclient` (the two are interchangeable for the purpos
 $ vtctlclient ApplySchema -ddl_strategy "online" -sql "ALTER TABLE demo MODIFY id bigint UNSIGNED" commerce
 a2994c92_f1d4_11ea_afa3_f875a4d24e90
 ```
- 
+
+ You my run multiple migrations withing the same `ApplySchema` command:
+```shell
+$ vtctlclient ApplySchema -skip_preflight -ddl_strategy "online" -sql "ALTER TABLE demo MODIFY id bigint UNSIGNED; CREATE TABLE sample (id int PRIMARY KEY); DROP TABLE another;" commerce
+3091ef2a_4b87_11ec_a827_0a43f95f28a3
+```
+
+`ApplySchema` accepts the following flags:
+
+- `-ddl_strategy`: by default migrations run directly via MySQL standard DDL. This flag must be aupplied to indicate an online strategy. See also [DDL strategies](../ddl-strategies) and [ddl_strategy flags](../ddl-strategy-flags).
+- `-request_context <unique-value>`: all migrations in a `ApplySchema` command are logically grouped via a unique _context_. A unique value will be supplied automatically. The user may choose to supply their own value, and it's their responsibility to provide with a unique value. Any string format is accepted.
+  The context can then be used to search for migrations, via `SHOW VITESS_MIGRATIONS LIKE 'the-context'`. It is visible in `SHOW VITESS_MIGRATIONS ...` output as the `migration_context` column.
+- `-skip_preflight`: skip an internal Vitess schema validation. When running an online DDL it's recommended to add `-skip_preflight`. In future Vitess versions this flag may be removed or default to `true`.
+
 ## Tracking migrations
 
 You may track the status of a single or of multiple migrations. Since migrations run asycnhronously, it is the user's responsibility to audit the progress and state of submitted migrations. Users are likely to want to know when a migration is complete (or failed) so as to be able to deploy code changes or run other operations.

--- a/content/en/docs/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/user-guides/schema-changes/ddl-strategies.md
@@ -13,6 +13,8 @@ Vitess supports both managed, online schema migrations (aka Online DDL) as well 
 
 `CREATE` and `DROP` are managed in the same way, by Vitess, whether strategy is `online`, `gh-ost` or `pt-osc`.
 
+See also [ddl_strategy flags](../ddl-strategy-flags).
+
 ## Specifying a DDL strategy
 
 You will set either `@@ddl_strategy` session variable, or `-ddl_strategy` command line flag. Examples:

--- a/content/en/docs/user-guides/schema-changes/ddl-strategy-flags.md
+++ b/content/en/docs/user-guides/schema-changes/ddl-strategy-flags.md
@@ -1,0 +1,33 @@
+---
+title: ddl_strategy flags
+weight: 4
+aliases: ['/docs/user-guides/schema-changes/ddl-strategy-flags/']
+---
+
+[`ddl_strategy`](../ddl-strategies) accepts flags in command line format. The flags can be vitess-specific, or, if unrecognized by Vitess, are passed on the underlying online schema change tools.
+
+## Vitess flags
+
+Vitess respects the following flags. They can be combined unless specifically indicated otherwise:
+
+- `-allow-zero-in-date`: normally Vitess operates with a strict `sql_mode`. If you have columns such as `my_datetime DATETIME DEFAULT '0000-00-00 00:00:00'` and you wish to run DDL on these tables, Vitess will prevent the migration due to invalid values. Provide `-allow-zero-in-date` to allow either a fully zero-date or a zero-in-date inyour schema. See also [NO_ZERO_IN_DATE](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_in_date) and [NO_ZERO_DATE](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_date) documentation for [sql_mode](https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html).
+- `-declarative`: mark the migration as declarative. You will define a desired schema state by supplying `CREATE` and `DROP` statements, ad Vitess will infer how to achieve the desired schema. If need be, it will generate an `ALTER` migration to convert to the new schema. See [declarative migrations](../declarative-migrations).
+- `-postpone-completion`: initiate a migration that will only cut-over per user command, i.e. will not auto-complete. This gives the user control over the time when the schema change takes effect. See [postponed migrations](../postponed-migrations).
+- `-singleton`: only allow a single pending migration to be submitted at a time. From the moment the migration is queued, and until either completion, failure or cancellation, no other new `-singleton` migration can be submitted. New requests will be rejected with error. `-singleton` works as a an exclusive lock for pending migrations. Note that this only affects migrations with `-singleton` flag. Migrations running without that flag are unaffected and unblocked.
+- `-singleton-context`: only allow migrations submitted under same _context_ to be pending at any given time. Migrations submitted with a different _context_ are rejected for as long as at least one of the initially submitted migrations is pending.
+
+## Pass-through flags
+
+Flags unrecognized by Vitess are passed on to the underlying schema change tools. For example, a `gh-ost` migration can run with:
+```sql
+set @@ddl_strategy='gh-ost --max-load Threads_running=200'
+```
+Since Vitess knows nothing about `--max-load` it will pass it on as a command line argument to `gh-ost`. Consult [gh-ost documentation](https://github.com/github/gh-ost) for supported command line flags.
+
+Similarly, a `pt-online-schema-change` migration can run with:
+```sql
+set @@ddl_strategy='pt-osc --null-to-not-null'
+```
+Consult [pt-online-schema-change documentation](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html) for supported command line flags.
+
+The `online` strategy uses Vitess internal mechanisms and is not a standalone command line tool. therefore, it has no particular command line flags. For internal testing/CI purposes, the `online` strategy supports `-vreplication-test-suite`, and this flag must **not** be used in production as it can have destructive consequences.

--- a/content/en/docs/user-guides/schema-changes/declarative-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/declarative-migrations.md
@@ -1,6 +1,6 @@
 ---
 title: Declarative migrations
-weight: 6
+weight: 11
 aliases: ['/docs/user-guides/schema-changes/declarative-migrations/']
 ---
 

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -35,8 +35,6 @@ As general overview:
 
 The standard MySQL syntax for `CREATE`, `ALTER` and `DROP` is supported.
 
-
-
 ### ALTER TABLE
 
 Use the standard MySQL `ALTER TABLE` syntax to run online DDL. Whether your schema migration runs synchronously (the default MySQL behavior) or asynchronously (aka online), is determined by `ddl_strategy`.
@@ -92,6 +90,8 @@ You will set either `@@ddl_strategy` session variable, or `-ddl_strategy` comman
 
 `CREATE` and `DROP` statements run in the same way for `"online"`, `"gh-ost"` and `"pt-osc"` strategies, and we consider them all to be _online_.
 
+See also [ddl_strategy flags](../ddl-strategy-flags).
+
 ## Running, tracking and controlling Online DDL
 
 Vitess provides two interfaces to interacting with Online DDL:
@@ -133,9 +133,21 @@ mysql> drop table customer;
 #### Executing an Online DDL via vtctl/ApplySchema
 
 ```shell
-$ vtctlclient ApplySchema -ddl_strategy "online" -sql "ALTER TABLE demo MODIFY id bigint UNSIGNED" commerce
+$ vtctlclient ApplySchema -skip_preflight -ddl_strategy "online" -sql "ALTER TABLE demo MODIFY id bigint UNSIGNED" commerce
 a2994c92_f1d4_11ea_afa3_f875a4d24e90
 ```
+You my run multiple migrations withing the same `ApplySchema` command:
+```shell
+$ vtctlclient ApplySchema -skip_preflight -ddl_strategy "online" -sql "ALTER TABLE demo MODIFY id bigint UNSIGNED; CREATE TABLE sample (id int PRIMARY KEY); DROP TABLE another;" commerce
+3091ef2a_4b87_11ec_a827_0a43f95f28a3
+```
+
+`ApplySchema` accepts the following flags:
+
+- `-ddl_strategy`: by default migrations run directly via MySQL standard DDL. This flag must be aupplied to indicate an online strategy. See also [DDL strategies](../ddl-strategies) and [ddl_strategy flags](../ddl-strategy-flags).
+- `-request_context <unique-value>`: all migrations in a `ApplySchema` command are logically grouped via a unique _context_. A unique value will be supplied automatically. The user may choose to supply their own value, and it's their responsibility to provide with a unique value. Any string format is accepted.
+  The context can then be used to search for migrations, via `SHOW VITESS_MIGRATIONS LIKE 'the-context'`. It is visible in `SHOW VITESS_MIGRATIONS ...` output as the `migration_context` column.
+- `-skip_preflight`: skip an internal Vitess schema validation. When running an online DDL it's recommended to add `-skip_preflight`. In future Vitess versions this flag may be removed or default to `true`.
 
 ## Migration flow and states
 

--- a/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/user-guides/schema-changes/managed-online-schema-changes.md
@@ -28,7 +28,7 @@ As general overview:
 - Tablets will independently run schema migrations:
   - `ALTER TABLE` statements run via `VReplication`, `gh-ost` or `pt-online-schema-change`, as per selected [strategy](../ddl-strategies)
   - `CREATE TABLE` statements run directly.
-  - `DROP TABLE` statements run [safely and lazily](../../../reference/features/table-lifecycle/).
+  - `DROP TABLE` statements run [safely and lazily](../../../design-docs/table-lifecycle/safe-lazy-drop-tables/).
 - Vitess provides the user a mechanism to view migration status, cancel or retry migrations, based on the job ID.
 
 ## Syntax

--- a/content/en/docs/user-guides/schema-changes/postponed-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/postponed-migrations.md
@@ -1,6 +1,6 @@
 ---
 title: Postponed migrations
-weight: 7
+weight: 12
 aliases: ['/docs/user-guides/schema-changes/postponed-migrations/']
 ---
 

--- a/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/recoverable-migrations.md
@@ -1,6 +1,6 @@
 ---
 title: Recoverable, failover agnostic migrations
-weight: 10
+weight: 13
 aliases: ['/docs/user-guides/schema-changes/recoverable-migrations/']
 ---
 

--- a/content/en/docs/user-guides/schema-changes/revertible-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/revertible-migrations.md
@@ -1,6 +1,6 @@
 ---
 title: Revertible migrations
-weight: 11
+weight: 14
 aliases: ['/docs/user-guides/schema-changes/revertible-migrations/']
 ---
 

--- a/content/en/docs/user-guides/schema-changes/revertible-migrations.md
+++ b/content/en/docs/user-guides/schema-changes/revertible-migrations.md
@@ -218,7 +218,7 @@ mysql> select * from t;
 
 Revert for `CREATE` and `DROP` are implemented similarly for all online strategies.
 
-- The revert for a `CREATE` DDL is to rename the table away and into a [table lifecycle](../../../reference/features/table-lifecycle/) name, rather than actually `DROP` it. This keeps th etale safe for a period of time, and makes it possible to reinstate the table, populated with all data, via a 2nd revert.
+- The revert for a `CREATE` DDL is to rename the table away and into a [table lifecycle](../table-lifecycle/) name, rather than actually `DROP` it. This keeps th etale safe for a period of time, and makes it possible to reinstate the table, populated with all data, via a 2nd revert.
 - The revert for a `DROP` relies on the fact that Online DDL `DROP TABLE` does not, in fact, drop the table, but actually rename it away. Thus, reverting the `DROP` is merely a `RENAME` back into its original place.
 - The revert for `ALTER` is only available for `online` strategy, implemented by `VReplication`. VReplication keep track of a DDL migration by writing down the GTID position through the migration flow. In particular, at time of cut-over and when tables are swapped, VReplication notes the _final_ GTID pos for the migration.
   When a revert is requested, Vitess computes a new VReplication rule/filter for the new stream. It them copies the _final_ GTID pos from the reverted migration, and instructs VReplication to resume from that point.

--- a/content/en/docs/user-guides/schema-changes/table-lifecycle.md
+++ b/content/en/docs/user-guides/schema-changes/table-lifecycle.md
@@ -1,6 +1,6 @@
 ---
 title: Table lifecycle
-weight: 4
+weight: 5
 aliases: ['/docs/user-guides/table-lifecycle/','/docs/reference/table-lifecycle/', 'docs/reference/features/table-lifecycle/']
 ---
 


### PR DESCRIPTION
Related issue: https://github.com/vitessio/website/issues/888 

this PR Documents the supported `ddl_strategies`:

- `-allow-zero-in-date`
- `-declarative`
- `-singleton`
- `-singleton-context`
- `-postpone-completion`

As well as the internal `-vreplication-test-suite` flag.

It also documents `vtctl ApplySchema -request_context` and explains what a context is.

- `-allow-concurrent` (introduced in https://github.com/vitessio/vitess/pull/9192, unmerged yet) will be covered in a different PR.
