### PR TITLE
Remove enable_semi_sync from docs and add cross_cell durability policy

### DIFF
--- a/content/en/docs/15.0/reference/features/topology-service.md
+++ b/content/en/docs/15.0/reference/features/topology-service.md
@@ -543,7 +543,7 @@ TABLET_ALIAS="${CELL_NAME}-${TABLET_UID}"
 KEYSPACE="CustomerInfo"
 
 vttablet ${GLBOAL_TOPOLOGY} --tablet-path=${TABLET_ALIAS} --tablet_dir=${VTDATAROOT}/${TABLET_ALIAS} \
-  --mycnf-file=${VTDATAROOT}/${TABLET_ALIAS}/my.cnf --init_keyspace=${KEYSPACE} --enable_semi_sync=true \
+  --mycnf-file=${VTDATAROOT}/${TABLET_ALIAS}/my.cnf --init_keyspace=${KEYSPACE} \
   --init_shard=0 --init_tablet_type=replica --port=15100 --grpc_port=16100 \
   --service_map='grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
   ${OTHER_VTTABLET_FLAGS}

--- a/content/en/docs/15.0/reference/programs/vttablet.md
+++ b/content/en/docs/15.0/reference/programs/vttablet.md
@@ -127,7 +127,7 @@ The following global options apply to `vttablet`:
 | --enable_hot_row_protection |  | If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots. |
 | --enable_hot_row_protection_dry_run |  | If true, hot row protection is not enforced but logs if transactions would have been queued. |
 | --enable_replication_reporter |  | Register the health check module that monitors MySQL replication |
-| --enable_semi_sync |  | DEPRECATED - Set the correct durability policy in the keyspace information instead |
+| --enable_semi_sync |  | DEPRECATED - Set the correct durability policy on the keyspace instead. |
 | --enable_transaction_limit |  | If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not. |
 | --enable_transaction_limit_dry_run |  | If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced. |
 | --enforce-tableacl-config |  | if this flag is true, vttablet will fail to start if a valid tableacl config does not exist |

--- a/content/en/docs/15.0/reference/programs/vttablet.md
+++ b/content/en/docs/15.0/reference/programs/vttablet.md
@@ -44,7 +44,6 @@ Even if a MySQL is external, you can still make vttablet perform some management
 * `--disable_active_reparents`: If this flag is set, then any reparent or replica commands will not be allowed. These are InitShardMaster, PlannedReparent, PlannedReparent, EmergencyReparent, and ReparentTablet. In this mode, you should use the TabletExternallyReparented command to inform vitess of the current primary.
 * `--replication_connect_retry`: This value is give to mysql when it connects a replica to the primary as the retry duration parameter.
 * `--enable_replication_reporter`: If this flag is set, then vttablet will transmit replica lag related information to the vtgates, which will allow it to balance load better. Additionally, enabling this will also cause vttablet to restart replication if it was stopped. However, it will do this only if --disable_active_reparents was not turned on.
-* `--enable_semi_sync`: This option will automatically enable semi-sync on new replicas as well as on any tablet that transitions into a replica type. This includes the demotion of a primary to a replica.
 * `--heartbeat_enable` and `--heartbeat interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
 
 ## Options
@@ -128,7 +127,7 @@ The following global options apply to `vttablet`:
 | --enable_hot_row_protection |  | If true, incoming transactions for the same row (range) will be queued and cannot consume all txpool slots. |
 | --enable_hot_row_protection_dry_run |  | If true, hot row protection is not enforced but logs if transactions would have been queued. |
 | --enable_replication_reporter |  | Register the health check module that monitors MySQL replication |
-| --enable_semi_sync |  | Enable semi-sync when configuring replication, on primary and replica tablets only (rdonly tablets will not ack). |
+| --enable_semi_sync |  | DEPRECATED - Set the correct durability policy in the keyspace information instead |
 | --enable_transaction_limit |  | If true, limit on number of transactions open at the same time will be enforced for all users. User trying to open a new transaction after exhausting their limit will receive an error immediately, regardless of whether there are available slots or not. |
 | --enable_transaction_limit_dry_run |  | If true, limit on number of transactions open at the same time will be tracked for all users, but not enforced. |
 | --enforce-tableacl-config |  | if this flag is true, vttablet will fail to start if a valid tableacl config does not exist |

--- a/content/en/docs/15.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/15.0/user-guides/configuration-basic/durability_policy.md
@@ -15,31 +15,13 @@ type Durabler interface {
 }
 ```
 
-There are 2 implementations supported in this release:
+There are 3 implementations supported in this release:
  - ***semi_sync*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers to acknowledge semi sync. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
  - ***none** (default)* - This durability policy does not set any semi-sync configurations. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
+ - ***cross_cell*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers from a different cell than the current primary to acknowledge semi sync. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
 
 
 [EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting) and [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting) will use the durability rules while choosing the correct candidate for promotion.
 
 This configuration must be stored in the topo server in the keyspace record using the command [CreateKeyspace](../../../reference/programs/vtctldclient/vtctldclient_createkeyspace/) or [SetKeyspaceDurabilityPolicy](../../../reference/programs/vtctldclient/vtctldclient_setkeyspacedurabilitypolicy/).
 
