### PR TITLE
Update all vtctld --service_map args to include new service by default

### DIFF
--- a/content/en/docs/14.0/reference/features/topology-service.md
+++ b/content/en/docs/14.0/reference/features/topology-service.md
@@ -487,7 +487,7 @@ etcd --enable-v2=true --data-dir ${VTDATAROOT}/etcd/global --listen-client-urls 
 
 ``` sh
 vtctld --topo_implementation=etcd2 --topo_global_server_address=${GLOBAL_ETCD_SERVER} \
-  --topo_global_root=/vitess/global --port=15000 --grpc_port=15999 --service_map='grpc-vtctl' \
+  --topo_global_root=/vitess/global --port=15000 --grpc_port=15999 --service_map='grpc-vtctl,grpc-vtctld' \
   ${OTHER_VTCTLD_FLAGS}
 ```
 

--- a/content/en/docs/14.0/user-guides/configuration-basic/vtctld.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/vtctld.md
@@ -12,7 +12,7 @@ vtctld <topo_flags> <backup_flags> \
   --log_dir=${VTDATAROOT}/tmp \
   --port=15000 \
   --grpc_port=15999 \
-  --service_map='grpc-vtctl' \
+  --service_map='grpc-vtctl,grpc-vtctld' \
   --durability_policy='none'
 ```
 

--- a/content/en/docs/15.0/reference/features/topology-service.md
+++ b/content/en/docs/15.0/reference/features/topology-service.md
@@ -487,7 +487,7 @@ etcd --enable-v2=true --data-dir ${VTDATAROOT}/etcd/global --listen-client-urls 
 
 ``` sh
 vtctld --topo_implementation=etcd2 --topo_global_server_address=${GLOBAL_ETCD_SERVER} \
-  --topo_global_root=/vitess/global --port=15000 --grpc_port=15999 --service_map='grpc-vtctl' \
+  --topo_global_root=/vitess/global --port=15000 --grpc_port=15999 --service_map='grpc-vtctl,grpc-vtctld' \
   ${OTHER_VTCTLD_FLAGS}
 ```
 

--- a/content/en/docs/15.0/user-guides/configuration-basic/vtctld.md
+++ b/content/en/docs/15.0/user-guides/configuration-basic/vtctld.md
@@ -12,7 +12,7 @@ vtctld <topo_flags> <backup_flags> \
   --log_dir=${VTDATAROOT}/tmp \
   --port=15000 \
   --grpc_port=15999 \
-  --service_map='grpc-vtctl' \
+  --service_map='grpc-vtctl,grpc-vtctld' \
   --durability_policy='none'
 ```
 


### PR DESCRIPTION
I did this only for 14.0+.

We want the examples to, uhh, _encourage_ users to use the new things by default.