### PR TITLE
Fix resharding command in documentation

### DIFF
--- a/content/en/docs/14.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/14.0/user-guides/configuration-advanced/resharding.md
@@ -176,7 +176,7 @@ for i in 400 401 402; do
 done
 
 vtctlclient InitShardPrimary -- --force customer/-80 zone1-300
-vtctlclient InitShardPrimary -force customer/80- zone1-400
+vtctlclient InitShardPrimary -- --force customer/80- zone1-400
 ```
 
 ## Start the Reshard

--- a/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
@@ -176,7 +176,7 @@ for i in 400 401 402; do
 done
 
 vtctlclient InitShardPrimary -- --force customer/-80 zone1-300
-vtctlclient InitShardPrimary -force customer/80- zone1-400
+vtctlclient InitShardPrimary -- --force customer/80- zone1-400
 ```
 
 ## Start the Reshard


### PR DESCRIPTION
The command has a wrong parameter. If you run it you'll get this error

```
vitess@c05574c06193:/vt/local$ vtctlclient InitShardPrimary -force customer/80- zone1-400
unknown shorthand flag: 'f' in -force
```
