### PR TITLE
Mark IgnoreHealthError as deprecated, delete docs for RPC

### DIFF
--- a/content/en/docs/13.0/reference/programs/vtctl/_index.md
+++ b/content/en/docs/13.0/reference/programs/vtctl/_index.md
@@ -27,7 +27,6 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 | [RefreshState](../vtctl/tablets#refreshstate) | `RefreshState <tablet alias>` |
 | [RefreshStateByShard](../vtctl/tablets#refreshstatebyshard) | `RefreshStateByShard [-cells=c1,c2,...] <keyspace/shard>` |
 | [RunHealthCheck](../vtctl/tablets#runhealthcheck) | `RunHealthCheck <tablet alias>` |
-| [IgnoreHealthError](../vtctl/tablets#ignorehealtherror) | `IgnoreHealthError <tablet alias> <ignore regexp>` |
 | [Sleep](../vtctl/tablets#sleep) | `Sleep <tablet alias> <duration>` |
 | [ExecuteHook](../vtctl/tablets#executehook) | `ExecuteHook <tablet alias> <hook name> [<param1=value1> <param2=value2> ...]` |
 | [ExecuteFetchAsApp](../vtctl/tablets#executefetchasapp) | `ExecuteFetchAsApp [-max_rows=10000] [-json] [-use_pool] <tablet alias> <sql command>` |

--- a/content/en/docs/13.0/reference/programs/vtctl/tablets.md
+++ b/content/en/docs/13.0/reference/programs/vtctl/tablets.md
@@ -75,20 +75,7 @@ Outputs a JSON structure that contains information about the Tablet.
 
 ### IgnoreHealthError
 
-Sets the regexp for health check errors to ignore on the specified tablet. The pattern has implicit ^$ anchors. Set to empty string or restart vttablet to stop ignoring anything.
-
-#### Example
-
-<pre class="command-example">IgnoreHealthError &lt;tablet alias&gt; &lt;ignore regexp&gt;</pre>
-
-#### Arguments
-
-* <code>&lt;tablet alias&gt;</code> &ndash; Required. A Tablet Alias uniquely identifies a vttablet. The argument value is in the format <code>&lt;cell name&gt;-&lt;uid&gt;</code>.
-* <code>&lt;ignore regexp&gt;</code> &ndash; Required.
-
-#### Errors
-
-* the <code>&lt;tablet alias&gt;</code> and <code>&lt;ignore regexp&gt;</code> arguments are required for the <code>&lt;IgnoreHealthError&gt;</code> command This error occurs if the command is not called with exactly 2 arguments.
+Deprecated.
 
 ### UpdateTabletAddrs
 
@@ -316,23 +303,6 @@ Runs a health check on a remote tablet.
 
 * the <code>&lt;tablet alias&gt;</code> argument is required for the <code>&lt;RunHealthCheck&gt;</code> command This error occurs if the command is not called with exactly one argument.
 * this only reports an error if a "healthcheck" RPC call to a vttablet fails. It is only useful as a connectivity and vttablet liveness check.
-
-### IgnoreHealthError
-
-Sets the regexp for health check errors to ignore on the specified tablet. The pattern has implicit ^$ anchors. Set to empty string or restart vttablet to stop ignoring anything.
-
-#### Example
-
-<pre class="command-example">IgnoreHealthError &lt;tablet alias&gt; &lt;ignore regexp&gt;</pre>
-
-#### Arguments
-
-* <code>&lt;tablet alias&gt;</code> &ndash; Required. A Tablet Alias uniquely identifies a vttablet. The argument value is in the format <code>&lt;cell name&gt;-&lt;uid&gt;</code>.
-* <code>&lt;ignore regexp&gt;</code> &ndash; Required.
-
-#### Errors
-
-* the <code>&lt;tablet alias&gt;</code> and <code>&lt;ignore regexp&gt;</code> arguments are required for the <code>&lt;IgnoreHealthError&gt;</code> command This error occurs if the command is not called with exactly 2 arguments.
 
 ### Sleep
 


### PR DESCRIPTION
Docs for https://github.com/vitessio/vitess/pull/9594

RPC was deprecated some time ago, deleted now.
Deprecating vtctl command now, we'll delete in the next release.