### PR TITLE
Updating current version of vitess in the docs' sidebar following v13

### DIFF
--- a/content/en/docs/12.0/_index.md
+++ b/content/en/docs/12.0/_index.md
@@ -1,8 +1,6 @@
 ---
-title: v12.0 (Stable)
-description: >
-  Latest stable release.
-  Everything you need to know about scaling MySQL with Vitess.
+title: v12.0
+description: Everything you need to know about scaling MySQL with Vitess.
 notoc: true
 cascade:
   version: v12.0

--- a/content/en/docs/13.0/_index.md
+++ b/content/en/docs/13.0/_index.md
@@ -1,7 +1,7 @@
 ---
-title: v13.0 (RC)
+title: v13.0 (Stable)
 description: >
-  Release candidate.
+  Latest stable release.
   Everything you need to know about scaling MySQL with Vitess.
 notoc: true
 cascade:

--- a/content/en/docs/14.0/_index.md
+++ b/content/en/docs/14.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v14.0 (Development)
+title: v14.0 (Future Release)
 description: > 
   Under construction, upcoming release.
   Everything you need to know about scaling MySQL with Vitess.

--- a/content/en/docs/14.0/_index.md
+++ b/content/en/docs/14.0/_index.md
@@ -1,7 +1,7 @@
 ---
-title: v14.0 (Future Release)
+title: v14.0 (Development)
 description: > 
-  Under construction, upcoming release.
+  Under construction, development release.
   Everything you need to know about scaling MySQL with Vitess.
 notoc: true
 cascade:

--- a/content/zh/docs/13.0/_index.md
+++ b/content/zh/docs/13.0/_index.md
@@ -1,6 +1,6 @@
 ---
-title: v13.0 (Current release)
-description: Most recent release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
+title: v13.0 (Stable)
+description: Latest stable release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:
   version: v13.0

--- a/content/zh/docs/14.0/_index.md
+++ b/content/zh/docs/14.0/_index.md
@@ -1,6 +1,6 @@
 ---
-title: v14.0 (Future release)
-description: Under construction, upcoming release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
+title: v14.0 (Development)
+description: Under construction, development release. 因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:
   version: v14.0


### PR DESCRIPTION
This pull request updates the documentation's sidebar with `v13` being the latest stable release.