### PR TITLE
Versioning prep work

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,9 @@ pygmentsCodeFences = true
 pygmentsUseClasses = false
 pygmentsStyle = "fruity"
 
+[params.versions]
+latest = "12.0"
+
 [params.assets]
 js = ["app"]
 fontawesomeversion = "5.7.2"
@@ -118,3 +121,14 @@ icon = "magic"
 
 [markup.goldmark.renderer]
 unsafe = true
+
+[mediaTypes]
+"text/netlify" = { }
+
+[outputFormats.REDIRECTS]
+mediaType = "text/netlify"
+baseName = "_redirects"
+notAlternative = true
+
+[outputs]
+home = [ "HTML", "REDIRECTS", "RSS" ]

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,3 +1,5 @@
+{{ $latest := site.Params.versions.latest }}
+
 /vitess/*   go-get=1 /go-import/vitess.html   200
 /messages/* go-get=1 /go-import/messages.html 200
 /operator/* go-get=1 /go-import/operator.html 200
@@ -41,3 +43,5 @@
 # RSS URL Redirect
 /blog/rss          /blog/index.xml	 301
 
+# Redirect to Slack invite link.
+/slack https://join.slack.com/t/vitess/shared_invite/zt-rbtfk682-uqBu8WCyAUEDLFpydt1BOQ 302

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,9 +13,3 @@ command = "make preview-build"
 
 [context.branch-deploy]
 command = "make preview-build"
-
-# Redirect to Slack invite link.
-[[redirects]]
-from = "/slack"
-to = "https://join.slack.com/t/vitess/shared_invite/zt-rbtfk682-uqBu8WCyAUEDLFpydt1BOQ"
-status = 302


### PR DESCRIPTION
Some prep work for PR #907 
Contributes to #625 

Moving `static/_redirects` -> `layouts/index.redirects`
Consolidating all redirects in new `layouts/index.redirects` file
Adding sample variable in new `layouts/index.redirects` file for #907 prep
Updating `config.toml`:
  * for use with new `layouts/index.redirects` file
  * with `[params.versions]` `latest`