### PR TITLE
User guides: clarify that Online DDL is the recommended approach, v14 and v15

### DIFF
--- a/content/en/docs/14.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/14.0/reference/compatibility/mysql-compatibility.md
@@ -14,9 +14,9 @@ Vitess provides `READ COMMITTED` semantics when executing cross-shard queries. T
 
 The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt).
 
-### DDL                                                                      
+### DDL
 
-Vitess supports MySQL DDL, and will send `ALTER TABLE` statements to each of the underlying tablet servers. For large tables it is recommended to use an external schema deployment tool and apply directly to the underlying MySQL shard instances. This is discussed further in [Applying MySQL Schema](../../../user-guides/schema-changes).
+Vitess supports MySQL DDL. It offers both [managed, online schema changes](../../../user-guides/schema-changes/managed-online-schema-changes), or non-managed DDL. It is recommended to use Vitess's managed schema changes, which offer non-blocking, trackable, failure agnostic, revertible, concurrent changes, and more. Read more about [making schema changes](../../../user-guides/schema-changes).
 
 ### Join Queries
 

--- a/content/en/docs/14.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/_index.md
@@ -12,6 +12,8 @@ Quick links:
 - Vitess supports [managed, online schema changes](../schema-changes/managed-online-schema-changes/) using different [strategies](../schema-changes/ddl-strategies/), and with visibility and control over the migration process
 - Multiple approaches to [unmanaged schema changes](../schema-changes/unmanaged-schema-changes/), either blocking, or owned by the user/DBA.
 
+It is recommended to use Vitess' managed, online schema changes.
+
 Some background on schema changes follows.
 
 ## The schema change problem

--- a/content/en/docs/14.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/14.0/user-guides/schema-changes/_index.md
@@ -12,7 +12,9 @@ Quick links:
 - Vitess supports [managed, online schema changes](../schema-changes/managed-online-schema-changes/) using different [strategies](../schema-changes/ddl-strategies/), and with visibility and control over the migration process
 - Multiple approaches to [unmanaged schema changes](../schema-changes/unmanaged-schema-changes/), either blocking, or owned by the user/DBA.
 
+{{< info >}}
 It is recommended to use Vitess' managed, online schema changes.
+{{< /info >}}
 
 Some background on schema changes follows.
 

--- a/content/en/docs/15.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/15.0/reference/compatibility/mysql-compatibility.md
@@ -14,9 +14,9 @@ Vitess provides `READ COMMITTED` semantics when executing cross-shard queries. T
 
 The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt).
 
-### DDL                                                                      
+### DDL
 
-Vitess supports MySQL DDL, and will send `ALTER TABLE` statements to each of the underlying tablet servers. For large tables it is recommended to use an external schema deployment tool and apply directly to the underlying MySQL shard instances. This is discussed further in [Applying MySQL Schema](../../../user-guides/schema-changes).
+Vitess supports MySQL DDL. It offers both [managed, online schema changes](../../../user-guides/schema-changes/managed-online-schema-changes), or non-managed DDL. It is recommended to use Vitess's managed schema changes, which offer non-blocking, trackable, failure agnostic, revertible, concurrent changes, and more. Read more about [making schema changes](../../../user-guides/schema-changes).
 
 ### Join Queries
 

--- a/content/en/docs/15.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/15.0/user-guides/schema-changes/_index.md
@@ -12,6 +12,8 @@ Quick links:
 - Vitess supports [managed, online schema changes](../schema-changes/managed-online-schema-changes/) using different [strategies](../schema-changes/ddl-strategies/), and with visibility and control over the migration process
 - Multiple approaches to [unmanaged schema changes](../schema-changes/unmanaged-schema-changes/), either blocking, or owned by the user/DBA.
 
+It is recommended to use Vitess' managed, online schema changes.
+
 Some background on schema changes follows.
 
 ## The schema change problem

--- a/content/en/docs/15.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/15.0/user-guides/schema-changes/_index.md
@@ -12,7 +12,9 @@ Quick links:
 - Vitess supports [managed, online schema changes](../schema-changes/managed-online-schema-changes/) using different [strategies](../schema-changes/ddl-strategies/), and with visibility and control over the migration process
 - Multiple approaches to [unmanaged schema changes](../schema-changes/unmanaged-schema-changes/), either blocking, or owned by the user/DBA.
 
+{{< info >}}
 It is recommended to use Vitess' managed, online schema changes.
+{{< /info >}}
 
 Some background on schema changes follows.
 


### PR DESCRIPTION
Small update; when referencing the topic of schema changes, we note that we recommend using Online DDL vs direct DDL. This also fixes a mysql-compatibility outdated text.