### PR TITLE
Add VTOrc bug documentation to 14.0

### DIFF
--- a/content/en/docs/14.0/get-started/operator.md
+++ b/content/en/docs/14.0/get-started/operator.md
@@ -49,6 +49,8 @@ kubectl apply -f 101_initial_cluster.yaml
 
 {{< info >}}
 We have supplied an example yaml for bringing up Vitess with the experimental [vtorc](../../user-guides/configuration-basic/vtorc) component. You can try this out by using the following command: `kubectl apply -f vtorc_example.yaml`. Once `vtorc` is officially released, the examples will be updated accordingly.
+
+After the [port forwarding](#setup-port-forward) is setup, you are required to run [`SetKeyspaceDurabilityPolicy`](../../reference/programs/vtctldclient/vtctldclient_setkeyspacedurabilitypolicy/) with the desired [durability policy](../../user-guides/configuration-basic/durability_policy) and restart VTOrc.
 {{< /info >}}
 
 ### Verify cluster

--- a/content/en/docs/14.0/user-guides/configuration-basic/vtorc.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/vtorc.md
@@ -44,3 +44,10 @@ You can optionally add a `clusters_to_watch` flag that contains a comma separate
 You can perform planned failovers using `vtorc`. Additionally, `vtorc` will also perform failure detection with automatic failovers while honoring the [durability policies](../../configuration-basic/durability_policy).
 
 Other Orchestrator settings may also be carefully added to the config. However, some of them may not be compatible with Vitess. These will be documented soon.
+
+{{< info >}}
+**Known Issues**
+
+- [VTOrc doesn't discover the tablets](https://github.com/vitessio/vitess/issues/10650) of a keyspace if the [durability policy](../../configuration-basic/durability_policy) doesn't exist in the topo server when it comes up. This can be resolved by restarting VTOrc.
+
+{{< /info >}}


### PR DESCRIPTION
## Description

This PR adds the VTOrc bug documentation for https://github.com/vitessio/vitess/issues/10650 to 14.0 docs. It also adds the additional steps that the user will have to take in the VTop example to get VTOrc to work.