### PR TITLE
Documented the recent changes to the tablet gateway

### DIFF
--- a/content/en/docs/14.0/reference/programs/vtgate.md
+++ b/content/en/docs/14.0/reference/programs/vtgate.md
@@ -21,7 +21,6 @@ vtgate \
   --cell test \
   --cells_to_watch test \
   --tablet_types_to_wait PRIMARY,REPLICA \
-  --gateway_implementation tabletgateway \
   --service_map 'grpc-vtgateservice' \
   --pid_file $VTDATAROOT/tmp/vtgate.pid \
   --mysql_auth_server_impl none
@@ -58,7 +57,6 @@ The following global options apply to `vtgate`:
 | --enable_system_settings | boolean | Enables the system settings to be changed per session at the database connection level. Override with @@enable_system_settings session variable. |
 | --enable_set_var | boolean | This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections. |
 | --gate_query_cache_size | int | gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 10000) |
-| --gateway_implementation | string | The implementation of gateway (default "tabletgateway") |
 | --gateway_initial_tablet_timeout | duration | At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype (default 30s) |
 | --grpc_auth_mode | string | Which auth plugin implementation to use (eg: static) |
 | --grpc_auth_mtls_allowed_substrings | string | List of substrings of at least one of the client certificate names (separated by colon). |

--- a/content/en/docs/15.0/reference/programs/vtgate.md
+++ b/content/en/docs/15.0/reference/programs/vtgate.md
@@ -21,7 +21,6 @@ vtgate \
   --cell test \
   --cells_to_watch test \
   --tablet_types_to_wait PRIMARY,REPLICA \
-  --gateway_implementation tabletgateway \
   --service_map 'grpc-vtgateservice' \
   --pid_file $VTDATAROOT/tmp/vtgate.pid \
   --mysql_auth_server_impl none
@@ -58,7 +57,6 @@ The following global options apply to `vtgate`:
 | --enable_system_settings | boolean | Enables the system settings to be changed per session at the database connection level. Override with @@enable_system_settings session variable. |
 | --enable_set_var | boolean | This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections. |
 | --gate_query_cache_size | int | gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 10000) |
-| --gateway_implementation | string | The implementation of gateway (default "tabletgateway") |
 | --gateway_initial_tablet_timeout | duration | At startup, the gateway will wait up to that duration to get one tablet per keyspace/shard/tablettype (default 30s) |
 | --grpc_auth_mode | string | Which auth plugin implementation to use (eg: static) |
 | --grpc_auth_mtls_allowed_substrings | string | List of substrings of at least one of the client certificate names (separated by colon). |

--- a/wip-docs/doc/TabletRouting.md
+++ b/wip-docs/doc/TabletRouting.md
@@ -20,10 +20,10 @@ shard to use.
 The SrvKeyspace object contains the following information about a Keyspace, for
 a given cell:
 
-* The served_from field: for a given tablet type (master, replica, read-only),
+* The served_from field: for a given tablet type (primary/master, replica, rdonly),
   another keyspace is used to serve the data. This is used for vertical
   resharding.
-* The partitions field: for a given tablet type (master, replica, read-only),
+* The partitions field: for a given tablet type (primary/master, replica, read-only),
   the list of shards to use. This can change when we perform horizontal
   resharding.
 
@@ -49,7 +49,7 @@ tablet in turn returns:
 * The tablet alias of this tablet (so the source of the StreamHealth RPC can
   check it is the right tablet, and not another table that restarted on the same
   host / port, as can happen in container environments).
-  
+
 That information is updated on a regular basis (every health check interval, and
 when something changes), and streamed back.
 
@@ -78,121 +78,21 @@ This module also provides helper methods to find a tablet to route traffic
 to. Since it knows the health status of all tablets for a given keyspace / shard
 / tablet type, and their replication lag, it can provide a good list of tablets.
 
-## Vtgate Gateway interface
+## Vtgate TabletGateway
 
-An important interface inside vtgate is the Gateway interface. It can send
+An important component inside vtgate is the TabletGateway. It can send
 queries to a tablet by keyspace, shard, and tablet type.
 
 As mentioned previously, the higher levels inside vtgate can resolve queries to
-a keyspace, shard and tablet type. The queries are then passed to the Gateway
-implementation inside vtgate, to route them to the right tablet.
+a keyspace, shard and tablet type. The queries are then passed to the TabletGateway inside vtgate,
+to route them to the right tablet.
 