-{{< info >}}
-Currently the durability policies are not used to setup semi-sync in EmergencyReparentShard or PlannedReparentShard. All the RPCs are still using the `--enable_semi_sync` flag on vttablet to setup semi-sync. This flag is currently being used for promotion rules and to log discrepancies in semi-sync setup. Nonetheless, this flag should be specified correctly for upgrade considerations to future releases when the durability policies will be used to setup semi-sync and `--enable_semi_sync` is deprecated.
-{{< /info >}}
-
-If you notice any logs like the following, please verify that your vttablet configuration and keyspace record in topo match:
-```
-invalid configuration - semi-sync should be setup according to durability policies, but enable_semi_sync is not set
-```
-```
-invalid configuration - semi-sync should be setup according to durability policies, but the tablet is not primaryEligible
-```
-If `--enable_semi_sync` is set on the vttablets, then `semi_sync` durability policy must be stored in the keyspace record. If semi-sync is not being used then the durability policy must be `none`.
-
-If the configurations are in order , then you should create an issue [here](https://github.com/vitessio/vitess/issues) and report it.
-
-If the following log is noticed when all the components are upgraded, then it should also be reported:
-```
-invalid configuration - enabling semi sync even though not specified by durability policies. Possibly in the process of upgrading
-```

--- a/content/en/docs/15.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/15.0/user-guides/configuration-basic/durability_policy.md
@@ -16,9 +16,9 @@ type Durabler interface {
 ```
 
 There are 3 implementations supported in this release:
- - ***semi_sync*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers to acknowledge semi sync. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
+ - ***semi_sync*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers to acknowledge semi sync. It returns NeutralPromoteRule for replica tablet types, MustNotPromoteRule for everything else.
  - ***none** (default)* - This durability policy does not set any semi-sync configurations. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
- - ***cross_cell*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers from a different cell than the current primary to acknowledge semi sync. It returns NeutralPromoteRule for Primary and Replica tablet types, MustNotPromoteRule for everything else
+ - ***cross_cell*** - This durability policy sets the number of required semi-sync ACKers to 1. It only allows Primary and Replica type servers from a different cell than the current primary to acknowledge semi sync. It returns NeutralPromoteRule for replica tablet types, MustNotPromoteRule for everything else.
 
 
 [EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting) and [PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting) will use the durability rules while choosing the correct candidate for promotion.

--- a/content/en/docs/15.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/15.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -132,7 +132,6 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 
 There are some additional parameters that we recommend setting:
 
-* `enable_semi_sync`: The recommended value for this is TRUE. You will need to bring up at least three vttablets for this setting to work correctly. This flag will be deprecated once `vtorc` takes over the management of MySQL instances.
 * `enable_replication_reporter`: Enabling this flag will make vttablet send its replication lag information to the vtgates, and they will use this information to avoid sending queries to replicas that are lagged beyond a threshold.
 * `unhealthy_threshold`: If `enable_replication_reporter` is enabled, and the replication lag exceeds this threshold, then vttablet stops serving queries. This value is meant to match the vtgate `discovery_high_replication_lag_minimum_serving` flag.
 * `degraded_threshold`: This flag does not change vttablet’s behavior. This threshold is used to report a warning in the status page if the replication lag exceeds this threshold. This value is meant to match the vtgate `discovery_low_replication_lag` flag.
@@ -158,7 +157,6 @@ vttablet <topo_flags> <backup_flags> \
   --port=15100 \
   --grpc_port=16100 \
   --service_map 'grpc-queryservice,grpc-tabletmanager’ \
-  --enable_semi_sync=true \
   --enable_replication_reporter=true \
   --restore_from_backup=true \
   --queryserver-config-pool-size=16 \

--- a/content/zh/docs/15.0/reference/vitess-replication.md
+++ b/content/zh/docs/15.0/reference/vitess-replication.md
@@ -68,7 +68,7 @@ We have plans to make this Update Stream feature more consistent, very resilient
 
 ## Semi-Sync
 
-If you tell Vitess to enforce semi-sync ([semisynchronous replication](https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html)) by passing the -enable_semi_sync flag to vttablets, then the following will happen:
+If you tell Vitess to enforce semi-sync ([semisynchronous replication](https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html)) by setting the `semi_sync` or `cross_cell` [durability policy](../../../../../docs/15.0/user-guides/configuration-basic/durability_policy), then the following will happen:
 
 * The master will only accept writes if it has at least one slave connected and sending semi-sync ACK. It will never fall back to asynchronous (not requiring ACKs) because of timeouts while waiting for ACK, nor because of having zero slaves connected (although it will fall back to asynchronous in case of shutdown, abrupt or graceful).
 

--- a/content/zh/docs/15.0/reference/vitess-replication.md
+++ b/content/zh/docs/15.0/reference/vitess-replication.md
@@ -68,7 +68,7 @@ We have plans to make this Update Stream feature more consistent, very resilient
 
 ## Semi-Sync
 
-If you tell Vitess to enforce semi-sync ([semisynchronous replication](https://www.percona.com/doc/percona-toolkit/LATEST/pt-online-schema-change.html)) by setting the `semi_sync` or `cross_cell` [durability policy](../../../../../docs/15.0/user-guides/configuration-basic/durability_policy), then the following will happen:
+If you tell Vitess to enforce semi-sync ([semisynchronous replication](https://dev.mysql.com/doc/refman/8.0/en/replication-semisync.html)) by setting the `semi_sync` or `cross_cell` [durability policy](../../../../../docs/15.0/user-guides/configuration-basic/durability_policy), then the following will happen:
 
 * The master will only accept writes if it has at least one slave connected and sending semi-sync ACK. It will never fall back to asynchronous (not requiring ACKs) because of timeouts while waiting for ACK, nor because of having zero slaves connected (although it will fall back to asynchronous in case of shutdown, abrupt or graceful).
 

--- a/content/zh/docs/15.0/user-guides/vttablet-modes.md
+++ b/content/zh/docs/15.0/user-guides/vttablet-modes.md
@@ -44,7 +44,6 @@ Even if a MySQL is remote, you can still make vttablet perform some management f
 * `-disable_active_reparents`: If this flag is set, then any reparent or slave commands will not be allowed. These are InitShardMaster, PlannedReparent, PlannedReparent, EmergencyReparent, and ReparentTablet. In this mode, you should use the TabletExternallyReparented command to inform vitess of the current master.
 * `-master_connect_retry`: This value is give to mysql when it connects a slave to the master as the retry duration parameter.
 * `-enable_replication_reporter`: If this flag is set, then vttablet will transmit replica lag related information to the vtgates, which will allow it to balance load better. Additionally, enabling this will also cause vttablet to restart replication if it was stopped. However, it will do this only if -disable_active_reparents was not turned on.
-* `-enable_semi_sync`: This option will automatically enable semi-sync on new replicas as well as on any tablet that transitions into a replica type. This includes the demotion of a master to a replica.
 * `-heartbeat_enable` and `-heartbeat interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
 
 ## Typical vttablet command line flags
@@ -71,7 +70,6 @@ Example `TOPOLOGY_FLAGS` for a lockserver like zookeeper:
 ### Additional parameters to enable cluster management
 
 ```
--enable_semi_sync
 -enable_replication_reporter
 -backup_storage_implementation file
 -file_backup_storage_root $BACKUP_MOUNT

--- a/wip-docs/user-guides/vitess-replication.md
+++ b/wip-docs/user-guides/vitess-replication.md
@@ -108,7 +108,7 @@ feature more consistent, very resilient, fast, and transparent to sharding.
 
 If you tell Vitess to enforce semi-sync
 ([semisynchronous replication](https://dev.mysql.com/doc/refman/5.7/en/replication-semisync.html))
-by passing the `-enable_semi_sync` flag to vttablets,
+by setting the `semi_sync` or `cross_cell` [durability policy](../../../content/docs/15.0/user-guides/configuration-basic/durability_policy),
 then the following will happen:
 
 *   The master will only accept writes if it has at least one slave connected

--- a/wip-docs/user-guides/vttablet-modes.md
+++ b/wip-docs/user-guides/vttablet-modes.md
@@ -43,7 +43,6 @@ Even if a MySQL is remote, you can still make vttablet perform some management f
 * `-disable_active_reparents`: If this flag is set, then any reparent or slave commands will not be allowed. These are InitShardMaster, PlannedReparent, PlannedReparent, EmergencyReparent, and ReparentTablet. In this mode, you should use the TabletExternallyReparented command to inform vitess of the current master.
 * `-master_connect_retry`: This value is give to mysql when it connects a slave to the master as the retry duration parameter.
 * `-enable_replication_reporter`: If this flag is set, then vttablet will transmit replica lag related information to the vtgates, which will allow it to balance load better. Additionally, enabling this will also cause vttablet to restart replication if it was stopped. However, it will do this only if -disable_active_reparents was not turned on.
-* `-enable_semi_sync`: This option will automatically enable semi-sync on new replicas as well as on any tablet that transitions into a replica type. This includes the demotion of a master to a replica.
 * `-heatbeat_enable` and `-heartbeat interval duration`: cause vttablet to write heartbeats to the sidecar database. This information is also used by the replication reporter to assess replica lag.
 
 ## Typical vttablet command line flags
@@ -68,7 +67,6 @@ Example TOPOLOGY\_FLAGS for a lockserver like zookeeper:
 
 ### Additional parameters to enable cluster management
 ```
--enable_semi_sync
 -enable_replication_reporter
 -backup_storage_implementation file
 -file_backup_storage_root $BACKUP_MOUNT


### PR DESCRIPTION
## Description

This PR reflects the changes made in https://github.com/vitessio/vitess/pull/10695. In this PR, all references to `enable_semi_sync` have been removed and instead, we point to the durability policy. 
An additional durability policy `cross_cell` is also added to the durability policy docs page.