### PR TITLE
Upgrade hugo to v0.96.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.78.2"
+HUGO_VERSION = "0.96.0"
 
 [context.production]
 HUGO_ENVIRONMENT = "production"


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

This PR updates the Hugo version for our Netlify deploys to [v0.96.0](https://github.com/gohugoio/hugo/releases/tag/v0.96.0), the latest version. Since this PR _only_ affects Netlify deploys, **those that build and run with Hugo locally are recommended to upgrade their Hugo version to match.** See https://gohugo.io/getting-started/installing/. 

(I ticketed https://github.com/vitessio/website/issues/1005 to add a little bit of tooling to make this easier.) 

v0.78.2 was [released](https://github.com/gohugoio/hugo/releases/tag/v0.78.2) in November 2020 so we are pretty out of date. There's been a bunch of cool stuff released since then; here's the [CHANGELOG](https://github.com/gohugoio/hugo/releases). Notable changes:
- [v0.82.0](https://github.com/gohugoio/hugo/releases/tag/v0.82.0) code fences can have custom markdown attributes
- [v0.93.0](https://github.com/gohugoio/hugo/releases/tag/v0.93.0) support for Markdown diagrams and code block render hooks. GoAT (Go ASCII Tool) is supported out of the box, and we could add Mermaid support if we want even fancier graphs. They look great and I <3 them. 
- [v0.94.0](https://github.com/gohugoio/hugo/releases/tag/v0.94.0) big reductions in build time and memory usage.
- [v0.95.0](https://github.com/gohugoio/hugo/releases/tag/v0.95.0) Go 1.18 support (and more performance improvements) 
- [v0.96.0](https://github.com/gohugoio/hugo/releases/tag/v0.96.0) improvements for multi language "mounts", which I haven't investigated but looks interesting! (Something about missing translations getting filled in from other languages, which could be cool.)

No breaking changes; worth calling out the following from [v0.95.0](https://github.com/gohugoio/hugo/releases/tag/v0.95.0):

> Hugo now only builds with Go versions >= 1.18. Note that you do not need Go installed to run Hugo, and for Hugo Modules, any recent Go version can be used.
