### PR TITLE
Update message table schema for efficient poller and w/o potential message loss

### DIFF
--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -51,18 +51,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -53,15 +53,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
-  priority tinyint NOT NULL DEFAULT '0',
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority asc, time_next desc)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/en/docs/11.0/reference/features/messaging.md
+++ b/content/en/docs/11.0/reference/features/messaging.md
@@ -1,7 +1,5 @@
 ---
-title: Messaging
-weight: 18
-aliases: ['/docs/advanced/messaging/','/docs/reference/messaging/']
+title: Vitess Messaging
 ---
 
 Vitess messaging gives the application an easy way to schedule and manage work
@@ -15,10 +13,11 @@ properties:
   successful ack is received.
 * **Non-blocking**: If the sending is backlogged, new messages continue to be
   accepted for eventual delivery.
-* **Adaptive**: Messages that fail delivery are backed off exponentially.
-* **Analytics**: The retention period for messages is dictated by the
-  application. One could potentially choose to never delete any messages and
-  use the data for performing analytics.
+* **Adaptive**: Messages that fail delivery are backed off exponentially with
+  jitter to prevent thundering herds.
+* **Analytics**: Acknowledged messages are retained for a period of time — dictated
+  by the `time_acked` value for the row and the `vt_purge_after` (seconds) value
+  provided for the table — and can be used for analytics.
 * **Transactional**: Messages can be created or acked as part of an existing
   transaction. The action will complete only if the commit succeeds.
 
@@ -39,13 +38,13 @@ Messages are good for:
 
 Messages are not a good fit for the following use cases:
 
-* Broadcasting of events to multiple subscribers.
+* Broadcasting each event to multiple subscribers.
 * Ordered delivery.
 * Real-time delivery.
 
 ## Creating a message table
 
-The current implementation requires a fixed schema. This will be made more
+The current implementation requires a base fixed schema. This will be made more
 flexible in the future. There will also be a custom DDL syntax. For now, a
 message table must be created like this:
 
