### PR TITLE
Vitess OnlineDDL no longer experimental

### DIFF
--- a/content/en/docs/14.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/_index.md
@@ -100,7 +100,7 @@ Vitess automatically garbage-collects the "old" tables, artifacts of `vitess`, `
 
 Vitess allows a variety of approaches to schema changes, from fully automated to fully owned by the user.
 
-- Managed, online schema changes are _experimental_ at this time, but are Vitess's way forward
+- Managed, online schema changes are the preferred approach in Vitess .
 - Direct, blocking ALTERs are generally impractical in production given that they can block writes for substantial lengths of time.
 - User controlled migrations are allowed, and under the user's responsibility.
 

--- a/content/en/docs/14.0/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/ddl-strategies.md
@@ -9,7 +9,7 @@ Vitess supports both managed, online schema migrations (aka Online DDL) as well 
 - `direct`: the direct apply of DDL to your database. This is not an online DDL. It is a synchronous and blocking operation. This is the default strategy. 
 - `vitess` (formerly known as `online`): utilizes Vitess's built in [VReplication](../../../reference/vreplication/vreplication/) mechanism. This is the preferred strategy in Vitess.
 - `gh-ost`: uses 3rd party GitHub's [gh-ost](https://github.com/github/gh-ost) tool.
-- `pt-osc`: uses 3rd party Percona's [pt-online-schema-change](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html) as part of [Percona Toolkit](https://www.percona.com/doc/percona-toolkit/3.0/index.html)
+- `pt-osc`: uses 3rd party Percona's [pt-online-schema-change](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html) as part of [Percona Toolkit](https://www.percona.com/doc/percona-toolkit/3.0/index.html). `pt-osc` strategy is **experimental**.
 
 `CREATE` and `DROP` are managed in the same way, by Vitess, whether strategy is `vitess`, `gh-ost` or `pt-osc`.
 

--- a/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
@@ -58,7 +58,7 @@ This statement can be executed as:
 
 - a `VReplication`, managed online migration
 - a `gh-ost`, managed online migration
-- a `pt-online-schema-change`, managed online migration
+- a `pt-online-schema-change`, managed online migration (**experimental**)
 - a synchronous, [unmanaged schema change](../unmanaged-schema-changes/)
 
 See [DDL Strategies](../ddl-strategies) for discussion around the different options.

--- a/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/managed-online-schema-changes.md
@@ -4,8 +4,6 @@ weight: 2
 aliases: ['/docs/user-guides/managed-online-schema-changes/']
 ---
 
-**Note:** `gh-ost` migrations are considered stable. `pt-osc` and `vitess` migrations are considered **EXPERIMENTAL**.
-
 Vitess offers managed, online schema migrations (aka Online DDL), transparently to the user. Vitess Onine DDL offers:
 
 - Non-blocking migrations
@@ -21,6 +19,7 @@ Vitess offers managed, online schema migrations (aka Online DDL), transparently 
 - See also [advanced usage](../advanced-usage/)
 
 As general overview:
+
 - User chooses a [strategy](../ddl-strategies) for online DDL (online DDL is opt in)
 - User submits one or more schema change queries, using the standard MySQL `CREATE TABLE`, `ALTER TABLE` and `DROP TABLE` syntax.
 - Vitess responds with a Job ID for each schema change query.


### PR DESCRIPTION
We consider Vitess's Online DDL to be production grade. This includein particular includes `vitess` strategy migrations, based on VReplication.

This PR updates the docs to remove "experimental" notes, and moreover indicate that Online DDL is the preferred way of running schema migrations in Vitess.
 