### PR TITLE
update vtexplain flag

### DIFF
--- a/content/en/docs/14.0/reference/programs/vtexplain.md
+++ b/content/en/docs/14.0/reference/programs/vtexplain.md
@@ -26,22 +26,22 @@ vtexplain -shards 128 -vschema-file vschema.json -schema-file schema.sql -replic
 
 The following parameters apply to `mysqlctl`:
 
-| Name | Type | Definition |
-| :-------------------- | :--------- | :---------------------------------------------------- |
-| -output-mode | string | Output in human-friendly text or json (default "text") |
-| -planner-version | string | Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "Gen4") |
-| -normalize |  | Whether to enable vtgate normalization (default false) |
-| -shards | int | Number of shards per keyspace (default 2) |
-| -replication-mode | string | The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW") |
-| -schema | string | The SQL table schema (default "") |
-| -schema-file | string | Identifies the file that contains the SQL table schema (default "") |
-| -sql | string | A list of semicolon-delimited SQL commands to analyze (default "") |
-| -sql-file | string | Identifies the file that contains the SQL commands to analyze (default "") |
-| -vschema | string | Identifies the VTGate routing schema (default "") |
-| -vschema-file | string | Identifies the VTGate routing schema file (default "") |
-| -ks-shard-map | string | Identifies the shard keyranges for unevenly-sharded keyspaces (default "") |
-| -ks-shard-map-file | string | Identifies the shard keyranges file (default "") |
-| -dbname | string | Optional database target to override normal routing (default "") |
+| Name                                 | Type | Definition |
+|:-------------------------------------| :--------- | :---------------------------------------------------- |
+| -output-mode                         | string | Output in human-friendly text or json (default "text") |
+| -planner_version                     | string | Sets the query planner version to use when generating the explain output. Valid values are V3 and Gen4 (default "Gen4") |
+| -normalize                           |  | Whether to enable vtgate normalization (default false) |
+| -shards                              | int | Number of shards per keyspace (default 2) |
+| -replication-mode                    | string | The replication mode to simulate -- must be set to either ROW or STATEMENT (default "ROW") |
+| -schema                              | string | The SQL table schema (default "") |
+| -schema-file                         | string | Identifies the file that contains the SQL table schema (default "") |
+| -sql                                 | string | A list of semicolon-delimited SQL commands to analyze (default "") |
+| -sql-file                            | string | Identifies the file that contains the SQL commands to analyze (default "") |
+| -vschema                             | string | Identifies the VTGate routing schema (default "") |
+| -vschema-file                        | string | Identifies the VTGate routing schema file (default "") |
+| -ks-shard-map                        | string | Identifies the shard keyranges for unevenly-sharded keyspaces (default "") |
+| -ks-shard-map-file                   | string | Identifies the shard keyranges file (default "") |
+| -dbname                              | string | Optional database target to override normal routing (default "") |
 | -queryserver-config-passthrough-dmls |  | query server pass through all dml statements without rewriting (default false) |
 
 <br>


### PR DESCRIPTION
Update the planner version flag to align with vtgate.

The indentation was automagically done by goland and not intentional, but I like it, so I kept it.