### PR TITLE
Add some minor clarifications for sequences

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ package-lock.json
 # vim files
 *.swp
 tags
+
+# vscode files
+.vscode/


### PR DESCRIPTION
This does the following:
 - Removes comments regarding past implementations and comments about long term goals as these produce clutter and noise when we want clarity
 - Helps to better clarify how vitess sequences compare to MySQL auto_increment columns
 - Adds a note that `bigint unsigned` columns are not supported in the backing table
 - Adds additional language on the fact that the sequences must live in an unsharded keyspace and that they are served from a cache maintained on the primary serving tablet of that unsharded keyspace
 - Adds a section on initializing a sequence to clarify/highlight this need and how to do it

Addresses: https://github.com/vitessio/vitess/issues/3331