### PR TITLE
Document -max_replication_lag_allowed flag

### DIFF
--- a/content/en/docs/13.0/reference/vreplication/flags.md
+++ b/content/en/docs/13.0/reference/vreplication/flags.md
@@ -1,5 +1,5 @@
 ---
-title: Flags
+title: VTTablet Flags
 description: vttablet flags related to VReplication functionality
 weight: 80
 ---

--- a/content/en/docs/13.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/switchtraffic.md
@@ -69,6 +69,21 @@ If set to false these reverse replication streams will not be created and you wi
 
 </div>
 
+#### -max_transaction_lag_allowed
+**optional**\
+**default**  the value used for `-timeout`
+
+<div class="cmd">
+
+While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise
+report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target. Usually, when VReplication has caught up, this should be very small (under a second).
+
+While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting downtime.
+
+This can also be useful if only reads are being switched: if the lag is too high the app might be reading stale data.
+
+</div>
+
 #### -dry-run
 **optional**\
 **default** false

--- a/content/en/docs/13.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/switchtraffic.md
@@ -75,12 +75,11 @@ If set to false these reverse replication streams will not be created and you wi
 
 <div class="cmd">
 
-While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise
-report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this should be very small (under a second).
+While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise report an error and don't attempt the switch. The calculated VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the last event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this lag should be very small (under a second).
 
-While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting write-unavailability.
+While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. This means that the application can effectively be partially down for this cutover period as writes will pause or error out. While switching write traffic this flag can ensure that you only switch traffic if the current lag is low, thus limiting this period of write-unavailability and avoiding it entirely if we're not likely to catch up within the `-timeout` window.
 
-While switching read traffic this can be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
+While switching read traffic this can also be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
 
 </div>
 

--- a/content/en/docs/13.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/switchtraffic.md
@@ -76,11 +76,11 @@ If set to false these reverse replication streams will not be created and you wi
 <div class="cmd">
 
 While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise
-report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target. Usually, when VReplication has caught up, this should be very small (under a second).
+report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this should be very small (under a second).
 
-While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting downtime.
+While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting write-unavailability.
 
-This can also be useful if only reads are being switched: if the lag is too high the app might be reading stale data.
+While switching read traffic this can be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
 
 </div>
 

--- a/content/en/docs/13.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/13.0/reference/vreplication/switchtraffic.md
@@ -69,7 +69,7 @@ If set to false these reverse replication streams will not be created and you wi
 
 </div>
 
-#### -max_transaction_lag_allowed
+#### -max_replication_lag_allowed
 **optional**\
 **default**  the value used for `-timeout`
 

--- a/content/en/docs/14.0/reference/vreplication/flags.md
+++ b/content/en/docs/14.0/reference/vreplication/flags.md
@@ -1,5 +1,5 @@
 ---
-title: Flags
+title: VTTablet Flags
 description: vttablet flags related to VReplication functionality
 weight: 80
 ---

--- a/content/en/docs/14.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/14.0/reference/vreplication/switchtraffic.md
@@ -75,12 +75,11 @@ If set to false these reverse replication streams will not be created and you wi
 
 <div class="cmd">
 
-While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise
-report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this should be very small (under a second).
+While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise report an error and don't attempt the switch. The calculated VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the last event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this lag should be very small (under a second).
 
-While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting write-unavailability.
+While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. This means that the application can effectively be partially down for this cutover period as writes will pause or error out. While switching write traffic this flag can ensure that you only switch traffic if the current lag is low, thus limiting this period of write-unavailability and avoiding it entirely if we're not likely to catch up within the `-timeout` window.
 
-While switching read traffic this can be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
+While switching read traffic this can also be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
 
 </div>
 

--- a/content/en/docs/14.0/reference/vreplication/switchtraffic.md
+++ b/content/en/docs/14.0/reference/vreplication/switchtraffic.md
@@ -69,6 +69,21 @@ If set to false these reverse replication streams will not be created and you wi
 
 </div>
 
+#### -max_replication_lag_allowed
+**optional**\
+**default**  the value used for `-timeout`
+
+<div class="cmd">
+
+While switching traffic ensure that the VReplication lag for the workflow is less than this duration, otherwise
+report an error and don't switch. VReplication lag is the estimated maximum lag across workflow streams between the last event seen at the source and the event processed by the target (which would be a heartbeat event if we're fully caught up). Usually, when VReplication has caught up, this should be very small (under a second).
+
+While switching write traffic, we temporarily make the source databases read-only, and wait for the targets to catchup. The application will be down for this time: writes will error out. While switching write traffic, this flag can ensure that you only switch traffic if the current lag is small limiting write-unavailability.
+
+While switching read traffic this can be used to set an approximate upper bound on how stale reads will be against the replica tablets when using `@replica` shard targeting.
+
+</div>
+
 #### -dry-run
 **optional**\
 **default** false


### PR DESCRIPTION
Document new flag implemented in https://github.com/vitessio/vitess/pull/9538
Signed-off-by: Rohit Nayak <rohit@planetscale.com>

Relevant change here: https://deploy-preview-957--vitess.netlify.app/docs/13.0/reference/vreplication/switchtraffic/#-max_transaction_lag_allowed