### PR TITLE
Add netlify status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Vitess website
 
+[![Netlify Status](https://api.netlify.com/api/v1/badges/c27ea8e4-51d5-41b5-abfd-0597410506a3/deploy-status)](https://app.netlify.com/sites/vitess/deploys)
+
 This repo houses the assets used to build the website at https://vitess.io.
 
 ## Running the site locally


### PR DESCRIPTION
Signed-off-by: Sara Bee <855595+doeg@users.noreply.github.com>

Thought this was cute and useful as well! I don't feel strongly about merging it or anything though. :) 

Netlify does show partial deploy information for this repo even when logged out or not in the Netlify team, which is pretty handy: 

<img width="1904" alt="Screen Shot 2022-05-12 at 10 15 54 AM" src="https://user-images.githubusercontent.com/855595/168096185-2cea274d-84f8-47c9-8398-da81fce88971.png">