@@ -54,13 +53,13 @@ create table my_message(
   # required columns
   id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
   priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
-  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends the message, and is used for incremental backoff doubling',
   time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
   time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
 
   # add as many custom fields here as required
   # optional - these are suggestions
-  tenant_id bigint,
+  tenant_id bigint COMMENT 'offers a nice way to segment your messages',
   message json,
 
   # required indexes
@@ -73,10 +72,9 @@ create table my_message(
 
 The application-related columns are as follows:
 
-* `id`: can be any type. Must be unique.
+* `id`: can be any type. Must be unique (for sharded message tables, this will typically be your primary vindex column).
 * `message`: can be any type.
-* `time_scheduled`: must be a bigint. It will be used to store unix time in
-  nanoseconds. If unspecified, the `Now` value is inserted.
+* `priority`: messages with a lower priority will be processed first.
 
 The above indexes are recommended for optimum performance. However, some
 variation can be allowed to achieve different performance trade-offs.
@@ -85,6 +83,8 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+  backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30s for the first message ack. If one is not
   received, resend.
 * `vt_purge_after=86400`: Purge acked messages that are older than 86400
@@ -99,10 +99,10 @@ operation will be allowed on a table that has failed to load.
 
 ## Enqueuing messages
 
-The application can enqueue messages using an insert statement:
+The application can enqueue messages using an insert statement, for example:
 
 ```sql
-insert into my_message(id, message) values(1, 'hello world')
+insert into my_message(id, message) values(1, '{"message": "hello world"}')
 ```
 
 These inserts can be part of a regular transaction. Multiple messages can be
@@ -110,25 +110,18 @@ inserted to different tables. Avoid accumulating too many big messages within a
 transaction as it consumes memory on the VTTablet side. At the time of commit,
 memory permitting, all messages are instantly enqueued to be sent.
 
-Messages can also be created to be sent in the future:
-
-```sql
-insert into my_message(id, message, time_scheduled) values(1, 'hello world', :future_time)
-```
-
-`future_time` must be the unix time expressed in nanoseconds.
-
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-request to VTGate. If there are multiple subscribers, the messages will be
+gRPC request to VTGate or using the `stream * from <table>` SQL statement
+(if using the interactive mysql command-line client you must also pass the
+`-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that this is not a broadcast; Each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a vitess `Result`. This means that
 standard database tools that understand query results can also be message
-recipients. Currently, there is no SQL format for subscribing to messages, but
-one will be provided soon.
+recipients.
 
 ### Subsetting
 
@@ -147,7 +140,8 @@ request parameters are as follows:
 
 ## Acknowledging messages
 
-A received (or processed) message can be acknowledged using the `MessageAck`
+A received and processed (you've completed some meaningful work based on the
+message contents) message can be acknowledged using the `MessageAck`
 API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
@@ -161,7 +155,8 @@ Once a message is successfully acked, it will never be resent.
 
 A message that was successfully sent will wait for the specified ack wait time.
 If no ack is received by then, it will be resent. The next attempt will be 2x
-the previous wait, and this delay is doubled for every attempt.
+the previous wait, and this delay is doubled for every attempt (with some added
+jitter to avoid thundering herds).
 
 ## Purging
 
@@ -170,50 +165,36 @@ exceeds the time period specified by `vt_purge_after`.
 
 ## Advanced usage
 
-The `MessageAck` functionality is currently an API call and cannot be used
-inside a transaction. However, you can ack messages using a regular DML. It
-should look like this:
+The `MessageAck` functionality is currently an gRPC API call and cannot be used
+inside a transaction or more generally from the SQL interface. However, you can
+manually ack messages using a regular DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null
 ```
 
-You can manually change the schedule of existing messages with a statement like
+You can also manually change the schedule of existing messages with a statement like
 this:
 
 ```sql
-update my_message set time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
+update my_message set priority = :priority, time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
 ```
 
 This comes in handy if a bunch of messages had chronic failures and got
 postponed to the distant future. If the root cause of the problem was fixed,
 the application could reschedule them to be delivered immediately. You can also
-optionally change the epoch. Lower epoch values increase the priority of the
-message and the back-off is less aggressive.
+optionally change the priroity and or epoch. Lower priority and epoch values
+both increase the priority of the message and the back-off is less aggressive.
 
-You can also view messages using regular `select` queries.
-
-## Undocumented features
-
-These are features that were previously known limitations, but have since been supported
-and are awaiting further documentation.
-
-* Flexible columns: Allow any number of application defined columns to be in
-  the message table.
-* No ACL check for receivers: To be added.
-* Monitoring support: To be added.
-* Dropped tables: The message engine does not currently detect dropped tables.
+You can also view messages using regular `select` queries against the message table.
 
 ## Known limitations
 
-The message feature is currently in alpha, and can be improved. Here is the
-list of possible limitations/improvements:
+Here is a short list of possible limitations/improvements:
 
 * Proactive scheduling: Upcoming messages can be proactively scheduled for
   timely delivery instead of waiting for the next polling cycle.
 * Changed properties: Although the engine detects new message tables, it does
   not refresh properties of an existing table.
-* A `SELECT` style syntax for subscribing to messages.
-* No rate limiting.
-* Usage of partitions for efficient purging.
+* Usage of MySQL partitions for more efficient purging.
 

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -51,18 +51,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -53,15 +53,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
-  priority tinyint NOT NULL DEFAULT '0',
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority asc, time_next desc)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/en/docs/12.0/reference/features/messaging.md
+++ b/content/en/docs/12.0/reference/features/messaging.md
@@ -1,7 +1,5 @@
 ---
-title: Messaging
-weight: 18
-aliases: ['/docs/advanced/messaging/','/docs/reference/messaging/']
+title: Vitess Messaging
 ---
 
 Vitess messaging gives the application an easy way to schedule and manage work
@@ -15,10 +13,11 @@ properties:
   successful ack is received.
 * **Non-blocking**: If the sending is backlogged, new messages continue to be
   accepted for eventual delivery.
-* **Adaptive**: Messages that fail delivery are backed off exponentially.
-* **Analytics**: The retention period for messages is dictated by the
-  application. One could potentially choose to never delete any messages and
-  use the data for performing analytics.
+* **Adaptive**: Messages that fail delivery are backed off exponentially with
+  jitter to prevent thundering herds.
+* **Analytics**: Acknowledged messages are retained for a period of time — dictated
+  by the `time_acked` value for the row and the `vt_purge_after` (seconds) value
+  provided for the table — and can be used for analytics.
 * **Transactional**: Messages can be created or acked as part of an existing
   transaction. The action will complete only if the commit succeeds.
 
@@ -39,13 +38,13 @@ Messages are good for:
 
 Messages are not a good fit for the following use cases:
 
-* Broadcasting of events to multiple subscribers.
+* Broadcasting each event to multiple subscribers.
 * Ordered delivery.
 * Real-time delivery.
 
 ## Creating a message table
 
-The current implementation requires a fixed schema. This will be made more
+The current implementation requires a base fixed schema. This will be made more
 flexible in the future. There will also be a custom DDL syntax. For now, a
 message table must be created like this:
 
@@ -54,13 +53,13 @@ create table my_message(
   # required columns
   id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
   priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
-  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends the message, and is used for incremental backoff doubling',
   time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
   time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
 
   # add as many custom fields here as required
   # optional - these are suggestions
-  tenant_id bigint,
+  tenant_id bigint COMMENT 'offers a nice way to segment your messages',
   message json,
 
   # required indexes
@@ -73,10 +72,9 @@ create table my_message(
 
 The application-related columns are as follows:
 
-* `id`: can be any type. Must be unique.
+* `id`: can be any type. Must be unique (for sharded message tables, this will typically be your primary vindex column).
 * `message`: can be any type.
-* `time_scheduled`: must be a bigint. It will be used to store unix time in
-  nanoseconds. If unspecified, the `Now` value is inserted.
+* `priority`: messages with a lower priority will be processed first.
 
 The above indexes are recommended for optimum performance. However, some
 variation can be allowed to achieve different performance trade-offs.
@@ -85,6 +83,8 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+  backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30s for the first message ack. If one is not
   received, resend.
 * `vt_purge_after=86400`: Purge acked messages that are older than 86400
@@ -99,10 +99,10 @@ operation will be allowed on a table that has failed to load.
 
 ## Enqueuing messages
 
-The application can enqueue messages using an insert statement:
+The application can enqueue messages using an insert statement, for example:
 
 ```sql
-insert into my_message(id, message) values(1, 'hello world')
+insert into my_message(id, message) values(1, '{"message": "hello world"}')
 ```
 
 These inserts can be part of a regular transaction. Multiple messages can be
@@ -110,25 +110,18 @@ inserted to different tables. Avoid accumulating too many big messages within a
 transaction as it consumes memory on the VTTablet side. At the time of commit,
 memory permitting, all messages are instantly enqueued to be sent.
 
-Messages can also be created to be sent in the future:
-
-```sql
-insert into my_message(id, message, time_scheduled) values(1, 'hello world', :future_time)
-```
-
-`future_time` must be the unix time expressed in nanoseconds.
-
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-request to VTGate. If there are multiple subscribers, the messages will be
+gRPC request to VTGate or using the `stream * from <table>` SQL statement
+(if using the interactive mysql command-line client you must also pass the
+`-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that this is not a broadcast; Each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a vitess `Result`. This means that
 standard database tools that understand query results can also be message
-recipients. Currently, there is no SQL format for subscribing to messages, but
-one will be provided soon.
+recipients.
 
 ### Subsetting
 
@@ -147,7 +140,8 @@ request parameters are as follows:
 
 ## Acknowledging messages
 
-A received (or processed) message can be acknowledged using the `MessageAck`
+A received and processed (you've completed some meaningful work based on the
+message contents) message can be acknowledged using the `MessageAck`
 API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
@@ -161,7 +155,8 @@ Once a message is successfully acked, it will never be resent.
 
 A message that was successfully sent will wait for the specified ack wait time.
 If no ack is received by then, it will be resent. The next attempt will be 2x
-the previous wait, and this delay is doubled for every attempt.
+the previous wait, and this delay is doubled for every attempt (with some added
+jitter to avoid thundering herds).
 
 ## Purging
 
@@ -170,50 +165,36 @@ exceeds the time period specified by `vt_purge_after`.
 
 ## Advanced usage
 
-The `MessageAck` functionality is currently an API call and cannot be used
-inside a transaction. However, you can ack messages using a regular DML. It
-should look like this:
+The `MessageAck` functionality is currently an gRPC API call and cannot be used
+inside a transaction or more generally from the SQL interface. However, you can
+manually ack messages using a regular DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null
 ```
 
-You can manually change the schedule of existing messages with a statement like
+You can also manually change the schedule of existing messages with a statement like
 this:
 
 ```sql
-update my_message set time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
+update my_message set priority = :priority, time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
 ```
 
 This comes in handy if a bunch of messages had chronic failures and got
 postponed to the distant future. If the root cause of the problem was fixed,
 the application could reschedule them to be delivered immediately. You can also
-optionally change the epoch. Lower epoch values increase the priority of the
-message and the back-off is less aggressive.
+optionally change the priroity and or epoch. Lower priority and epoch values
+both increase the priority of the message and the back-off is less aggressive.
 
-You can also view messages using regular `select` queries.
-
-## Undocumented features
-
-These are features that were previously known limitations, but have since been supported
-and are awaiting further documentation.
-
-* Flexible columns: Allow any number of application defined columns to be in
-  the message table.
-* No ACL check for receivers: To be added.
-* Monitoring support: To be added.
-* Dropped tables: The message engine does not currently detect dropped tables.
+You can also view messages using regular `select` queries against the message table.
 
 ## Known limitations
 
-The message feature is currently in alpha, and can be improved. Here is the
-list of possible limitations/improvements:
+Here is a short list of possible limitations/improvements:
 
 * Proactive scheduling: Upcoming messages can be proactively scheduled for
   timely delivery instead of waiting for the next polling cycle.
 * Changed properties: Although the engine detects new message tables, it does
   not refresh properties of an existing table.
-* A `SELECT` style syntax for subscribing to messages.
-* No rate limiting.
-* Usage of partitions for efficient purging.
+* Usage of MySQL partitions for more efficient purging.
 

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -51,18 +51,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -53,15 +53,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
-  priority tinyint NOT NULL DEFAULT '0',
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority asc, time_next desc)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/en/docs/13.0/reference/features/messaging.md
+++ b/content/en/docs/13.0/reference/features/messaging.md
@@ -1,7 +1,5 @@
 ---
-title: Messaging
-weight: 18
-aliases: ['/docs/advanced/messaging/','/docs/reference/messaging/']
+title: Vitess Messaging
 ---
 
 Vitess messaging gives the application an easy way to schedule and manage work
@@ -15,10 +13,11 @@ properties:
   successful ack is received.
 * **Non-blocking**: If the sending is backlogged, new messages continue to be
   accepted for eventual delivery.
-* **Adaptive**: Messages that fail delivery are backed off exponentially.
-* **Analytics**: The retention period for messages is dictated by the
-  application. One could potentially choose to never delete any messages and
-  use the data for performing analytics.
+* **Adaptive**: Messages that fail delivery are backed off exponentially with
+  jitter to prevent thundering herds.
+* **Analytics**: Acknowledged messages are retained for a period of time — dictated
+  by the `time_acked` value for the row and the `vt_purge_after` (seconds) value
+  provided for the table — and can be used for analytics.
 * **Transactional**: Messages can be created or acked as part of an existing
   transaction. The action will complete only if the commit succeeds.
 
@@ -39,13 +38,13 @@ Messages are good for:
 
 Messages are not a good fit for the following use cases:
 
-* Broadcasting of events to multiple subscribers.
+* Broadcasting each event to multiple subscribers.
 * Ordered delivery.
 * Real-time delivery.
 
 ## Creating a message table
 
-The current implementation requires a fixed schema. This will be made more
+The current implementation requires a base fixed schema. This will be made more
 flexible in the future. There will also be a custom DDL syntax. For now, a
 message table must be created like this:
 
@@ -54,13 +53,13 @@ create table my_message(
   # required columns
   id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
   priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
-  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends the message, and is used for incremental backoff doubling',
   time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
   time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
 
   # add as many custom fields here as required
   # optional - these are suggestions
-  tenant_id bigint,
+  tenant_id bigint COMMENT 'offers a nice way to segment your messages',
   message json,
 
   # required indexes
@@ -73,10 +72,9 @@ create table my_message(
 
 The application-related columns are as follows:
 
-* `id`: can be any type. Must be unique.
+* `id`: can be any type. Must be unique (for sharded message tables, this will typically be your primary vindex column).
 * `message`: can be any type.
-* `time_scheduled`: must be a bigint. It will be used to store unix time in
-  nanoseconds. If unspecified, the `Now` value is inserted.
+* `priority`: messages with a lower priority will be processed first.
 
 The above indexes are recommended for optimum performance. However, some
 variation can be allowed to achieve different performance trade-offs.
@@ -85,6 +83,8 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+  backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30s for the first message ack. If one is not
   received, resend.
 * `vt_purge_after=86400`: Purge acked messages that are older than 86400
@@ -99,10 +99,10 @@ operation will be allowed on a table that has failed to load.
 
 ## Enqueuing messages
 
-The application can enqueue messages using an insert statement:
+The application can enqueue messages using an insert statement, for example:
 
 ```sql
-insert into my_message(id, message) values(1, 'hello world')
+insert into my_message(id, message) values(1, '{"message": "hello world"}')
 ```
 
 These inserts can be part of a regular transaction. Multiple messages can be
@@ -110,25 +110,18 @@ inserted to different tables. Avoid accumulating too many big messages within a
 transaction as it consumes memory on the VTTablet side. At the time of commit,
 memory permitting, all messages are instantly enqueued to be sent.
 
-Messages can also be created to be sent in the future:
-
-```sql
-insert into my_message(id, message, time_scheduled) values(1, 'hello world', :future_time)
-```
-
-`future_time` must be the unix time expressed in nanoseconds.
-
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-request to VTGate. If there are multiple subscribers, the messages will be
+gRPC request to VTGate or using the `stream * from <table>` SQL statement
+(if using the interactive mysql command-line client you must also pass the
+`-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that this is not a broadcast; Each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a vitess `Result`. This means that
 standard database tools that understand query results can also be message
-recipients. Currently, there is no SQL format for subscribing to messages, but
-one will be provided soon.
+recipients.
 
 ### Subsetting
 
@@ -147,7 +140,8 @@ request parameters are as follows:
 
 ## Acknowledging messages
 
-A received (or processed) message can be acknowledged using the `MessageAck`
+A received and processed (you've completed some meaningful work based on the
+message contents) message can be acknowledged using the `MessageAck`
 API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
@@ -161,7 +155,8 @@ Once a message is successfully acked, it will never be resent.
 
 A message that was successfully sent will wait for the specified ack wait time.
 If no ack is received by then, it will be resent. The next attempt will be 2x
-the previous wait, and this delay is doubled for every attempt.
+the previous wait, and this delay is doubled for every attempt (with some added
+jitter to avoid thundering herds).
 
 ## Purging
 
@@ -170,50 +165,36 @@ exceeds the time period specified by `vt_purge_after`.
 
 ## Advanced usage
 
-The `MessageAck` functionality is currently an API call and cannot be used
-inside a transaction. However, you can ack messages using a regular DML. It
-should look like this:
+The `MessageAck` functionality is currently an gRPC API call and cannot be used
+inside a transaction or more generally from the SQL interface. However, you can
+manually ack messages using a regular DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null
 ```
 
-You can manually change the schedule of existing messages with a statement like
+You can also manually change the schedule of existing messages with a statement like
 this:
 
 ```sql
-update my_message set time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
+update my_message set priority = :priority, time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
 ```
 
 This comes in handy if a bunch of messages had chronic failures and got
 postponed to the distant future. If the root cause of the problem was fixed,
 the application could reschedule them to be delivered immediately. You can also
-optionally change the epoch. Lower epoch values increase the priority of the
-message and the back-off is less aggressive.
+optionally change the priroity and or epoch. Lower priority and epoch values
+both increase the priority of the message and the back-off is less aggressive.
 
-You can also view messages using regular `select` queries.
-
-## Undocumented features
-
-These are features that were previously known limitations, but have since been supported
-and are awaiting further documentation.
-
-* Flexible columns: Allow any number of application defined columns to be in
-  the message table.
-* No ACL check for receivers: To be added.
-* Monitoring support: To be added.
-* Dropped tables: The message engine does not currently detect dropped tables.
+You can also view messages using regular `select` queries against the message table.
 
 ## Known limitations
 
-The message feature is currently in alpha, and can be improved. Here is the
-list of possible limitations/improvements:
+Here is a short list of possible limitations/improvements:
 
 * Proactive scheduling: Upcoming messages can be proactively scheduled for
   timely delivery instead of waiting for the next polling cycle.
 * Changed properties: Although the engine detects new message tables, it does
   not refresh properties of an existing table.
-* A `SELECT` style syntax for subscribing to messages.
-* No rate limiting.
-* Usage of partitions for efficient purging.
+* Usage of MySQL partitions for more efficient purging.
 

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -51,18 +51,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -53,15 +53,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
-  priority tinyint NOT NULL DEFAULT '0',
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(priority asc, time_next desc)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/en/docs/14.0/reference/features/messaging.md
+++ b/content/en/docs/14.0/reference/features/messaging.md
@@ -1,7 +1,5 @@
 ---
-title: Messaging
-weight: 18
-aliases: ['/docs/advanced/messaging/','/docs/reference/messaging/']
+title: Vitess Messaging
 ---
 
 Vitess messaging gives the application an easy way to schedule and manage work
@@ -15,10 +13,11 @@ properties:
   successful ack is received.
 * **Non-blocking**: If the sending is backlogged, new messages continue to be
   accepted for eventual delivery.
-* **Adaptive**: Messages that fail delivery are backed off exponentially.
-* **Analytics**: The retention period for messages is dictated by the
-  application. One could potentially choose to never delete any messages and
-  use the data for performing analytics.
+* **Adaptive**: Messages that fail delivery are backed off exponentially with
+  jitter to prevent thundering herds.
+* **Analytics**: Acknowledged messages are retained for a period of time — dictated
+  by the `time_acked` value for the row and the `vt_purge_after` (seconds) value
+  provided for the table — and can be used for analytics.
 * **Transactional**: Messages can be created or acked as part of an existing
   transaction. The action will complete only if the commit succeeds.
 
@@ -39,13 +38,13 @@ Messages are good for:
 
 Messages are not a good fit for the following use cases:
 
-* Broadcasting of events to multiple subscribers.
+* Broadcasting each event to multiple subscribers.
 * Ordered delivery.
 * Real-time delivery.
 
 ## Creating a message table
 
-The current implementation requires a fixed schema. This will be made more
+The current implementation requires a base fixed schema. This will be made more
 flexible in the future. There will also be a custom DDL syntax. For now, a
 message table must be created like this:
 
@@ -54,13 +53,13 @@ create table my_message(
   # required columns
   id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
   priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
-  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends the message, and is used for incremental backoff doubling',
   time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
   time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
 
   # add as many custom fields here as required
   # optional - these are suggestions
-  tenant_id bigint,
+  tenant_id bigint COMMENT 'offers a nice way to segment your messages',
   message json,
 
   # required indexes
@@ -73,10 +72,9 @@ create table my_message(
 
 The application-related columns are as follows:
 
-* `id`: can be any type. Must be unique.
+* `id`: can be any type. Must be unique (for sharded message tables, this will typically be your primary vindex column).
 * `message`: can be any type.
-* `time_scheduled`: must be a bigint. It will be used to store unix time in
-  nanoseconds. If unspecified, the `Now` value is inserted.
+* `priority`: messages with a lower priority will be processed first.
 
 The above indexes are recommended for optimum performance. However, some
 variation can be allowed to achieve different performance trade-offs.
@@ -85,6 +83,8 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+  backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30s for the first message ack. If one is not
   received, resend.
 * `vt_purge_after=86400`: Purge acked messages that are older than 86400
@@ -99,10 +99,10 @@ operation will be allowed on a table that has failed to load.
 
 ## Enqueuing messages
 
-The application can enqueue messages using an insert statement:
+The application can enqueue messages using an insert statement, for example:
 
 ```sql
-insert into my_message(id, message) values(1, 'hello world')
+insert into my_message(id, message) values(1, '{"message": "hello world"}')
 ```
 
 These inserts can be part of a regular transaction. Multiple messages can be
@@ -110,25 +110,18 @@ inserted to different tables. Avoid accumulating too many big messages within a
 transaction as it consumes memory on the VTTablet side. At the time of commit,
 memory permitting, all messages are instantly enqueued to be sent.
 
-Messages can also be created to be sent in the future:
-
-```sql
-insert into my_message(id, message, time_scheduled) values(1, 'hello world', :future_time)
-```
-
-`future_time` must be the unix time expressed in nanoseconds.
-
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-request to VTGate. If there are multiple subscribers, the messages will be
+gRPC request to VTGate or using the `stream * from <table>` SQL statement
+(if using the interactive mysql command-line client you must also pass the
+`-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that this is not a broadcast; Each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a vitess `Result`. This means that
 standard database tools that understand query results can also be message
-recipients. Currently, there is no SQL format for subscribing to messages, but
-one will be provided soon.
+recipients.
 
 ### Subsetting
 
@@ -147,7 +140,8 @@ request parameters are as follows:
 
 ## Acknowledging messages
 
-A received (or processed) message can be acknowledged using the `MessageAck`
+A received and processed (you've completed some meaningful work based on the
+message contents) message can be acknowledged using the `MessageAck`
 API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
@@ -161,7 +155,8 @@ Once a message is successfully acked, it will never be resent.
 
 A message that was successfully sent will wait for the specified ack wait time.
 If no ack is received by then, it will be resent. The next attempt will be 2x
-the previous wait, and this delay is doubled for every attempt.
+the previous wait, and this delay is doubled for every attempt (with some added
+jitter to avoid thundering herds).
 
 ## Purging
 
@@ -170,50 +165,36 @@ exceeds the time period specified by `vt_purge_after`.
 
 ## Advanced usage
 
-The `MessageAck` functionality is currently an API call and cannot be used
-inside a transaction. However, you can ack messages using a regular DML. It
-should look like this:
+The `MessageAck` functionality is currently an gRPC API call and cannot be used
+inside a transaction or more generally from the SQL interface. However, you can
+manually ack messages using a regular DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null
 ```
 
-You can manually change the schedule of existing messages with a statement like
+You can also manually change the schedule of existing messages with a statement like
 this:
 
 ```sql
-update my_message set time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
+update my_message set priority = :priority, time_next = :time_next, epoch = :epoch where id in ::ids and time_acked is null
 ```
 
 This comes in handy if a bunch of messages had chronic failures and got
 postponed to the distant future. If the root cause of the problem was fixed,
 the application could reschedule them to be delivered immediately. You can also
-optionally change the epoch. Lower epoch values increase the priority of the
-message and the back-off is less aggressive.
+optionally change the priroity and or epoch. Lower priority and epoch values
+both increase the priority of the message and the back-off is less aggressive.
 
-You can also view messages using regular `select` queries.
-
-## Undocumented features
-
-These are features that were previously known limitations, but have since been supported
-and are awaiting further documentation.
-
-* Flexible columns: Allow any number of application defined columns to be in
-  the message table.
-* No ACL check for receivers: To be added.
-* Monitoring support: To be added.
-* Dropped tables: The message engine does not currently detect dropped tables.
+You can also view messages using regular `select` queries against the message table.
 
 ## Known limitations
 
-The message feature is currently in alpha, and can be improved. Here is the
-list of possible limitations/improvements:
+Here is a short list of possible limitations/improvements:
 
 * Proactive scheduling: Upcoming messages can be proactively scheduled for
   timely delivery instead of waiting for the next polling cycle.
 * Changed properties: Although the engine detects new message tables, it does
   not refresh properties of an existing table.
-* A `SELECT` style syntax for subscribing to messages.
-* No rate limiting.
-* Usage of partitions for efficient purging.
+* Usage of MySQL partitions for more efficient purging.
 

--- a/content/zh/docs/11.0/reference/messaging.md
+++ b/content/zh/docs/11.0/reference/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/zh/docs/11.0/reference/messaging.md
+++ b/content/zh/docs/11.0/reference/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/zh/docs/11.0/reference/messaging.md
+++ b/content/zh/docs/11.0/reference/messaging.md
@@ -51,14 +51,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(time_next, epoch)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/zh/docs/11.0/reference/messaging.md
+++ b/content/zh/docs/11.0/reference/messaging.md
@@ -49,18 +49,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/zh/docs/12.0/reference/messaging.md
+++ b/content/zh/docs/12.0/reference/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/zh/docs/12.0/reference/messaging.md
+++ b/content/zh/docs/12.0/reference/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/zh/docs/12.0/reference/messaging.md
+++ b/content/zh/docs/12.0/reference/messaging.md
@@ -51,14 +51,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(time_next, epoch)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/zh/docs/12.0/reference/messaging.md
+++ b/content/zh/docs/12.0/reference/messaging.md
@@ -49,18 +49,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/zh/docs/13.0/reference/messaging.md
+++ b/content/zh/docs/13.0/reference/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/zh/docs/13.0/reference/messaging.md
+++ b/content/zh/docs/13.0/reference/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/zh/docs/13.0/reference/messaging.md
+++ b/content/zh/docs/13.0/reference/messaging.md
@@ -51,14 +51,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(time_next, epoch)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/zh/docs/13.0/reference/messaging.md
+++ b/content/zh/docs/13.0/reference/messaging.md
@@ -49,18 +49,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:

--- a/content/zh/docs/14.0/reference/messaging.md
+++ b/content/zh/docs/14.0/reference/messaging.md
@@ -166,8 +166,8 @@ exceeds the time period specified by `vt_purge_after`.
 ## Advanced usage
 
 The `MessageAck` functionality is currently an gRPC API call and cannot be used
-inside a transaction or more generally from the SQL interface. However, you can
-manually ack messages using a regular DML query like this:
+from the SQL interface. However, you can manually ack messages using a regular
+DML query like this:
 
 ```sql
 update my_message set time_acked = :time_acked, time_next = null where id in ::ids and time_acked is null

--- a/content/zh/docs/14.0/reference/messaging.md
+++ b/content/zh/docs/14.0/reference/messaging.md
@@ -44,7 +44,8 @@ Messages are not a good fit for the following use cases:
 ## Creating a message table
 
 The current implementation requires a base fixed schema with properties defined
-using specific table COMMENT directives. The message table format is as follows:
+using Vitess specific table `COMMENT` directives. The message table format is as
+follows:
 
 ```sql
 create table my_message(
@@ -81,7 +82,7 @@ The comment section specifies additional configuration parameters. The fields
 are as follows:
 
 * `vitess_message`: Indicates that this is a message table.
-* `vt_min_backoff=30`, `vt_max_backoff=3600`: set bounds, in seconds, on exponential
+* `vt_min_backoff=30`, `vt_max_backoff=3600`: Set bounds, in seconds, on exponential
   backoff for message retries.
 * `vt_ack_wait=30`: Wait for 30 seconds for the *first* message send to be acked.
   If one is not received within this time frame, the message will be resent.
@@ -112,22 +113,22 @@ memory permitting, all messages are instantly enqueued to be sent.
 ## Receiving messages
 
 Processes can subscribe to receive messages by sending a `MessageStream`
-gRPC request to VTGate or using the `stream * from <table>` SQL statement
+gRPC request to a `VTGate` or using the `stream * from <table>` SQL statement
 (if using the interactive mysql command-line client you must also pass the
 `-q`/`--quick` option). If there are multiple subscribers, the messages will be
 delivered in a round-robin fashion. Note that *this is not a broadcast*; each
 message will be sent to at most one subscriber.
 
 The format for messages is the same as a standard Vitess `Result` received from
-a vtgate. This means that standard database tools that understand query results
+a `VTGate`. This means that standard database tools that understand query results
 can also be message receivers.
 
 ### Subsetting
 
 It's possible that you may want to subscribe to specific shards or groups of
 shards while requesting messages. This is useful for partitioning or load
-balancing. The `MessageStream` API allows you to specify these constraints. The
-request parameters are as follows:
+balancing. The `MessageStream` gRPC API call allows you to specify these
+constraints. The request parameters are as follows:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present.
@@ -141,7 +142,7 @@ request parameters are as follows:
 
 A received and processed (you've completed some meaningful work based on the
 message contents received) message can be acknowledged using the `MessageAck`
-API call. This call accepts the following parameters:
+gRPC API call. This call accepts the following parameters:
 
 * `Name`: Name of the message table.
 * `Keyspace`: Keyspace where the message table is present. This field can be
@@ -152,7 +153,7 @@ Once a message is successfully acked, it will never be resent.
 
 ## Exponential backoff
 
-A message that was successfully sent we will wait for the specified `vt_ack_wait`
+For a message that was successfully sent we will wait for the specified `vt_ack_wait`
 time. If no ack is received by then, it will be resent. The next attempt will be 2x
 the previous wait, and this delay is doubled for every attempt (with some added
 jitter to avoid thundering herds).

--- a/content/zh/docs/14.0/reference/messaging.md
+++ b/content/zh/docs/14.0/reference/messaging.md
@@ -51,14 +51,15 @@ message table must be created like this:
 create table my_message(
   time_scheduled bigint,
   id bigint,
-  time_next bigint,
+  time_next bigint DEFAULT 0,
   epoch bigint,
   time_created bigint,
   time_acked bigint,
   message varchar(128),
+  priority tinyint NOT NULL DEFAULT 0,
   primary key(time_scheduled, id),
   unique index id_idx(id),
-  index next_idx(time_next, epoch)
+  index poller_idx(time_acked, priority, time_next desc)
 ) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 

--- a/content/zh/docs/14.0/reference/messaging.md
+++ b/content/zh/docs/14.0/reference/messaging.md
@@ -49,18 +49,24 @@ message table must be created like this:
 
 ```sql
 create table my_message(
-  time_scheduled bigint,
-  id bigint,
-  time_next bigint DEFAULT 0,
-  epoch bigint,
-  time_created bigint,
-  time_acked bigint,
-  message varchar(128),
-  priority tinyint NOT NULL DEFAULT 0,
-  primary key(time_scheduled, id),
-  unique index id_idx(id),
+  # required columns
+  id bigint NOT NULL COMMENT 'often an event id, can also be auto-increment or a sequence',
+  priority tinyint NOT NULL DEFAULT '50' COMMENT 'lower number priorities process first',
+  epoch bigint NOT NULL DEFAULT '0' COMMENT 'Vitess increments this each time it sends a message, and is used for incremental backoff doubling',
+  time_next bigint DEFAULT 0 COMMENT 'the earliest time the message will be sent in epoch nanoseconds. Must be null if time_acked is set',
+  time_acked bigint DEFAULT NULL COMMENT 'the time the message was acked in epoch nanoseconds. Must be null if time_next is set',
+
+  # add as many custom fields here as required
+  # optional - these are suggestions
+  tenant_id bigint,
+  message json,
+
+  # required indexes
+  primary key(id),
   index poller_idx(time_acked, priority, time_next desc)
-) comment 'vitess_message,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
+
+  # add any secondary indexes or foreign keys - no restrictions
+) comment 'vitess_message,vt_min_backoff=30,vt_max_backoff=3600,vt_ack_wait=30,vt_purge_after=86400,vt_batch_size=10,vt_cache_size=10000,vt_poller_interval=30'
 ```
 
 The application-related columns are as follows:


### PR DESCRIPTION
This updates the docs based on the work done in: https://github.com/vitessio/vitess/pull/10132

The potential for loss of messages — or more accurately messages never sent — comes from the `time_next bigint` column definition that we had in the docs, which is effectively `time_next bigint DEFAULT NULL`.  If the `time_next` value is NULL, then [it *never* gets read from the underlying message table in the poller / results streamer query](https://github.com/vitessio/vitess/blob/c9853797bda8752202583695133c41a25d390930/go/vt/vttablet/tabletserver/messager/message_manager.go#L254-L256) because `<` is *not* NULL safe and that `< <time_next_val>` clause will never match those rows where the value is NULL (unknown). So while rows INSERTed with `time_next` being NULL _while the binlog streamer is running_ will catch these rows and process them, any rows INSERTed _while the binlog streamer is not running, or the cache is full, will be lost._ 

We were already [using a `DEFAULT 0` clause for the `time_next` column in our tests](https://github.com/vitessio/vitess/pull/10132/commits/1d3cbdcbec9a7db8aed3ac94eb6210131a68ffe1), but this was not done in the docs.