### PR TITLE
Fixes for v13 links 

### DIFF
--- a/content/en/docs/11.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/11.0/user-guides/schema-changes/_index.md
@@ -71,7 +71,7 @@ When using either managed schema changes, or direct schema changes via `vtctl` o
 
 ### Schedule
 
-In managed, online schema changes, Vitess owns and tracks all pending and active migrations. As a rule of thumb, it is generally advisable to only run one online schema change at a time on a given server. Following that rule of thumb, Vitess will by default queue incoming schema change requests and schedule them to run sequentially. There are cases for concurrent execution, and Vitess is able to run some types of migrations concurrently. See [concurrent migrations](./concurrent-migrations).
+In managed, online schema changes, Vitess owns and tracks all pending and active migrations. As a rule of thumb, it is generally advisable to only run one online schema change at a time on a given server. Following that rule of thumb, Vitess will queue incoming schema change requests and schedule them to run sequentially.
 
 ### Execute
 

--- a/content/en/docs/13.0/concepts/vschema.md
+++ b/content/en/docs/13.0/concepts/vschema.md
@@ -2,9 +2,8 @@
 title: VSchema
 ---
 
-A [VSchema](../../reference/vschema) allows you to describe how data is organized within keyspaces and shards. This information is used for routing queries, and also during resharding operations.
+A [VSchema](../../reference/features/vschema) allows you to describe how data is organized within keyspaces and shards. This information is used for routing queries, and also during resharding operations.
 
 For a Keyspace, you can specify if it's sharded or not. For sharded keyspaces, you can specify the list of vindexes for each table.
 
 Vitess also supports [sequence generators](../../reference/features/vitess-sequences/) that can be used to generate new ids that work like MySQL auto increment columns. The VSchema allows you to associate table columns to sequence tables. If no value is specified for such a column, then VTGate will know to use the sequence table to generate a new value for it.
-

--- a/content/en/docs/13.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/13.0/reference/compatibility/mysql-compatibility.md
@@ -16,7 +16,7 @@ The following describes some of the major differences in SQL Syntax handling bet
 
 ### DDL                                                                      
 
-Vitess supports MySQL DDL, and will send `ALTER TABLE` statements to each of the underlying tablet servers. For large tables it is recommended to use an external schema deployment tool and apply directly to the underlying MySQL shard instances. This is discussed further in [Applying MySQL Schema](../../../user-guides/operating-vitess/making-schema-changes).
+Vitess supports MySQL DDL, and will send `ALTER TABLE` statements to each of the underlying tablet servers. For large tables it is recommended to use an external schema deployment tool and apply directly to the underlying MySQL shard instances. This is discussed further in [Applying MySQL Schema](../../../user-guides/schema-changes).
 
 ### Join Queries
 

