### PR TITLE
Update Reserved Conn documentation

### DIFF
--- a/content/en/docs/13.0/reference/query-serving/reserved-conn.md
+++ b/content/en/docs/13.0/reference/query-serving/reserved-conn.md
@@ -18,7 +18,8 @@ so that it does not actually do anything with user variables. Instead it keeps
 the state in the Vitess layer.
 
 In other cases, this approach is not enough, and Vitess can use 
-**reserved connections**. This means a dedicated connection is maintained for 
+**reserved connections**, which are controlled via the `-enable_system_settings` vtgate flag.
+Enabling reserved connections means a dedicated connection is maintained for 
 the `vtgate` session from the relevant `vttablet` to the MySQL server. Reserved 
 connections are used when changing system variables, using temporary tables, 
 or when using MySQL locking functions to acquire advisory locks. In general, it 

--- a/content/en/docs/14.0/reference/query-serving/reserved-conn.md
+++ b/content/en/docs/14.0/reference/query-serving/reserved-conn.md
@@ -18,7 +18,8 @@ so that it does not actually do anything with user variables. Instead it keeps
 the state in the Vitess layer.
 
 In other cases, this approach is not enough, and Vitess can use 
-**reserved connections**. This means a dedicated connection is maintained for 
+**reserved connections**, which are controlled via the `-enable_system_settings` vtgate flag.
+Enabling reserved connections means a dedicated connection is maintained for 
 the `vtgate` session from the relevant `vttablet` to the MySQL server. Reserved 
 connections are used when changing system variables, using temporary tables, 
 or when using MySQL locking functions to acquire advisory locks. In general, it 


### PR DESCRIPTION
Added a line to Reserved Conn feature description that mentions the vtgate flag `enable_system_settings`.

I updated v13 and v14 docs. v12 docs don't mention this var at all, so I did not want to add a line mentioning it without also updating the rest of the documentation to follow. I assume v12 documentation is of less importance at this time.

This was done to clearly call out, early in the Reserved Conn documentation what variable is used to enable/disable reserved conns. I reviewed the rest of the documentation and found it to be robust and clear as long as all links are followed and the documentation read in its entirety. 