### PR TITLE
Remove blank `description` from all vtctldclient doc frontmatter

### DIFF
--- a/content/en/docs/15.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtctldclient
 series: vtctldclient
-description:
 ---
 ## vtctldclient
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,6 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-description:
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,6 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-description:
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,6 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-description:
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,6 @@
 ---
 title: ApplySchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,6 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,6 @@
 ---
 title: Backup
 series: vtctldclient
-description:
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,6 @@
 ---
 title: BackupShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,6 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-description:
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,6 @@
 ---
 title: CreateShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteShards
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,6 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-description:
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,6 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,6 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-description:
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,6 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-description:
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,6 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-description:
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,6 @@
 ---
 title: GetBackups
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,6 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,6 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,6 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,6 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,6 @@
 ---
 title: GetPermissions
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,6 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,6 @@
 ---
 title: GetSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetSchema
 
@@ -18,6 +17,7 @@ vtctldclient GetSchema [--tables TABLES ...] [--exclude-tables EXCLUDE_TABLES ..
   -h, --help                      help for GetSchema
       --include-views             Includes views in the output in addition to base tables.
   -n, --table-names-only          Display only table names in the result.
+      --table-schema-only         Skip introspecting columns and fields metadata.
   -s, --table-sizes-only          Display only size information for matching tables. Ignored if --table-names-only is set.
       --tables /regexp/           List of tables to display the schema for. Each is either an exact match, or a regular expression of the form /regexp/.
 ```

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,6 @@
 ---
 title: GetShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,6 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,6 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,6 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,6 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,6 @@
 ---
 title: GetTablet
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,6 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,6 @@
 ---
 title: GetTablets
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,6 @@
 ---
 title: GetVSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,6 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-description:
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_InitShardPrimary.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_InitShardPrimary.md
@@ -1,7 +1,6 @@
 ---
 title: InitShardPrimary
 series: vtctldclient
-description:
 ---
 ## vtctldclient InitShardPrimary
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,6 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-description:
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,6 @@
 ---
 title: PingTablet
 series: vtctldclient
-description:
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,6 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,6 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-description:
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,6 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-description:
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,6 @@
 ---
 title: RefreshState
 series: vtctldclient
-description:
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,6 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,6 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-description:
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,6 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,6 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-description:
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,6 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-description:
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,6 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-description:
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,6 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-description:
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,6 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-description:
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,6 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-description:
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,6 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-description:
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,6 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-description:
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,6 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-description:
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,6 @@
 ---
 title: SetWritable
 series: vtctldclient
-description:
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,6 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-description:
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,6 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-description:
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,6 @@
 ---
 title: SleepTablet
 series: vtctldclient
-description:
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,6 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-description:
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,6 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-description:
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,6 @@
 ---
 title: StartReplication
 series: vtctldclient
-description:
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,6 @@
 ---
 title: StopReplication
 series: vtctldclient
-description:
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,6 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-description:
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,6 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-description:
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,6 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-description:
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,6 @@
 ---
 title: Validate
 series: vtctldclient
-description:
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,6 @@
 ---
 title: ValidateShard
 series: vtctldclient
-description:
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,6 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-description:
 ---
 ## vtctldclient ValidateVersionKeyspace
 


### PR DESCRIPTION
This doesn't actually do anything (I thought I needed it when I first wrote the codegen), and I've removed it from the template in https://github.com/vitessio/vitess/pull/10635