### PR TITLE
Adds planner_version documentation for the vttestserver image

### DIFF
--- a/content/en/docs/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/get-started/vttestserver-docker-image.md
@@ -63,6 +63,7 @@ The docker image expects some of the environment variables to be set to function
 | *FOREIGN_KEY_MODE* | no | This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow (default), disallow. |
 | *ENABLE_ONLINE_DDL* | no | Allow users to submit, review and control Online DDL. Valid values are: true (default), false. |
 | *ENABLE_DIRECT_DDL* | no | Allow users to submit direct DDL statements. Valid values are: true (default), false. |
+| *PLANNER_VERSION* | no | Sets the default planner to use when the session has not changed it. Valid values are: V3 (default), Gen4, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the new gen4 planner and falls back to the V3 planner if the gen4 fails. |
 
 Environment variables in docker can be specified using the `-e` aka `--env` flag.
 
@@ -76,7 +77,7 @@ run` command will publish the container's 33577 port to your local 33577 port, w
 An example command to run the docker image is as follows :
 
 ```shell
-docker run --name=vttestserver -p 33577:33577 -e PORT=33574 -e KEYSPACES=test,unsharded -e NUM_SHARDS=2,1 -e MYSQL_MAX_CONNECTIONS=70000 -e MYSQL_BIND_HOST=0.0.0.0 --health-cmd="mysqladmin ping -h127.0.0.1 -P33577" --health-interval=5s --health-timeout=2s --health-retries=5 vitess/vttestserver:mysql57
+docker run --name=vttestserver -p 33577:33577 -e PORT=33574 -e PLANNER_VERSION=gen4fallback -e KEYSPACES=test,unsharded -e NUM_SHARDS=2,1 -e MYSQL_MAX_CONNECTIONS=70000 -e MYSQL_BIND_HOST=0.0.0.0 --health-cmd="mysqladmin ping -h127.0.0.1 -P33577" --health-interval=5s --health-timeout=2s --health-retries=5 vitess/vttestserver:mysql57
 ```
 
 Now, we can connect to the vtgate from a MySQL client as follows :


### PR DESCRIPTION
The PR https://github.com/vitessio/vitess/pull/9296 added the support of specifying the planner_version in the vttestserver image. This PR adds the associated documentation for the change.