### PR TITLE
add `planner_version` flag reference and update its default value to Gen4

### DIFF
--- a/content/en/docs/14.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/14.0/get-started/vttestserver-docker-image.md
@@ -63,7 +63,7 @@ The docker image expects some of the environment variables to be set to function
 | *FOREIGN_KEY_MODE* | no | This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow (default), disallow. |
 | *ENABLE_ONLINE_DDL* | no | Allow users to submit, review and control Online DDL. Valid values are: true (default), false. |
 | *ENABLE_DIRECT_DDL* | no | Allow users to submit direct DDL statements. Valid values are: true (default), false. |
-| *PLANNER_VERSION* | no | Sets the default planner to use when the session has not changed it. Valid values are: V3 (default), Gen4, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the new gen4 planner and falls back to the V3 planner if the gen4 fails. |
+| *PLANNER_VERSION* | no | Sets the default planner to use when the session has not changed it. Valid values are: Gen4 (default), v3, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the new gen4 planner and falls back to the V3 planner if the gen4 fails. |
 
 Environment variables in docker can be specified using the `-e` aka `--env` flag.
 

--- a/content/en/docs/14.0/reference/programs/vtexplain.md
+++ b/content/en/docs/14.0/reference/programs/vtexplain.md
@@ -29,7 +29,7 @@ The following parameters apply to `mysqlctl`:
 | Name | Type | Definition |
 | :-------------------- | :--------- | :---------------------------------------------------- |
 | -output-mode | string | Output in human-friendly text or json (default "text") |
-| -planner-version | string | Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "V3"; Vitess 12.0+) |
+| -planner-version | string | Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "Gen4") |
 | -normalize |  | Whether to enable vtgate normalization (default false) |
 | -shards | int | Number of shards per keyspace (default 2) |
 | -replication-mode | string | The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW") |

--- a/content/en/docs/14.0/reference/programs/vtgate.md
+++ b/content/en/docs/14.0/reference/programs/vtgate.md
@@ -131,6 +131,7 @@ The following global options apply to `vtgate`:
 | -normalize_queries | boolean | Rewrite queries with bind vars. Turn this off if the app itself sends normalized queries with bind vars. (default true) |
 | -onterm_timeout | duration | wait no more than this for OnTermSync handlers before stopping (default 10s) |
 | -opentsdb_uri | string | URI of opentsdb /api/put method |
+| -planner_version | string | Sets the default planner to use when the session has not changed it. Valid values are: V3, Gen4, Gen4Greedy and Gen4Fallback. Gen4Fallback tries the gen4 planner and falls back to the V3 planner if the gen4 fails. |
 | -pid_file | string | If set, the process will write its pid to the named file, and delete it on graceful shutdown. |
 | -port | int | port for the server |
 | -proxy_protocol | boolean | Enable HAProxy PROXY protocol on MySQL listener socket |


### PR DESCRIPTION
This pull request is a follow up of https://github.com/vitessio/vitess/pull/9710 where we changed the default planner version to Gen4. In this pull request we update the doc to reflect that change.