### PR TITLE
Analytics: use GA4 tag

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,7 +2,7 @@ baseURL = "https://vitess.io"
 canonifyurls = true
 disableKinds = ["taxonomy", "taxonomyTerm"]
 enableGitInfo = true
-googleAnalytics = "UA-163836834-1"
+googleAnalytics = "G-JWT03RNV4P"
 enableRobotsTXT = true
 
 # Syntax highlighting settings


### PR DESCRIPTION
- Contributes to #1098
- Note that the UA tag will remain active, since it's connected to the GA4 tag. For details, see the issue.

/cc @nate-double-u 