### PR TITLE
Correct vtctl -wait-time flag in examples

### DIFF
--- a/content/en/docs/11.0/reference/vreplication/vdiff.md
+++ b/content/en/docs/11.0/reference/vreplication/vdiff.md
@@ -140,7 +140,7 @@ You may need to use one or more of the following recommendations while running l
 
 * If VDiff takes more than an hour `vtctlclient` will hit grpc/http timeouts of 1 hour. In that case you can use `vtctl` (the bundled `vctlclient` + `vtctld`) instead.
 * VDiff also synchronizes sources and targets to get consistent snapshots. If you have a high write QPS then you may encounter timeouts during the sync. Use higher values of `-filtered_replication_wait_time` to prevent that, for example `-filtered_replication_wait_time=4h`.
-* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait_time=168h`.
+* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait-time=168h`.
 * You can follow the progress of the command by tailing the vtctld logs. VDiff logs progress every 10 million rows. This can also give you an early indication of how long it will run for, allowing you to increase your settings if needed.
 
 ### Note

--- a/content/en/docs/12.0/reference/vreplication/vdiff.md
+++ b/content/en/docs/12.0/reference/vreplication/vdiff.md
@@ -140,7 +140,7 @@ You may need to use one or more of the following recommendations while running l
 
 * If VDiff takes more than an hour `vtctlclient` will hit grpc/http timeouts of 1 hour. In that case you can use `vtctl` (the bundled `vctlclient` + `vtctld`) instead.
 * VDiff also synchronizes sources and targets to get consistent snapshots. If you have a high write QPS then you may encounter timeouts during the sync. Use higher values of `-filtered_replication_wait_time` to prevent that, for example `-filtered_replication_wait_time=4h`.
-* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait_time=168h`.
+* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait-time=168h`.
 * You can follow the progress of the command by tailing the vtctld logs. VDiff logs progress every 10 million rows. This can also give you an early indication of how long it will run for, allowing you to increase your settings if needed.
 
 ### Note

--- a/content/en/docs/13.0/reference/vreplication/vdiff.md
+++ b/content/en/docs/13.0/reference/vreplication/vdiff.md
@@ -140,7 +140,7 @@ You may need to use one or more of the following recommendations while running l
 
 * If VDiff takes more than an hour `vtctlclient` will hit grpc/http timeouts of 1 hour. In that case you can use `vtctl` (the bundled `vctlclient` + `vtctld`) instead.
 * VDiff also synchronizes sources and targets to get consistent snapshots. If you have a high write QPS then you may encounter timeouts during the sync. Use higher values of `-filtered_replication_wait_time` to prevent that, for example `-filtered_replication_wait_time=4h`.
-* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait_time=168h`.
+* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait-time=168h`.
 * You can follow the progress of the command by tailing the vtctld logs. VDiff logs progress every 10 million rows. This can also give you an early indication of how long it will run for, allowing you to increase your settings if needed.
 
 ### Note

--- a/content/en/docs/14.0/reference/vreplication/vdiff.md
+++ b/content/en/docs/14.0/reference/vreplication/vdiff.md
@@ -147,7 +147,7 @@ You may need to use one or more of the following recommendations while running l
 
 * If VDiff takes more than an hour `vtctlclient` will hit grpc/http timeouts of 1 hour. In that case you can use `vtctl` (the bundled `vctlclient` + `vtctld`) instead.
 * VDiff also synchronizes sources and targets to get consistent snapshots. If you have a high write QPS then you may encounter timeouts during the sync. Use higher values of `-filtered_replication_wait_time` to prevent that, for example `-filtered_replication_wait_time=4h`.
-* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait_time=168h`.
+* If VDiff takes more than a day set the `-wait-time` parameter, which is the maximum time a vtctl command can run for, to a value comfortably higher than the expected run time, for example `-wait-time=168h`.
 * You can follow the progress of the command by tailing the vtctld logs. VDiff logs progress every 10 million rows. This can also give you an early indication of how long it will run for, allowing you to increase your settings if needed.
 
 ### Note


### PR DESCRIPTION
This flag is NOT one that accepts a dash OR an underscore:
```
$ vtctl -topo_implementation etcd2 -topo_global_server_address localhost:2379 -topo_global_root /vitess/global -wait_time=1h ListAllTablets | head -3
flag provided but not defined: -wait_time
Usage: vtctl [global parameters] command [command parameters]

$ vtctl -topo_implementation etcd2 -topo_global_server_address localhost:2379 -topo_global_root /vitess/global -wait-time=1h ListAllTablets | head -3
zone1-0000000100 commerce 0 primary 46cbd091ed73:15100 46cbd091ed73:17100 [] 2022-02-24T20:10:32Z
zone1-0000000101 commerce 0 replica 46cbd091ed73:15101 46cbd091ed73:17101 [] <null>
zone1-0000000102 commerce 0 rdonly 46cbd091ed73:15102 46cbd091ed73:17102 [] <null>
```