### PR TITLE
Fix section page filtering partials

### DIFF
--- a/layouts/partials/docs/pages-in-section.html
+++ b/layouts/partials/docs/pages-in-section.html
@@ -1,5 +1,5 @@
-{{ $skipSections := slice "vtctl" "vtctldclient" }}
-{{ $pages := where .RegularPages "Params.series" "not in" $skipSections }}
+{{ $pages := where .Pages "Params.series" "!=" "vtctl" }}
+{{ $pages := where $pages "Params.series" "!=" "vtctldclient" }}
 
 {{ if gt (len $pages) 0 }}
   <h3>

--- a/layouts/partials/docs/regular-pages-in-section.html
+++ b/layouts/partials/docs/regular-pages-in-section.html
@@ -1,5 +1,5 @@
-{{ $skipSections := slice "vtctl" "vtctldclient" }}
-{{ $pages := where .RegularPages "Params.series" "not in" $skipSections }}
+{{ $pages := where .RegularPages "Params.series" "!=" "vtctl" }}
+{{ $pages := where $pages "Params.series" "!=" "vtctldclient" }}
 
 {{ if gt (len $pages) 0 }}
   <h3>


### PR DESCRIPTION
This fixes #1057.

The `.Pages` => `.RegularPages` was a bad copy-paste from me in #1054, but doesn't solve the root problem. Apparently "not in" does not work as advertised, but doing two rounds of filtering does 🤷.

I checked a few other Section pages that should have these listings and they looked correct to me.