### PR TITLE
Correct mysql compat links & remove 5.6 in 13.0 doc

### DIFF
--- a/content/en/docs/11.0/overview/supported-databases.md
+++ b/content/en/docs/11.0/overview/supported-databases.md
@@ -10,7 +10,7 @@ The [VTGate](../../concepts/vtgate/) proxy server advertises its version as MySQ
 
 ## MySQL versions 5.6 to 8.0
 
-Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](../../reference/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0.
+Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](../../reference/compatibility/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0.
 
 With MySQL 5.6 reaching end of life in February 2021, it is recommended to deploy MySQL 5.7 and later.
 
@@ -24,4 +24,4 @@ Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does
 
 ## See also
 
-+ [MySQL Compatibility](../../reference/mysql-compatibility/)
++ [MySQL Compatibility](../../reference/compatibility/mysql-compatibility/)

--- a/content/en/docs/12.0/overview/supported-databases.md
+++ b/content/en/docs/12.0/overview/supported-databases.md
@@ -10,7 +10,7 @@ The [VTGate](../../concepts/vtgate/) proxy server advertises its version as MySQ
 
 ## MySQL versions 5.6 to 8.0
 
-Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](../../reference/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0.
+Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](../../reference/compatibility/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0.
 
 With MySQL 5.6 reaching end of life in February 2021, it is recommended to deploy MySQL 5.7 and later.
 
@@ -24,4 +24,4 @@ Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does
 
 ## See also
 
-+ [MySQL Compatibility](../../reference/mysql-compatibility/)
++ [MySQL Compatibility](../../reference/compatibility/mysql-compatibility/)

--- a/content/en/docs/13.0/overview/supported-databases.md
+++ b/content/en/docs/13.0/overview/supported-databases.md
@@ -8,15 +8,9 @@ Vitess deploys, scales and manages clusters of open-source SQL database instance
 
 The [VTGate](../../concepts/vtgate/) proxy server advertises its version as MySQL 5.7.
 
-## MySQL versions 5.6 to 8.0
+## MySQL versions 5.7 to 8.0
 
-Vitess supports the core features of MySQL versions 5.6 to 8.0, with [some limitations](../../reference/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.6 to 8.0.
-
-With MySQL 5.6 reaching end of life in February 2021, it is recommended to deploy MySQL 5.7 and later.
-
-{{< warning >}}
-MySQL and Percona 5.6 are no longer supported in Vitess 13.0 and later
-{{< /warning >}}
+Vitess supports the core features of MySQL versions 5.7 to 8.0, with [some limitations](../../reference/compatibility/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.7 to 8.0.
 
 ## MariaDB versions 10.0 to 10.3
 
@@ -24,4 +18,4 @@ Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does
 
 ## See also
 
-+ [MySQL Compatibility](../../reference/mysql-compatibility/)
++ [MySQL Compatibility](../../reference/compatibility/mysql-compatibility/)


### PR DESCRIPTION
This addresses the issue reported here: https://github.com/vitessio/vitess/issues/9445#issuecomment-1004847120

For the reviewers, these are the links to the pages:
 - https://deploy-preview-933--vitess.netlify.app/docs/12.0/overview/supported-databases/
 - https://deploy-preview-933--vitess.netlify.app/docs/13.0/overview/supported-databases/