### PR TITLE
Docs: 'cancelled' state at ALTER VITESS_MIGRATION ... CANCEL

### DIFF
--- a/content/en/docs/15.0/user-guides/schema-changes/audit-and-control.md
+++ b/content/en/docs/15.0/user-guides/schema-changes/audit-and-control.md
@@ -306,8 +306,8 @@ ok
 
 The user may cancel a migration, as follows:
 
-- If the migration hasn't started yet (it is `queued` or `ready`), then it is removed from queue and will not be executed.
-- If the migration is `running`, then it is forcibly interrupted. The migration is expected to transition to `failed` state.
+- If the migration hasn't started yet (it is `queued` or `ready`), then it transitions into `cancelled` state and doesn't get executed.
+- If the migration is `running`, then it is forcibly interrupted. The migration transitions to `cancelled` state.
 - In all other cases, cancelling a migration has no effect.
 
 #### Via VTGate/SQL
@@ -356,7 +356,7 @@ requested_timestamp: 2021-03-25 14:50:24
  liveness_timestamp: 2021-03-25 14:50:32
 completed_timestamp: NULL
   cleanup_timestamp: NULL
-   migration_status: failed
+   migration_status: cancelled
 ...
 ```
 
@@ -398,10 +398,10 @@ $ vtctlclient OnlineDDL commerce show 2201058f_f266_11ea_bab4_0242c0a8b007
 +-----------------+-------+--------------+-------------+------------+--------------------------------------+----------+---------------------+---------------------+------------------+
 |     Tablet      | shard | mysql_schema | mysql_table | ddl_action |            migration_uuid            | strategy |  started_timestamp  | completed_timestamp | migration_status |
 +-----------------+-------+--------------+-------------+------------+--------------------------------------+----------+---------------------+---------------------+------------------+
-| test-0000000401 | c0-   | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | failed           |
-| test-0000000301 | 80-c0 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | failed           |
-| test-0000000201 | 40-80 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | failed           |
-| test-0000000101 |   -40 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | failed           |
+| test-0000000401 | c0-   | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | cancelled        |
+| test-0000000301 | 80-c0 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | cancelled        |
+| test-0000000201 | 40-80 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | cancelled        |
+| test-0000000101 |   -40 | vt_commerce  | demo        | alter      | 2201058f_f266_11ea_bab4_0242c0a8b007 | online   | 2020-09-09 06:32:31 |                     | cancelled        |
 +-----------------+-------+--------------+-------------+------------+--------------------------------------+----------+---------------------+---------------------+------------------+
 ```
 


### PR DESCRIPTION
This documents the changes in https://github.com/vitessio/vitess/pull/10900 ; after `CANCEL`ling a migration, it transitions into `cancelled` state, and not to `failed`.