### PR TITLE
Fixed the author in the announcing v14 blog post

### DIFF
--- a/content/en/blog/2022-06-28-announcing-vitess-14.md
+++ b/content/en/blog/2022-06-28-announcing-vitess-14.md
@@ -1,5 +1,5 @@
 ---
-author: 'Vitess Engineering Team'
+author: 'Vitess Maintainer Team'
 date: 2022-06-28
 slug: '2022-06-28-announcing-vitess-14'
 tags: ['release','Vitess','MySQL','kubernetes','operator','cloud','GKE','sharding']


### PR DESCRIPTION
This PR changes the author of the announcing vitess 14 blog post from `vitess engineering team` to `vitess maintainer team`.