-There are two implementations of the Gateway interface:
-
-* discoveryGateway: It combines a set of TopologyWatchers (described in the
-  discovery section, one per cell) as a source of tablets, a HealthCheck module
-  to watch their health, and a TabletStatsCache to collect all the health
-  information. Based on this data, it can find the best tablet to use.
-* l2VTGateGateway: It keeps a map of l2vtgate processes to send queries to. See
-  next section for more details.
-  
-## l2vtgate
-
-As we started increasing the number of tablets in a cell, it became clear that a
-bottleneck of the system was going to be how many tablets a single vtgate is
-connecting to. Since vtgate maintains a streaming health check connection per
-tablet, the number of these connections can grow to large numbers. It is common
-for vtgate to watch tablets in other cells, to be able to find the master
-tablet.
-
-So l2vtgate came to exist, based on very similar concepts and interfaces:
-
-* l2vtgate is an extra hop between a vtgate pool and tablets.
-* A l2vtgate pool connects to a subset of tablets, therefore it can have a
-  reasonable number of streaming health connections. Externally, it exposes the
-  QueryService RPC interface (that has the Target for the query, keyspace /
-  shard / tablet type). Internally, it uses a discoveryGateway, as usual.
-* vtgate connects to l2vtgate pools (using the l2VTGateGateway instead of the
-  discoveryGateway). It has a map of which keyspace / shard / tablet type needs
-  to go to which l2vtgate pool. At this point, vtgate doesn't maintain any health
-  information about the tablets, it lets l2vtgate handle it.
-
-Note l2vtgate is not an ideal solution as it is now. For instance, if there are
-two cells, and the master for a shard can be in either, l2vtgate still has to
-watch the tablets in both cells, to know where the master is. Ideally, we'd want
-l2vtgate to be collocated with the tablets in a given cell, and not go
-cross-cell.
+TabletGateway combines a set of TopologyWatchers (described in the
+discovery section, one per cell) as a source of tablets, a HealthCheck module
+to watch their health, and a tabletHealthCheck per tablet to collect all the health
+information. Based on this data, it can find the best tablet to use.
 
 # Extensions, work in progress
-
-## Regions, cross-cell targeting
-
-At first, the discoveryGateway was routing queries the following way:
-
-* For master queries, just find the master tablet, whichever cell it's in, and
-  send the query to it. This was meant to handle cross-cell master fail-over.
-* For non-master queries, just route to the local cell vtgate is in.
-
-This turned out to be a bit limiting, as if no local tablet was available in the
-cell, the queries would just fail. We added the concept of Region, and if
-tablets in the same Region are available to serve, they can be used instead.
-This fix however is not entirely correct, as it uses the SrvKeyspace of the
-current cell, instead of the SrvKeyspace of the other cell. Both ServedFrom and
-the shard partition may be different in a different cell.
-
-## Percolating the cell back up
-
-We think the correct fix is to percolate the cell back up at the vtgate routing
-layer. That way when the higher level is asking for the SrvKeyspace object, it
-can ask for the right one, in the right cell. For instance, we can read the
-current SrvKeyspace for the current cell, see if it has healthy tablets for the
-shard(s) we're interested in, and if not find another cell in the same region
-that has healthy tablets.
-
-In the l2vtgate case though, this is not as easy, as the vtgate process has no
-idea what tablets are healthy. We propose to solve this by adding a healthcheck
-between vtgate and l2vtgate:
-
-* vtgate would maintain a healthcheck connection to the l2vtgate pool (a single
-  connection should be good enough, but we may be more aggressive to collect
-  more up to date information, so we don't depend on a single l2vtgate).
-* l2vtgate will report on a regular basis which keyspace / shard / tablet type
-  it can serve. It would also report the minimum and maximum replication lag
-  (and whatever other pertinent information vtgate needs).
-* l2vtgateGateway can then provide the health information back up inside vtgate.
-* This would also lift the limitation previously noted about l2vtgate going
-  cross-cell. When a master is moved from one cell to another, the l2vtgate in
-  the old cell would advertize back that they lost the ability to serve the
-  master tablet type, and the l2vtgate in the new cell would start advertizing
-  it. Vtgates would then know where to look.
-
-This would also be a good time to merge the vtgate code that uses the VSchema
-with the code that doesn't for SrvKeyspace access.
-
-## Hybrid Gateway
-
-It would be nice to re-organize the code a bit inside vtgate to allow for an
-hybrid gateway, and get rid of l2vtgate alltogether:
-
-* vtgate would use the discoveryGateway to watch the tablets in the current cell
-  (and optionally to any other cell we still want to consider local).
-* vtgate would use l2vtgateGateway to watch the tablets in a different cell.
-* vtgate would expose the RPC APIs currently exposed by the l2vtgate process.
-
-So vtgate would watch the tablets in the local cell only, but also know what
-healthy tablets are in the other cells, and be able to send query to them
-through their vtgate. The extra hop to the other cell vtgate should be a small
-latency price to pay, compared to going cross-cell already.
-
-So queries would go one of two routes:
-
-* client(cell1) -> vtgate(cell1) -> tablet(cell1)
-* client(cell1) -> vtgate(cell1) -> vtgate(cell2) -> tablet(cell2)
-
-If the number of tablets in a given cell is still too high for the local vtgate
-pool, two or more pools can still be created, each of them knowing about a
-subset of the tablets. And they would just forward queries to each others when
-addressing the other tablet set.
 
 ## Config-based routing
 


### PR DESCRIPTION
This Pull Request documents the changes made in https://github.com/vitessio/vitess/pull/9852 by removing the tablet gateway flag from the VTGate reference docs. It also mirrors the TabletRouting doc with what we have on [vitessio/vitess](https://github.com/vitessio/vitess/blob/main/doc/TabletRouting.md).