### PR TITLE
Document the usage of PlannedReparentShard with init_db.sql file

### DIFF
--- a/content/en/docs/13.0/user-guides/configuration-basic/initialize-shard-primary.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/initialize-shard-primary.md
@@ -7,7 +7,9 @@ The [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedrepa
 
 The InitShardPrimary step can also be used to do the same operation. However, it is a destructive command and should only be used by advanced users. This command copies over the `executed_gtid_set` from the primary to the replica which can break replication if the user isn't careful. 
 
-InitShardPrimary must be used in case the users are using a custom `init_db.sql` file in their setup which creates errant GTIDs on the vttablets. If the users have `SET sql_log_bin = 0` in the beginning of their file (like in the example `init_db.sql` file), then PlannedReparentShard will work as expected and it should be used.
+{{< info >}}
+If using a custom `init_db.sql` that omits `SET sql_log_bin = 0`, then InitShardPrimary must be used instead of PlannedReparentShard.
+{{< /info >}}
 
 The command for `InitShardPrimary` is as follows:
 

--- a/content/en/docs/13.0/user-guides/configuration-basic/initialize-shard-primary.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/initialize-shard-primary.md
@@ -7,6 +7,8 @@ The [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedrepa
 
 The InitShardPrimary step can also be used to do the same operation. However, it is a destructive command and should only be used by advanced users. This command copies over the `executed_gtid_set` from the primary to the replica which can break replication if the user isn't careful. 
 
+InitShardPrimary must be used in case the users are using a custom `init_db.sql` file in their setup which creates errant GTIDs on the vttablets. If the users have `SET sql_log_bin = 0` in the beginning of their file (like in the example `init_db.sql` file), then PlannedReparentShard will work as expected and it should be used.
+
 The command for `InitShardPrimary` is as follows:
 
 ```text


### PR DESCRIPTION
Release 13 onwards, we will be able to use PlannedReparentShard to initialise the cluster even with a `init_db.sql` file as long as no errant GTIDs are produced. This PR documents that scenario.