### PR TITLE
Update MySQL related version and recommendation info

### DIFF
--- a/content/en/docs/11.0/get-started/local.md
+++ b/content/en/docs/11.0/get-started/local.md
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 11:
 
 ```sh
-version=13.0.0
-file=vitess-${version}-bc4a960.tar.gz
+version=11.0.4
+file=vitess-${version}-cb142ee.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/11.0/get-started/local.md
+++ b/content/en/docs/11.0/get-started/local.md
@@ -12,7 +12,7 @@ A [docker setup](../local-docker/) is also available, which requires no dependen
 
 ## Install MySQL and etcd
 
-Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your installation method provides a choice:
+Vitess supports the databases listed [here](../../overview/supported-databases/). We recommend MySQL 8.0 if your installation method provides that option:
 
 ```sh
 # Ubuntu based
@@ -22,7 +22,7 @@ sudo apt install -y mysql-server etcd curl
 sudo apt install -y default-mysql-server default-mysql-client etcd curl
 
 # Yum based
-sudo yum -y localinstall https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm
+sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm
 sudo yum -y install mysql-community-server etcd curl
 ```
 
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 6:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
 
 ```sh
-version=6.0.20-20200818
-file=vitess-${version}-90741b8.tar.gz
+version=13.0.0
+file=vitess-${version}-bc4a960.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/11.0/overview/supported-databases.md
+++ b/content/en/docs/11.0/overview/supported-databases.md
@@ -22,7 +22,7 @@ MySQL and Percona Server for MySQL 5.6 are no longer supported in Vitess 13.0 an
 
 Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does not yet](https://github.com/vitessio/vitess/issues/5362) support later versions of MariaDB.
 
-{{< warning >}}MariaDB support is likely to end in the future. You can view and comment on [the relevant proposal here](https://github.com/vitessio/vitess/issues/9518).{{< /warning >}}
+{{< warning >}}MariaDB support has been EOL'd in Vitess 14.0.{{< /warning >}}
 
 ## See also
 

--- a/content/en/docs/11.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/11.0/user-guides/configuration-basic/planning.md
@@ -20,7 +20,7 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend etcd if you have no other preference.
 2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.6 to 8.0 and MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).

--- a/content/en/docs/11.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/11.0/user-guides/configuration-basic/planning.md
@@ -20,8 +20,8 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. TopoServer: This is the server in which Vitess stores its metadata. We currently support zookeeper or etcd.
-2. MySQL: Vitess supports MySQL/Percona Server 5.7 to 8.0, and MariaDB 10.0 to 10.3. MariaDB 10.4 is currently known to have installation issues ([#5362](https://github.com/vitessio/vitess/issues/5362)). The most common deployments use MySQL 5.7.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.6 to 8.0 and MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).
 

--- a/content/en/docs/12.0/get-started/local.md
+++ b/content/en/docs/12.0/get-started/local.md
@@ -12,7 +12,7 @@ A [docker setup](../local-docker/) is also available, which requires no dependen
 
 ## Install MySQL and etcd
 
-Vitess supports MySQL 5.6+ and MariaDB 10.0+. We recommend MySQL 5.7 if your installation method provides a choice:
+Vitess supports the databases listed [here](../../overview/supported-databases/). We recommend MySQL 8.0 if your installation method provides that option:
 
 ```sh
 # Ubuntu based
@@ -22,7 +22,7 @@ sudo apt install -y mysql-server etcd curl
 sudo apt install -y default-mysql-server default-mysql-client etcd curl
 
 # Yum based
-sudo yum -y localinstall https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm
+sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm
 sudo yum -y install mysql-community-server etcd curl
 ```
 
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 6:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
 
 ```sh
-version=6.0.20-20200818
-file=vitess-${version}-90741b8.tar.gz
+version=13.0.0
+file=vitess-${version}-bc4a960.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/12.0/get-started/local.md
+++ b/content/en/docs/12.0/get-started/local.md
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 12:
 
 ```sh
-version=13.0.0
-file=vitess-${version}-bc4a960.tar.gz
+version=12.0.3
+file=vitess-${version}-cbc6ab6.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/12.0/overview/supported-databases.md
+++ b/content/en/docs/12.0/overview/supported-databases.md
@@ -22,7 +22,7 @@ MySQL and Percona Server for MySQL 5.6 are no longer supported in Vitess 13.0 an
 
 Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does not yet](https://github.com/vitessio/vitess/issues/5362) support later versions of MariaDB.
 
-{{< warning >}}MariaDB support is likely to end in the future. You can view and comment on [the relevant proposal here](https://github.com/vitessio/vitess/issues/9518).{{< /warning >}}
+{{< warning >}}MariaDB support has been EOL'd in Vitess 14.0.{{< /warning >}}
 
 ## See also
 

--- a/content/en/docs/12.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/12.0/user-guides/configuration-basic/planning.md
@@ -20,7 +20,7 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend etcd if you have no other preference.
 2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.6 to 8.0 and MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).

--- a/content/en/docs/12.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/12.0/user-guides/configuration-basic/planning.md
@@ -20,8 +20,8 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. TopoServer: This is the server in which Vitess stores its metadata. We currently support zookeeper or etcd.
-2. MySQL: Vitess supports MySQL/Percona Server 5.7 to 8.0, and MariaDB 10.0 to 10.3. MariaDB 10.4 is currently known to have installation issues ([#5362](https://github.com/vitessio/vitess/issues/5362)). The most common deployments use MySQL 5.7.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.6 to 8.0 and MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).
 

--- a/content/en/docs/13.0/get-started/local.md
+++ b/content/en/docs/13.0/get-started/local.md
@@ -12,7 +12,7 @@ A [docker setup](../local-docker/) is also available, which requires no dependen
 
 ## Install MySQL and etcd
 
-Vitess supports the databases listed [here](../../../overview/supported-databases/). We recommend MySQL 5.7 if your installation method provides a choice:
+Vitess supports the databases listed [here](../../overview/supported-databases/). We recommend MySQL 8.0 if your installation method provides that option:
 
 ```sh
 # Ubuntu based
@@ -22,7 +22,7 @@ sudo apt install -y mysql-server etcd curl
 sudo apt install -y default-mysql-server default-mysql-client etcd curl
 
 # Yum based
-sudo yum -y localinstall https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm
+sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm
 sudo yum -y install mysql-community-server etcd curl
 ```
 
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 6:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
 
 ```sh
-version=6.0.20-20200818
-file=vitess-${version}-90741b8.tar.gz
+version=13.0.0
+file=vitess-${version}-bc4a960.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/13.0/overview/supported-databases.md
+++ b/content/en/docs/13.0/overview/supported-databases.md
@@ -18,7 +18,7 @@ Vitess supports the core features of MySQL versions 5.7 to 8.0, with [some limit
 
 Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does not yet](https://github.com/vitessio/vitess/issues/5362) support later versions of MariaDB.
 
-{{< warning >}}MariaDB support is likely to end in the the future. You can view and comment on [the relevant proposal here](https://github.com/vitessio/vitess/issues/9518).{{< /warning >}}
+{{< warning >}}MariaDB support has been EOL'd in Vitess 14.0.{{< /warning >}}
 
 ## See also
 

--- a/content/en/docs/13.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/planning.md
@@ -20,7 +20,7 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend etcd if you have no other preference.
 2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.7 to 8.0 and to a limited extent MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).

--- a/content/en/docs/13.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/planning.md
@@ -20,8 +20,8 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. TopoServer: This is the server in which Vitess stores its metadata. We currently support zookeeper or etcd.
-2. MySQL: Vitess supports MySQL/Percona Server 5.7 to 8.0, and MariaDB 10.0 to 10.3. MariaDB 10.4 is currently known to have installation issues ([#5362](https://github.com/vitessio/vitess/issues/5362)). The most common deployments use MySQL 5.7.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.7 to 8.0 and to a limited extent MariaDB 10.0 to 10.3. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).
 

--- a/content/en/docs/14.0/contributing/build-on-centos.md
+++ b/content/en/docs/14.0/contributing/build-on-centos.md
@@ -37,7 +37,7 @@ export GOPATH=/home/<user>/go
 
 ### Packages from CentOS repos
 
-The MariaDB version included with CentOS 7 (5.5) is not supported by Vitess. First install the MySQL 5.7 repository from Oracle:
+First install the MySQL 5.7 repository from Oracle:
 
 ```
 sudo yum localinstall -y https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm

--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -12,7 +12,7 @@ A [docker setup](../local-docker/) is also available, which requires no dependen
 
 ## Install MySQL and etcd
 
-Vitess supports the databases listed [here](../../../overview/supported-databases/). We recommend MySQL 5.7 if your installation method provides a choice:
+Vitess supports the databases listed [here](../../overview/supported-databases/). We recommend MySQL 8.0 if your installation method provides that option:
 
 ```sh
 # Ubuntu based
@@ -22,7 +22,7 @@ sudo apt install -y mysql-server etcd curl
 sudo apt install -y default-mysql-server default-mysql-client etcd curl
 
 # Yum based
-sudo yum -y localinstall https://dev.mysql.com/get/mysql57-community-release-el7-9.noarch.rpm
+sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm
 sudo yum -y install mysql-community-server etcd curl
 ```
 
@@ -58,11 +58,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 6:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
 
 ```sh
-version=6.0.20-20200818
-file=vitess-${version}-90741b8.tar.gz
+version=13.0.0
+file=vitess-${version}-bc4a960.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/14.0/overview/supported-databases.md
+++ b/content/en/docs/14.0/overview/supported-databases.md
@@ -4,7 +4,7 @@ weight: 2
 featured: true
 ---
 
-Vitess deploys, scales and manages clusters of open-source SQL database instances. Currently, Vitess supports the [MySQL](https://www.mysql.com/), [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server), and to a limited extent [MariaDB](https://mariadb.org) databases.
+Vitess deploys, scales and manages clusters of open-source SQL database instances. Currently, Vitess supports the [MySQL](https://www.mysql.com/) and [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) databases.
 
 The [VTGate](../../concepts/vtgate/) proxy server advertises its version as MySQL 5.7.
 
@@ -13,12 +13,6 @@ The [VTGate](../../concepts/vtgate/) proxy server advertises its version as MySQ
 Vitess supports the core features of MySQL versions 5.7 to 8.0, with [some limitations](../../reference/compatibility/mysql-compatibility/). Vitess also supports [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) versions 5.7 to 8.0.
 
 {{< info >}}For new Vitess installations, MySQL or Percona Server for MySQL version 8 are recommended.{{< /info >}}
-
-## MariaDB versions 10.0 to 10.3
-
-Vitess supports the core features of MariaDB versions 10.0 to 10.3. Vitess [does not yet](https://github.com/vitessio/vitess/issues/5362) support later versions of MariaDB.
-
-{{< warning >}}MariaDB support is likely to end in the the future. You can view and comment on [the relevant proposal here](https://github.com/vitessio/vitess/issues/9518).{{< /warning >}}
 
 ## See also
 

--- a/content/en/docs/14.0/overview/whatisvitess.md
+++ b/content/en/docs/14.0/overview/whatisvitess.md
@@ -4,7 +4,7 @@ weight: 1
 featured: true
 ---
 
-Vitess is a database solution for deploying, scaling and managing large clusters of open-source database instances. It currently supports MySQL, Percona and MariaDB. It's architected to run as effectively in a public or private cloud architecture as it does on dedicated hardware. It combines and extends many important SQL features with the scalability of a NoSQL database. Vitess can help you with the following problems:
+Vitess is a database solution for deploying, scaling and managing large clusters of open-source database instances. It currently supports MySQL and Percona Server for MySQL. It's architected to run as effectively in a public or private cloud architecture as it does on dedicated hardware. It combines and extends many important SQL features with the scalability of a NoSQL database. Vitess can help you with the following problems:
 
 1. Scaling a SQL database by allowing you to shard it, while keeping application changes to a minimum.
 2. Migrating from baremetal to a private or public cloud.

--- a/content/en/docs/14.0/reference/vreplication/materialize.md
+++ b/content/en/docs/14.0/reference/vreplication/materialize.md
@@ -18,7 +18,7 @@ can be copies, aggregations or views. The target tables are kept in sync in near
 You can specify multiple tables to materialize using the json_spec parameter.
 
 {{< warning >}}
-Be careful to avoid using the `INSTANT ADD COLUMN` feature in [MySQL 8.0+](https://mysqlserverteam.com/mysql-8-0-innodb-now-supports-instant-add-column/) and [MariaDB 10.3+](https://mariadb.com/kb/en/instant-add-column-for-innodb/) with materialization source tables as this can cause the vreplication based materialization workflow to break.
+Be careful to avoid using the `INSTANT ADD COLUMN` feature in [MySQL 8.0+](https://mysqlserverteam.com/mysql-8-0-innodb-now-supports-instant-add-column/) with materialization source tables as this can cause the vreplication based materialization workflow to break.
 {{< /warning >}}
 
 ### Parameters

--- a/content/en/docs/14.0/user-guides/configuration-basic/collations.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/collations.md
@@ -17,8 +17,8 @@ The following table lists all of the supported collations in the current release
 | Legend | |
 |----|----|
 | ✅ | Vitess has full support for this collation. |
-| ⚠️ | The underlying MySQL engine supports this collation, but Vitess does not. |
-| ❌ | Neither Vitess nor the underlying MySQL engine supports this collation. |
+| ⚠️ | The underlying MySQL (or compatible) database supports this collation, but Vitess does not. |
+| ❌ | Neither Vitess nor the underlying MySQL database supports this collation. |
 
 Using collations that are not supported by Vitess but implemented in the underlying MySQL instance can lead to unpredictable behavior.
 

--- a/content/en/docs/14.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/planning.md
@@ -20,7 +20,7 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend etcd if you have no other preference.
 2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.7 to 8.0. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).

--- a/content/en/docs/14.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/planning.md
@@ -20,8 +20,8 @@ Before starting, we assume that you have downloaded Vitess and finished the [Get
 
 Vitess relies on two external components, and we recommend that you choose them upfront:
 
-1. TopoServer: This is the server in which Vitess stores its metadata. We currently support zookeeper or etcd.
-2. MySQL: Vitess supports MySQL/Percona Server 5.7 to 8.0, and MariaDB 10.0 to 10.3. MariaDB 10.4 is currently known to have installation issues ([#5362](https://github.com/vitessio/vitess/issues/5362)). The most common deployments use MySQL 5.7.
+1. [TopoServer](../../../concepts/topology-service/): This is the server in which Vitess stores its metadata. We recommend Etcd if you have no other preference.
+2. [MySQL](../../../overview/supported-databases/): Vitess supports MySQL/Percona Server 5.7 to 8.0. We recommend MySQL 8.0 for new installations.
 
 In this guide, we will be covering the case where the MySQL instances are managed by Vitess. A different section covers the details of running against [externally managed databases](../../configuration-advanced/unmanaged-tablet).
 

--- a/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -14,9 +14,8 @@ A compatible version of [xtrabackup](https://www.percona.com/doc/percona-xtrabac
 
 ### Supported Versions of Xtrabackup
 
-* [For MySQL 5.7 and MariaDB 10](https://www.percona.com/doc/percona-xtrabackup/2.4/index.html#installation)
+* [For MySQL 5.7](https://www.percona.com/doc/percona-xtrabackup/2.4/index.html#installation)
 * [MySQL 8.0](https://www.percona.com/doc/percona-xtrabackup/8.0/index.html#installation)
-* MariaDB 10.3 is not compatible with xtrabackup
 
 ### Basic VTTablet and Vtctld Configuration
 


### PR DESCRIPTION
H/T to @mreschke for pointing these out [here](https://github.com/vitessio/vitess/issues/9518#issuecomment-1055975374).

This updates and clarifies the databases we support and recommend:
- We begin formally recommending MySQL 8
- We remove MySQL 5.6 in Vitess versions released since its support deprecation
- We formally Deprecate MariaDB support in v14