### PR TITLE
Document usage of DESC index for messaging tables

### DIFF
--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -61,7 +61,7 @@ create table my_message(
   priority tinyint NOT NULL DEFAULT '0',
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority, time_next)
+  index next_idx(priority asc, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -61,7 +61,7 @@ create table my_message(
   priority tinyint NOT NULL DEFAULT '0',
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority, time_next)
+  index next_idx(priority asc, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -61,7 +61,7 @@ create table my_message(
   priority tinyint NOT NULL DEFAULT '0',
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority, time_next)
+  index next_idx(priority asc, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -61,7 +61,7 @@ create table my_message(
   priority tinyint NOT NULL DEFAULT '0',
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority, time_next)
+  index next_idx(priority asc, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 


### PR DESCRIPTION
MySQL 8 added support for [descending indexes](https://dev.mysql.com/doc/refman/8.0/en/descending-indexes.html) (the `DESC` clause is stripped and ignored in MySQL 5.7 and older).

Leveraging that for [Vitess Messaging](https://vitess.io/docs/14.0/reference/features/messaging/) tables is very important because of [the query used to read unprocessed messages from the underlying MySQL table](https://github.com/vitessio/vitess/blob/eeb05bfb22ac3fb03b161efd980ac049bbb662f5/go/vt/vttablet/tabletserver/messager/message_manager.go#L254-L256).

Without the index defined to match the `ORDER BY` clause — `priority ASC, time_next DESC` (`ASC` being the default) — then we have to do a full table scan, order the results using a filesort, and only then can we apply the `LIMIT` to the ordered results. That can be quite problematic if the underlying table gets large or has other contention. With the index defined to match the `ORDER BY` clause the index condition gets pushed down to InnoDB and InnoDB uses b+ trees with the leaf nodes in an ordered linked list — so we find a starting point in the btree and can then scan the linked list, returning immediately after `LIMIT` number of records. You can [see a demonstration of that here](https://gist.github.com/mattlord/ca840e802301853c2ea5fe5fa7b5276d).

This PR simply updates the documentation to match [the unofficial recommendation that we already had in code](https://github.com/vitessio/vitess/blob/eeb05bfb22ac3fb03b161efd980ac049bbb662f5/go/test/endtoend/messaging/main_test.go#L40-L61).