### PR TITLE
using make command (shortcut) when running the docker image

### DIFF
--- a/content/en/docs/11.0/get-started/local-docker.md
+++ b/content/en/docs/11.0/get-started/local-docker.md
@@ -31,10 +31,10 @@ This creates a docker image named `vitess/local` (aka `vitess/local:latest`)
 
 ## Run the docker image
 
-Execute: 
+In your shell, execute:
 
 ```shell
-./docker/local/run.sh
+make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 

--- a/content/en/docs/12.0/get-started/local-docker.md
+++ b/content/en/docs/12.0/get-started/local-docker.md
@@ -31,10 +31,10 @@ This creates a docker image named `vitess/local` (aka `vitess/local:latest`)
 
 ## Run the docker image
 
-Execute: 
+In your shell, execute:
 
 ```shell
-./docker/local/run.sh
+make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 

--- a/content/en/docs/13.0/get-started/local-docker.md
+++ b/content/en/docs/13.0/get-started/local-docker.md
@@ -31,10 +31,10 @@ This creates a docker image named `vitess/local` (aka `vitess/local:latest`)
 
 ## Run the docker image
 
-Execute: 
+In your shell, execute:
 
 ```shell
-./docker/local/run.sh
+make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 

--- a/content/en/docs/14.0/get-started/local-docker.md
+++ b/content/en/docs/14.0/get-started/local-docker.md
@@ -31,10 +31,10 @@ This creates a docker image named `vitess/local` (aka `vitess/local:latest`)
 
 ## Run the docker image
 
-Execute: 
+In your shell, execute:
 
 ```shell
-./docker/local/run.sh
+make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 

--- a/content/en/docs/15.0/get-started/local-docker.md
+++ b/content/en/docs/15.0/get-started/local-docker.md
@@ -31,10 +31,10 @@ This creates a docker image named `vitess/local` (aka `vitess/local:latest`)
 
 ## Run the docker image
 
-Execute: 
+In your shell, execute:
 
 ```shell
-./docker/local/run.sh
+make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 


### PR DESCRIPTION
This PR updates the docs for "Local Install via Docker" (Run the docker image section) in which we use the shortcut command to run the docker image