### PR TITLE
Docs: use 'vitess' ddl strategy, replacing 'online'

### DIFF
--- a/content/en/docs/14.0/user-guides/schema-changes/concurrent-migrations.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/concurrent-migrations.md
@@ -46,7 +46,7 @@ vtctl ApplySchema -skip_preflight -ddl_strategy "online -allow-concurrent" -sql 
 To clarify:
 
 - `gh-ost` and `pt-osc` `ALTER` migrations are not eligible to run concurrently
-- A "normal" `online` `ALTER` migration is not eligible to run concurrently. A `REVERT` of an `online` migration _is_ eligible though.
+- A "normal" `vitess` `ALTER` migration is not eligible to run concurrently. A `REVERT` of a `vitess` migration _is_ eligible though.
 
 ## Scheduling notes
 

--- a/content/en/docs/14.0/user-guides/schema-changes/ddl-strategy-flags.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/ddl-strategy-flags.md
@@ -39,4 +39,4 @@ set @@ddl_strategy='pt-osc --null-to-not-null'
 ```
 Consult [pt-online-schema-change documentation](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html) for supported command line flags.
 
-The `online` strategy uses Vitess internal mechanisms and is not a standalone command line tool. therefore, it has no particular command line flags. For internal testing/CI purposes, the `online` strategy supports `-vreplication-test-suite`, and this flag must **not** be used in production as it can have destructive consequences.
+The `vitess` strategy (formerly known as `online`) uses Vitess internal mechanisms and is not a standalone command line tool. therefore, it has no particular command line flags. For internal testing/CI purposes, the `vitess` strategy supports `-vreplication-test-suite`, and this flag must **not** be used in production as it can have destructive consequences.

--- a/content/en/docs/14.0/user-guides/schema-changes/declarative-migrations.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/declarative-migrations.md
@@ -113,5 +113,5 @@ Consider the following types of migrations:
 
 Declarative DDLs are [revertible](../revertible-migrations/). Note:
 
-- A declarative migration which ends up being an `ALTER` is only revertible if executed with `online` strategy.
+- A declarative migration which ends up being an `ALTER` is only revertible if executed with `vitess` strategy.
 - A declarative migration which ends up being a noop (and implicitly successful), implies a noop revert.

--- a/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
@@ -4,7 +4,7 @@ weight: 2
 aliases: ['/docs/user-guides/managed-online-schema-changes/']
 ---
 
-**Note:** `gh-ost` migrations are considered stable. `pt-osc` and `online` migrations are considered **EXPERIMENTAL**.
+**Note:** `gh-ost` migrations are considered stable. `pt-osc` and `vitess` migrations are considered **EXPERIMENTAL**.
 
 Vitess offers managed, online schema migrations (aka Online DDL), transparently to the user. Vitess Onine DDL offers:
 
@@ -207,9 +207,9 @@ The primary use case is a primary failure and failover. The newly promoted table
 
 ## Throttling
 
-All three strategies: `online`, `gh-ost` and `pt-osc` utilize the tablet throttler, which is a cooperative throttler service based on replication lag. The tablet throttler automatically detects topology `REPLICA` tablets and adapts to changes in the topology. See [Tablet throttler](../../../reference/features/tablet-throttler/).
+All three strategies: `vitess`, `gh-ost` and `pt-osc` utilize the tablet throttler, which is a cooperative throttler service based on replication lag. The tablet throttler automatically detects topology `REPLICA` tablets and adapts to changes in the topology. See [Tablet throttler](../../../reference/features/tablet-throttler/).
 
-- `online` strategy uses the throttler by the fact VReplication natively uses the throttler on both source and target ends (for both reads and writes)
+- `vitess` strategy uses the throttler by the fact VReplication natively uses the throttler on both source and target ends (for both reads and writes)
 - `gh-ost` uses the throttler via `--throttle-http`, which is automatically provided by Vitess
 - `pt-osc` uses the throttler by replication lag plugin, automatically injected by Vitess.
 

--- a/content/en/docs/14.0/user-guides/schema-changes/postponed-migrations.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/postponed-migrations.md
@@ -164,7 +164,7 @@ mysql> show vitess_migrations like '3091ef2a_4b87_11ec_a827_0a43f95f28a3' \G
 Postponed completion is supported for:
 
 - `CREATE` and `DROP` for all online strategies
-- `ALTER` migrations in `online` strategy
+- `ALTER` migrations in `vitess` (formerly known as `online`) strategy
 - `ALTER` migrations in `gh-ost` strategy
 - `REVERT` of any of the above, as well as further cascading `REVERT` operations
 
@@ -179,6 +179,6 @@ Postponed completion is not supported in:
 
 The two strong cases for postponed migrations are `DROP` and log `ALTER`s. Both carry an amount of risk to production above other migrations.
 
-Postponed `ALTER` migrations (in `online` and `gh-ost` strategies) are actually executed, and begin copying table data as well as track ongoing changes. But as they reach the point where cut-over is agreeable, they stall, and keep waiting until the user issues the `alter vitess_migration ... complete` statement. Assuming the user runs the statement when all data has already been copied, it is typically a matter of seconds until the migration completes and the new schema is instated.
+Postponed `ALTER` migrations (in `vitess` and `gh-ost` strategies) are actually executed, and begin copying table data as well as track ongoing changes. But as they reach the point where cut-over is agreeable, they stall, and keep waiting until the user issues the `alter vitess_migration ... complete` statement. Assuming the user runs the statement when all data has already been copied, it is typically a matter of seconds until the migration completes and the new schema is instated.
 
 For `CREATE` and `DROP` statements, there's no such backfill process as with `ALTER`, and the migrations are simply not scheduled, until the user issues the `complete` statement. Once the statement is issued, the migrations still need to be scheduled, and may be possibly delayed by an existing queue of migrations.

--- a/content/en/docs/14.0/user-guides/schema-changes/recoverable-migrations.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/recoverable-migrations.md
@@ -4,13 +4,13 @@ weight: 13
 aliases: ['/docs/user-guides/schema-changes/recoverable-migrations/']
 ---
 
-Vitess's [managed schema changes](../managed-online-schema-changes/) offer _failover agnostic_ migrations in `online` strategy (VReplication based).
+Vitess's [managed schema changes](../managed-online-schema-changes/) offer _failover agnostic_ migrations in `vitess` strategy (VReplication based).
 
 Normally, schema migrations are coupled with the original MySQL server they operate on. A `gh-ost` or a `pt-online-schema-change`, as well as plain direct migrations, may only complete on the same server where they started. Any form of failover, whether planned or unplanned, either breaks the migration or makes it obsolete.
 
-`online` strategy migrations are agnostic to server promotion. A migration can begin on one `primary` tablet, and complete on another tablet which was promoted as `primary` throughout the migration. In large part this is a direct result of the nature of VReplication. 
+`vitess` strategy migrations are agnostic to server promotion. A migration can begin on one `primary` tablet, and complete on another tablet which was promoted as `primary` throughout the migration. In large part this is a direct result of the nature of VReplication. 
 
-`online` migrations will auto-survive:
+`vitess` migrations will auto-survive:
 
 - A planned failover (via [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting))
 - An emergency reparent ([EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting))
@@ -19,7 +19,7 @@ Normally, schema migrations are coupled with the original MySQL server they oper
 
 ## Behavior and limitations
 
-Whether by planned operation or an unplanned failure, an `online` migration's VReplication stream is interrupted while copying/applying data. VReplication's mechanism persists the state of data transfer transactionally with the transfer itself. Any replica will have a _consistent_ state of the migration, even if that replica lags behind the primary.
+Whether by planned operation or an unplanned failure, a `vitess` migration's VReplication stream is interrupted while copying/applying data. VReplication's mechanism persists the state of data transfer transactionally with the transfer itself. Any replica will have a _consistent_ state of the migration, even if that replica lags behind the primary.
 
 When a replica tablet is promoted as `primary`, it notices the VReplication stream, which is meant to be active and running. It sets up the connections and processes to resume its work. It is possible that some retries will take place as the stream re-evaluates its source of data.
 
@@ -27,6 +27,6 @@ The [Online DDL Scheduler](../../../design-docs/online-ddl/scheduler) detects th
 
 The stream must be no more than `10` minutes stale, otherwise the scheduler marks the migration as failed.
 
-There is no limitation on the number of failovers an `online` migration can survive.
+There is no limitation on the number of failovers a `vitess` migration can survive.
 
 No user action is required. Immediately after promotion/failover the migration will present as making no progress. It is likely to present progress within 1 or 2 minutes after promotion.

--- a/content/en/docs/14.0/user-guides/schema-changes/revertible-migrations.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/revertible-migrations.md
@@ -10,7 +10,7 @@ Revertible migrations supported for:
 
 - `CREATE TABLE` statements: the _revert_ is to _uncreate_ the table
 - `DROP TABLE` statements: the _revert_ is to _reinstate_ the table, populated with data from time of `DROP`
-- `ALTER TABLE` statements: supported in `online` strategy, the _revert_ is to reapply previous table schema, without losing any data added/modified since migration completion.
+- `ALTER TABLE` statements: supported in `vitess` strategy, the _revert_ is to reapply previous table schema, without losing any data added/modified since migration completion.
 - Another `revert` migration. It is possible to revert a _revert_, revert the revert of a _revert_, and so forth.
 
 ## Behavior and limitations
@@ -19,7 +19,7 @@ Revertible migrations supported for:
 - Migrations are only for revertible for `24h` since completion.
 - It's only possible to revert the last successful migration on a given table. Illustrated following.
   - In the future it may be possible to revert down the stack of completed migrations.
-- `ALTER` migrations are revertible only in `online` strategy.
+- `ALTER` migrations are revertible only in `vitess` strategy.
 - If a DDL is a noop, then so is its revert:
   - If a table `t` exists, and an online DDL is `CREATE TABLE IF NOT EXISTS t (...)`, then the DDL does nothing, and its revert will do nothing.
   - If a table `t` does not exist, and an online DDL is `DROP TABLE IF EXISTS t`, then likewise the DDL does nothing, and its revert does nothing.
@@ -224,6 +224,6 @@ Revert for `CREATE` and `DROP` are implemented similarly for all online strategi
 
 - The revert for a `CREATE` DDL is to rename the table away and into a [table lifecycle](../table-lifecycle/) name, rather than actually `DROP` it. This keeps th etale safe for a period of time, and makes it possible to reinstate the table, populated with all data, via a 2nd revert.
 - The revert for a `DROP` relies on the fact that Online DDL `DROP TABLE` does not, in fact, drop the table, but actually rename it away. Thus, reverting the `DROP` is merely a `RENAME` back into its original place.
-- The revert for `ALTER` is only available for `online` strategy, implemented by `VReplication`. VReplication keep track of a DDL migration by writing down the GTID position through the migration flow. In particular, at time of cut-over and when tables are swapped, VReplication notes the _final_ GTID pos for the migration.
+- The revert for `ALTER` is only available for `vitess` strategy, implemented by `VReplication`. VReplication keep track of a DDL migration by writing down the GTID position through the migration flow. In particular, at time of cut-over and when tables are swapped, VReplication notes the _final_ GTID pos for the migration.
   When a revert is requested, Vitess computes a new VReplication rule/filter for the new stream. It them copies the _final_ GTID pos from the reverted migration, and instructs VReplication to resume from that point.
   As result, a revert for an `ALTER` migration only needs to catch up with the changelog (binary log entries) since the cut-over of the original migration. To elaborate, it does not need to copy table data, and only needs to consider events for the specific table affected by the revert. This makes the revert operation efficient.


### PR DESCRIPTION
Per https://github.com/vitessio/vitess/pull/9642, we renamed the `online` `ddl_strategy` as `vitess`. Both are supported (and are synonyms), but going forward we want to use `vitess` over `online`. This PR therefore updates the docs to always use `vitess` name.