### PR TITLE
Correct reshard -skip_schema_flag explanation

### DIFF
--- a/content/en/docs/11.0/reference/vreplication/reshard.md
+++ b/content/en/docs/11.0/reference/vreplication/reshard.md
@@ -32,7 +32,7 @@ Reshard is used to create and manage workflows to horizontally shard an existing
 <div class="cmd">
 
 Reshard is an "umbrella" command. The `action` sub-command defines the operation on the workflow.
-Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress 
+Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress
 
 </div>
 
@@ -81,8 +81,8 @@ Source Vitess tablet_type, or comma separated list of tablet types, that should 
 **default** false
 
 <div class="cmd">
-If true the source schema is copied to the target shards. If false, you need to create the tables
-before calling reshard.
+If false, the source schema is copied to the target shards. If true, the schema won't be copied
+and you need to create the tables before calling reshard.
 </div>
 
 #### -auto_start

--- a/content/en/docs/12.0/reference/vreplication/reshard.md
+++ b/content/en/docs/12.0/reference/vreplication/reshard.md
@@ -32,7 +32,7 @@ Reshard is used to create and manage workflows to horizontally shard an existing
 <div class="cmd">
 
 Reshard is an "umbrella" command. The `action` sub-command defines the operation on the workflow.
-Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress 
+Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress
 
 </div>
 
@@ -81,8 +81,8 @@ Source Vitess tablet_type, or comma separated list of tablet types, that should 
 **default** false
 
 <div class="cmd">
-If true the source schema is copied to the target shards. If false, you need to create the tables
-before calling reshard.
+If false, the source schema is copied to the target shards. If true, the schema won't be copied
+and you need to create the tables before calling reshard.
 </div>
 
 #### -auto_start

--- a/content/en/docs/13.0/reference/vreplication/reshard.md
+++ b/content/en/docs/13.0/reference/vreplication/reshard.md
@@ -32,7 +32,7 @@ Reshard is used to create and manage workflows to horizontally shard an existing
 <div class="cmd">
 
 Reshard is an "umbrella" command. The `action` sub-command defines the operation on the workflow.
-Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress 
+Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress
 
 </div>
 
@@ -81,8 +81,8 @@ Source Vitess tablet_type, or comma separated list of tablet types, that should 
 **default** false
 
 <div class="cmd">
-If true the source schema is copied to the target shards. If false, you need to create the tables
-before calling reshard.
+If false, the source schema is copied to the target shards. If true, the schema won't be copied
+and you need to create the tables before calling reshard.
 </div>
 
 #### -auto_start

--- a/content/en/docs/14.0/reference/vreplication/reshard.md
+++ b/content/en/docs/14.0/reference/vreplication/reshard.md
@@ -36,7 +36,7 @@ Reshard is used to create and manage workflows to horizontally shard an existing
 <div class="cmd">
 
 Reshard is an "umbrella" command. The `action` sub-command defines the operation on the workflow.
-Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress 
+Action must be one of the following: Create, Complete, Cancel, SwitchTraffic, ReverseTrafffic, Show, or Progress
 
 </div>
 
@@ -83,8 +83,8 @@ Source Vitess tablet_type, or comma separated list of tablet types, that should 
 **default** false
 
 <div class="cmd">
-If true the source schema is copied to the target shards. If false, you need to create the tables
-before calling reshard.
+If false, the source schema is copied to the target shards. If true, the schema won't be copied
+and you need to create the tables before calling reshard.
 </div>
 
 #### --auto_start


### PR DESCRIPTION
Logic in the explanation of the flag was backwards to what the flag actually does.

Also some whitespace fixes.