### PR TITLE
Tablet types are now case-insensitive for SwitchTraffic and ReverseTraffic

### DIFF
--- a/content/en/docs/13.0/reference/vreplication/reversetraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/reversetraffic.md
@@ -43,10 +43,6 @@ specified tablet types.
 A comma-separated list of tablet types for which traffic is to be reversed.
 One or more from primary, replica, rdonly.<br><br>
 
-{{< info >}}
-Note: ReverseTraffic expects the `-tablet_types` to be lower case.
-{{< /info >}}
-
 </div>
 
 

--- a/content/en/docs/13.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/switchtraffic.md
@@ -43,10 +43,6 @@ specified tablet types.
 A comma-separated list of tablet types for which traffic is to be switched.
 One or more from primary,replica,rdonly.<br><br>
 
-{{< info >}}
-Note: SwtichTraffic expects the `-tablet_types` to be lower case.
-{{< /info >}}
-
 </div>
 
 #### -timeout


### PR DESCRIPTION
Documentation change for https://github.com/vitessio/vitess/pull/9440