### PR TITLE
Fix warnings in examples

### DIFF
--- a/content/en/docs/14.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/14.0/user-guides/configuration-advanced/resharding.md
@@ -128,19 +128,19 @@ Applying the new VSchema instructs Vitess that the keyspace is sharded, which ma
 ### Using Operator
 
 ```bash
-vtctlclient ApplySchema -sql="$(cat create_commerce_seq.sql)" commerce
-vtctlclient ApplyVSchema -vschema="$(cat vschema_commerce_seq.json)" commerce
-vtctlclient ApplyVSchema -vschema="$(cat vschema_customer_sharded.json)" customer
-vtctlclient ApplySchema -sql="$(cat create_customer_sharded.sql)" customer
+vtctlclient ApplySchema -- --sql="$(cat create_commerce_seq.sql)" commerce
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_commerce_seq.json)" commerce
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_customer_sharded.json)" customer
+vtctlclient ApplySchema -- --sql="$(cat create_customer_sharded.sql)" customer
 ```
 
 ### Using a Local Deployment
 
 ``` sh
-vtctlclient ApplySchema -sql-file create_commerce_seq.sql commerce
-vtctlclient ApplyVSchema -vschema_file vschema_commerce_seq.json commerce
-vtctlclient ApplyVSchema -vschema_file vschema_customer_sharded.json customer
-vtctlclient ApplySchema -sql-file create_customer_sharded.sql customer
+vtctlclient ApplySchema -- --sql-file create_commerce_seq.sql commerce
+vtctlclient ApplyVSchema -- --vschema_file vschema_commerce_seq.json commerce
+vtctlclient ApplyVSchema -- --vschema_file vschema_customer_sharded.json customer
+vtctlclient ApplySchema -- --sql-file create_customer_sharded.sql customer
 ```
 
 ## Create new shards
@@ -185,9 +185,9 @@ This process starts the reshard operation. It occurs online, and will not block 
 
 ```bash
 # With Helm and Local Installation
-vtctlclient Reshard -source_shards '0' -target_shards '-80,80-' Create customer.cust2cust
+vtctlclient Reshard -- --source_shards '0' --target_shards '-80,80-' Create customer.cust2cust
 # With Operator
-vtctlclient Reshard -source_shards '-' -target_shards '-80,80-' Create customer.cust2cust
+vtctlclient Reshard -- --source_shards '-' --target_shards '-80,80-' Create customer.cust2cust
 ```
 
 All of the command options and parameters for `Reshard` are listed in our [reference page for Reshard](../../../reference/vreplication/reshard).
@@ -211,7 +211,7 @@ Summary for corder: {ProcessedRows:5 MatchingRows:5 MismatchedRows:0 ExtraRowsSo
 After validating for correctness, the next step is to switch read operations to occur at the new location. By switching read operations first, we are able to verify that the new tablet servers are healthy and able to respond to requests:
 
 ```bash
-vtctlclient Reshard -tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=rdonly,replica SwitchTraffic customer.cust2cust
 ```
 
 ## Switch Writes and Primary Reads
@@ -219,7 +219,7 @@ vtctlclient Reshard -tablet_types=rdonly,replica SwitchTraffic customer.cust2cus
 After the replica/rdonly reads have been switched, and the health of the system has been verified, it's time to switch writes. The usage is very similar to switching reads:
 
 ```bash
-vtctlclient Reshard -tablet_types=primary SwitchTraffic customer.cust2cust
+vtctlclient Reshard -- --tablet_types=primary SwitchTraffic customer.cust2cust
 ```
 
 ## Note

--- a/content/en/docs/14.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/14.0/user-guides/migration/move-tables.md
@@ -152,7 +152,7 @@ __Note:__ The following change does not change actual routing yet. We will use a
 In this step we will initiate the MoveTables, which copies tables from the commerce keyspace into customer. This operation does not block any database activity; the MoveTables operation is performed online:
 
 ```bash
-$ vtctlclient MoveTables -source commerce -tables 'customer,corder' Create customer.commerce2customer
+$ vtctlclient MoveTables -- --source commerce --tables 'customer,corder' Create customer.commerce2customer
 ```
 
 You can read this command as:  "Start copying the tables called **customer** and **corder** from the **commerce** keyspace to the **customer** keyspace."
@@ -236,7 +236,7 @@ This can obviously take a long time on very large tables.
 Once the MoveTables operation is complete, the first step in making the changes live is to _switch_ `SELECT` statements to read from the new keyspace. Other statements will continue to route to the `commerce` keyspace. By staging this as two operations, Vitess allows you to test the changes and reduce the associated risks. For example, you may have a different configuration of hardware or software on the new keyspace.
 
 ```bash
-vtctlclient MoveTables -tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
+vtctlclient MoveTables -- --tablet_types=rdonly,replica SwitchTraffic customer.commerce2customer
 ```
 
 ## Interlude: check the routing rules (optional)
@@ -354,7 +354,7 @@ As you can see, we now have requests to the `rdonly` and `replica` tablets for t
 After the replica/rdonly reads have been _switched_, and you have verified that the system is operating as expected, it is time to _switch_ the _write_ and primary read operations. The command to execute the switch is very similar to the one in Phase 1:
 
 ```bash
-$ vtctlclient MoveTables -tablet_types=primary SwitchTraffic customer.commerce2customer
+$ vtctlclient MoveTables -- --tablet_types=primary SwitchTraffic customer.commerce2customer
 ```
 
 ## Note


### PR DESCRIPTION
This PR fixes the warnings in commands that are provided in examples on the website to reflect the changes to the flag parsing to use double-dashed arguments.