--- a/content/en/docs/13.0/reference/features/mysql-replication.md
+++ b/content/en/docs/13.0/reference/features/mysql-replication.md
@@ -8,7 +8,7 @@ aliases: ['/docs/reference/row-based-replication/','/docs/reference/vitess-repli
 Vitess requires the use of Row-Based Replication with GTIDs enabled. In addition, Vitess only supports the default `binlog_row_image` of `FULL`.
 {{< /warning >}}
 
-Vitess makes use of MySQL Replication for both high availability and to receive a feed of changes to database tables. This feed is then used in features such as [VReplication](../vreplication), and to identify schema changes so that caches can be updated.
+Vitess makes use of MySQL Replication for both high availability and to receive a feed of changes to database tables. This feed is then used in features such as [VReplication](../../vreplication/vreplication/), and to identify schema changes so that caches can be updated.
 
 ## Semi-Sync
 

--- a/content/en/docs/13.0/reference/programs/vtctl/_index.md
+++ b/content/en/docs/13.0/reference/programs/vtctl/_index.md
@@ -78,9 +78,9 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 | [RebuildKeyspaceGraph](../vtctl/keyspaces#rebuildkeyspacegraph) | `RebuildKeyspaceGraph  [-cells=c1,c2,...] <keyspace> ...` |
 | [ValidateKeyspace](../vtctl/keyspaces#validatekeyspace) | `ValidateKeyspace  [-ping-tablets] <keyspace name>` |
 | [Reshard (v1)](../../vreplication/v1/reshard) | `Reshard  -v1 [-skip_schema_copy] <keyspace.workflow> <source_shards> <target_shards>` |
-| [Reshard (v2)](../../vreplication/v2/reshard) | `Reshard <options> <action> <workflow identifier>` |
+| [Reshard (v2)](../../vreplication/reshard) | `Reshard <options> <action> <workflow identifier>` |
 | [MoveTables (v1)](../../vreplication/v1/movetables) | `MoveTables  -v1 [-cell=<cell>] [-tablet_types=<source_tablet_types>] -workflow=<workflow> <source_keyspace> <target_keyspace> <table_specs>` |
-| [MoveTables (v2)](../../vreplication/v2/movetables) | `MoveTables  <options> <action> <workflow identifier>` |
+| [MoveTables (v2)](../../vreplication/movetables) | `MoveTables  <options> <action> <workflow identifier>` |
 | [DropSources](../../vreplication/v1/dropsources) | `DropSources  [-dry_run] <keyspace.workflow>` |
 | [CreateLookupVindex](../vtctl/keyspaces#createLookupvindex) | `CreateLookupVindex  [-cell=<cell>] [-tablet_types=<source_tablet_types>] <keyspace> <json_spec>` |
 | [ExternalizeVindex](../vtctl/keyspaces#externalizevindex) | `ExternalizeVindex  <keyspace>.<vindex>` |

--- a/content/en/docs/13.0/resources/presentations.md
+++ b/content/en/docs/13.0/resources/presentations.md
@@ -288,7 +288,7 @@ Please note the Vitess on Kubernetes deployment templates were removed as of Feb
 
 ## Oracle OpenWorld 2015
 
-Vitess team member [Anthony Yeh](https://github.com/enisoc)'s talk at Oracle OpenWorld 2015 focused on what the [Cloud Native Computing](http://cncf.io) paradigm means when applied to MySQL in the cloud. The talk also included a deep dive into [transparent, live resharding](../../sharding), one of the key
+Vitess team member [Anthony Yeh](https://github.com/enisoc)'s talk at Oracle OpenWorld 2015 focused on what the [Cloud Native Computing](http://cncf.io) paradigm means when applied to MySQL in the cloud. The talk also included a deep dive into [transparent, live resharding](../../reference/features/sharding/), one of the key
 features of Vitess that makes it well-adapted for a Cloud Native environment.
 
 {{< pdf src="/ViewerJS/#../files/openworld-2015-vitess.pdf" >}}

--- a/content/en/docs/13.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/13.0/user-guides/configuration-advanced/comment-directives.md
@@ -34,7 +34,7 @@ As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in millisec
 
 ## Multi-shard Autocommit (`MULTI_SHARD_AUTOCOMMIT`)
 
-Using this in, for example, an insert statement will cause individual shard autocommit to be used for the shards where the rows for the insert are routed. This means that if one of the individual shard inserts fails, it will not be possible to roll back the inserts on all the other shards. This is the default behavior. A helpful way to think of this is as best-effort cross-shard writes, with the application being responsible for repairs in the case of errors. For an example, read our [Shard Isolation and Atomicity guide](../../shard-isolation-atomicity/#method-1--the-naive-way).
+Using this in, for example, an insert statement will cause individual shard autocommit to be used for the shards where the rows for the insert are routed. This means that if one of the individual shard inserts fails, it will not be possible to roll back the inserts on all the other shards. This is the default behavior. A helpful way to think of this is as best-effort cross-shard writes, with the application being responsible for repairs in the case of errors. For an example, read our [Shard Isolation and Atomicity guide](../../configuration-advanced/shard-isolation-atomicity/#method-1--the-naive-way).
 
 ## Skip query plan cache (`SKIP_QUERY_PLAN_CACHE`)
 

--- a/content/en/docs/13.0/user-guides/configuration-advanced/integration-with-orchestrator.md
+++ b/content/en/docs/13.0/user-guides/configuration-advanced/integration-with-orchestrator.md
@@ -8,7 +8,7 @@ aliases: ['/docs/user-guides/integration-with-orchestrator/']
 
 For the most part, Vitess is agnostic to the actions of Orchestrator, which operates below Vitess at the MySQL level. That means you can pretty much [set up Orchestrator](https://github.com/github/orchestrator/wiki/Orchestrator-Manual) in the normal way, with just a few additions as described below.
 
-For the [Kubernetes](../../../get-started/kubernetes) example, we provide a sample script to launch Orchestrator for you with these settings applied.
+For the [Kubernetes](../../../get-started/operator) example, we provide a sample script to launch Orchestrator for you with these settings applied.
 
 ## Orchestrator configuration
 
@@ -23,7 +23,7 @@ Orchestrator needs to know some things from the Vitess side, like the tablet ali
 
 Vitess also needs to know the identity of the primary for each shard. This is necessary in case of a failover.
 
-It is important to ensure that orchestrator has access to `vtctlclient` so that orchestrator can trigger the change in topology via the [`TabletExternallyReparented`](../../../reference/vtctl/shards/#tabletexternallyreparented) command.
+It is important to ensure that orchestrator has access to `vtctlclient` so that orchestrator can trigger the change in topology via the [`TabletExternallyReparented`](../../../reference/programs/vtctl/shards/#tabletexternallyreparented) command.
 
 ``` json
 "PostMasterFailoverProcesses": [

--- a/content/en/docs/13.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/13.0/user-guides/configuration-advanced/region-sharding.md
@@ -10,7 +10,7 @@ This guide follows on from the Get Started guides. Please make sure that you hav
 
 ## Preparation
 
-Having gone through the Resharding tutorial, you should be familiar with [VSchema](../../../concepts/vschema) and [Vindexes](../../../reference/vindexes).
+Having gone through the Resharding tutorial, you should be familiar with [VSchema](../../../concepts/vschema) and [Vindexes](../../../reference/features/vindexes).
 In this tutorial, we will perform resharding on an existing keyspace using a location-based vindex. We will create 4 shards (-40, 40-80, 80-c0, c0-).
 The location will be denoted by a `country` column.
 

--- a/content/en/docs/13.0/user-guides/configuration-advanced/reparenting.md
+++ b/content/en/docs/13.0/user-guides/configuration-advanced/reparenting.md
@@ -74,7 +74,7 @@ This command performs the following actions:
 
 ## External Reparenting
 
-External reparenting occurs when another tool handles the process of changing a shard's primary tablet. After that occurs, the tool needs to call the [`vtctl TabletExternallyReparented`](../../../reference/vtctl/shards/#tabletexternallyreparented) command to ensure that the topology service, replication graph, and serving graph are updated accordingly.
+External reparenting occurs when another tool handles the process of changing a shard's primary tablet. After that occurs, the tool needs to call the [`vtctl TabletExternallyReparented`](../../../reference/programs/vtctl/shards/#tabletexternallyreparented) command to ensure that the topology service, replication graph, and serving graph are updated accordingly.
 
 That command performs the following operations:
 

--- a/content/en/docs/13.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/13.0/user-guides/configuration-advanced/resharding.md
@@ -10,7 +10,7 @@ This guide follows on from the Get Started guides. Please make sure that you hav
 
 ## Preparation
 
-[Resharding](../../../concepts/shard) enables you to both _initially shard_ and reshard tables so that your keyspace is partitioned across several underlying [tablets](../../../concepts/tablet). A sharded keyspace has some additional restrictions on both [query syntax](../../../reference/mysql-compatibility) and features such as `auto_increment`, so it is helpful to plan out a reshard operation diligently. However, you can always _reshard again_ if your sharding scheme turns out to be suboptimal.
+[Resharding](../../../concepts/shard) enables you to both _initially shard_ and reshard tables so that your keyspace is partitioned across several underlying [tablets](../../../concepts/tablet). A sharded keyspace has some additional restrictions on both [query syntax](../../../reference/compatibility/mysql-compatibility) and features such as `auto_increment`, so it is helpful to plan out a reshard operation diligently. However, you can always _reshard again_ if your sharding scheme turns out to be suboptimal.
 
 Using our example commerce and customer keyspaces, lets work through the two most common issues.
 
@@ -190,7 +190,7 @@ vtctlclient Reshard -source_shards '0' -target_shards '-80,80-' Create customer.
 vtctlclient Reshard -source_shards '-' -target_shards '-80,80-' Create customer.cust2cust
 ```
 
-All of the command options and parameters for `Reshard` are listed in our [reference page for Reshard](../../../reference/vreplication/v2/reshard).
+All of the command options and parameters for `Reshard` are listed in our [reference page for Reshard](../../../reference/vreplication/reshard).
 
 ## Validate Correctness
 

--- a/content/en/docs/13.0/user-guides/configuration-basic/exporting-data.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/exporting-data.md
@@ -23,7 +23,7 @@ to the database while running the dump.
 
 ### mysqldump
 
-The default invocation of `mysqldump` attempts to execute statements which are [not supported by Vitess](../../../reference/mysql-compatibility/), such as attempting to lock tables and dump GTID coordinates. The following options are required when using the `mysqldump` binary from MySQL 5.7 to export data from the `commerce` keyspace:
+The default invocation of `mysqldump` attempts to execute statements which are [not supported by Vitess](../../../reference/compatibility/mysql-compatibility/), such as attempting to lock tables and dump GTID coordinates. The following options are required when using the `mysqldump` binary from MySQL 5.7 to export data from the `commerce` keyspace:
 
 * `--lock-tables=off`: VTGate currently prohibits the syntax `LOCK TABLES` and `UNLOCK TABLES`.
 * `--set-gtid-purged=OFF`: `mysqldump` attemps to dump GTID coordinates of a server, but in the case of VTGate this does not make sense since it could be routing to multiple servers.

--- a/content/en/docs/13.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/13.0/user-guides/migration/move-tables.md
@@ -12,7 +12,7 @@ This guide follows on from the Get Started guides. Please make sure that you hav
 
 This feature enables you to move a subset of tables between keyspaces without downtime. For example, after [Initially deploying Vitess](../../../get-started/local), your single commerce schema may grow so large that it needs to be split into multiple keyspaces.
 
-All of the command options and parameters are listed in our [reference page for MoveTables](../../../reference/vreplication/v2/movetables).
+All of the command options and parameters are listed in our [reference page for MoveTables](../../../reference/vreplication/movetables).
 
 As a stepping stone towards splitting a single table across multiple servers (sharding), it usually makes sense to first split from having a single monolithic keyspace (`commerce`) to having multiple keyspaces (`commerce` and `customer`). For example, in our hypothetical ecommerce system we may know that `customer` and `corder` tables are closely related and both growing quickly.
 

--- a/content/en/docs/13.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/13.0/user-guides/schema-changes/_index.md
@@ -71,7 +71,7 @@ When using either managed schema changes, or direct schema changes via `vtctl` o
 
 ### Schedule
 
-In managed, online schema changes, Vitess owns and tracks all pending and active migrations. As a rule of thumb, it is generally advisable to only run one online schema change at a time on a given server. Following that rule of thumb, Vitess will queue incoming schema change requests and schedule them to run sequentially.
+In managed, online schema changes, Vitess owns and tracks all pending and active migrations. As a rule of thumb, it is generally advisable to only run one online schema change at a time on a given server. Following that rule of thumb, Vitess will by default queue incoming schema change requests and schedule them to run sequentially. There are cases for concurrent execution, and Vitess is able to run some types of migrations concurrently. See [concurrent migrations](../concurrent-migrations/).
 
 ### Execute
 

--- a/content/en/docs/13.0/user-guides/schema-changes/audit-and-control.md
+++ b/content/en/docs/13.0/user-guides/schema-changes/audit-and-control.md
@@ -526,7 +526,7 @@ $ vtctlclient OnlineDDL commerce show 2201058f_f266_11ea_bab4_0242c0a8b007
 
 ## Cleaning migration artifacts
 
-Migrations yield artifacts: these are leftover tables, such as the ghost or shadow tables in an `ALTER` DDL. These tables are audited and collected as part of [table lifecycle](../../../reference/features/table-lifecycle/).
+Migrations yield artifacts: these are leftover tables, such as the ghost or shadow tables in an `ALTER` DDL. These tables are audited and collected as part of [table lifecycle](../table-lifecycle/).
 
 The artifacts are essential to [Reverting a migration](../revertible-migrations/), and are kept intact for a while before destroyed.
 

--- a/content/en/docs/13.0/user-guides/sql/vtexplain-in-bulk.md
+++ b/content/en/docs/13.0/user-guides/sql/vtexplain-in-bulk.md
@@ -6,13 +6,13 @@ aliases: ['/docs/user-guides/vtexplain-in-bulk/']
 
 # Introduction 
 
-This document covers the way the [VTexplain tool](../../../reference/vtexplain) can be used to evaluate if Vitess is compatible with a list of SQL statements. Enabling the evaluation of if queries from an existing application that accesses a MySQL database are generally Vitess-compatible. If there are any issues identified they can be used to target any necessary application changes needed for a successful migration from MySQL to Vitess.
+This document covers the way the [VTexplain tool](../../../reference/programs/vtexplain) can be used to evaluate if Vitess is compatible with a list of SQL statements. Enabling the evaluation of if queries from an existing application that accesses a MySQL database are generally Vitess-compatible. If there are any issues identified they can be used to target any necessary application changes needed for a successful migration from MySQL to Vitess.
 
 ## Prerequisites
 
 You can find a prebuilt binary version of the VTexplain tool in [the most recent release of Vitess](https://github.com/vitessio/vitess/releases/).
 
-You can also build the `vtexplain` binary in your environment. To build this binary, refer to the [Build From Source](../../../contributing/build-from-source) guide.
+You can also build the `vtexplain` binary in your environment. To build this binary, refer to the [build guide](../../../contributing) for your OS.
 
 ## Overview
 

--- a/content/en/docs/13.0/user-guides/sql/vtexplain.md
+++ b/content/en/docs/13.0/user-guides/sql/vtexplain.md
@@ -6,13 +6,13 @@ aliases: ['/docs/user-guides/vtexplain/']
 
 # Introduction
 
-This document covers the way Vitess executes a particular SQL statement using the [VTExplain tool](../../../reference/vtexplain). This tool works similarly to the MySQL `EXPLAIN` statement.
+This document covers the way Vitess executes a particular SQL statement using the [VTExplain tool](../../../reference/programs/vtexplain). This tool works similarly to the MySQL `EXPLAIN` statement.
 
 ## Prerequisites
 
 You can find a prebuilt binary version of the VTExplain tool in [the most recent release of Vitess](https://github.com/vitessio/vitess/releases/).
 
-You can also build the `vtexplain` binary in your environment. To build this binary, refer to the [Build From Source](../../../contributing/build-from-source) guide.
+You can also build the `vtexplain` binary in your environment. To build this binary, refer to the [build guide](../../../contributing) for your OS.
 
 ## Overview
 
@@ -48,7 +48,7 @@ CREATE TABLE users_name_idx(
 
 ## 2. Identify a VSchema for the statement's source tables
 
-Next, identify a [VSchema](../../../concepts/vschema) that contains the [Vindexes](../../../reference/vindexes) for the tables in the statement.
+Next, identify a [VSchema](../../../concepts/vschema) that contains the [Vindexes](../../../reference/features/vindexes) for the tables in the statement.
 
 ### The VSchema must use a keyspace name.
 


### PR DESCRIPTION
Fixes for the broken links in v13 after the change to versioned docs. Still need to do v12 and v11.