### PR TITLE
Addition of `enable_set_var` to vtgate program reference

### DIFF
--- a/content/en/docs/14.0/reference/programs/vtgate.md
+++ b/content/en/docs/14.0/reference/programs/vtgate.md
@@ -56,6 +56,7 @@ The following global options apply to `vtgate`:
 | -enable_buffer | boolean | Enable buffering (stalling) of primary traffic during failovers. |
 | -enable_buffer_dry_run | boolean | Detect and log failover events, but do not actually buffer requests. |
 | -enable_system_settings | boolean | Enables the system settings to be changed per session at the database connection level. Override with @@enable_system_settings session variable. |
+| -enable_set_var | boolean | This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections. |
 | -gate_query_cache_size | int | gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 10000) |
 | -gateway_implementation | string | The implementation of gateway (default "tabletgateway") |
 | -gateway_initial_tablet_timeout | duration | At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype (default 30s) |


### PR DESCRIPTION
This pull request follows the changes made by https://github.com/vitessio/vitess/pull/9641 by adding the `enable_set_var` flag to v14 documentation.