### PR TITLE
Updating v12 and v13 descriptions to be shorter 

### DIFF
--- a/content/en/docs/12.0/_index.md
+++ b/content/en/docs/12.0/_index.md
@@ -1,6 +1,8 @@
 ---
-title: v12.0 (Latest release)
-description: Everything you need to know about the world's most scalable open-source MySQL platform
+title: v12.0 (Current release)
+description: >
+  Most recent release.
+  Everything you need to know about the world's most scalable open-source MySQL platform.
 notoc: true
 cascade:
   version: v12.0

--- a/content/en/docs/13.0/_index.md
+++ b/content/en/docs/13.0/_index.md
@@ -1,6 +1,8 @@
 ---
-title: v13.0 (Under construction, upcoming release)
-description: Everything you need to know about the world's most scalable open-source MySQL platform
+title: v13.0 (Future release)
+description: > 
+  Under construction, upcoming release.
+  Everything you need to know about the world's most scalable open-source MySQL platform.
 notoc: true
 cascade:
   version: v13.0

--- a/content/zh/docs/12.0/_index.md
+++ b/content/zh/docs/12.0/_index.md
@@ -1,6 +1,6 @@
 ---
-title: v12.0 (Latest release)
-description: 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
+title: v12.0 (Current release)
+description: Most recent release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:
   version: v12.0

--- a/content/zh/docs/13.0/_index.md
+++ b/content/zh/docs/13.0/_index.md
@@ -1,6 +1,6 @@
 ---
-title: v13.0 (Under construction, upcoming release)
-description: 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
+title: v13.0 (Future release)
+description: Under construction, upcoming release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:
   version: v13.0


### PR DESCRIPTION
Followup to #907 

Updating v12 and v13 descriptions [en & zh] to be shorter (and friendlier for the breadcrumb menu)

## Deploy previews

### en

https://deploy-preview-918--vitess.netlify.app/docs/
https://deploy-preview-918--vitess.netlify.app/docs/12.0/
https://deploy-preview-918--vitess.netlify.app/docs/13.0/

### zh

https://deploy-preview-918--vitess.netlify.app/zh/docs/
https://deploy-preview-918--vitess.netlify.app/zh/docs/12.0/
https://deploy-preview-918--vitess.netlify.app/zh/docs/13.0/