### PR TITLE
Consistent titles for options

### DIFF
--- a/content/en/docs/14.0/reference/vreplication/movetables.md
+++ b/content/en/docs/14.0/reference/vreplication/movetables.md
@@ -47,7 +47,7 @@ Each `action` has additional options/parameters that can be used to modify its b
 
 `actions` are common to both MoveTables and Reshard v2 workflows. Only the `create` action has different parameters, all other actions have common options and similar semantics. These actions are documented separately.
 
-#### source_keyspace
+#### --source
 **mandatory**
 <div class="cmd">
 
@@ -55,7 +55,7 @@ Name of existing keyspace that contains the tables to be moved
 
 </div>
 
-#### table_specs
+#### --tables
 **optional**  one of `table_specs` or `--all` needs to be specified
 <div class="cmd">
 


### PR DESCRIPTION
Some option headers referred to the value, while most referred to the option names themselves. This is a bit confusing when trying to use the page as a reference while using.

Signed-off-by: Lizz <liz@planetscale.com>