### PR TITLE
Document MySQL 8.0.30+ backup limitations

### DIFF
--- a/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/_index.md
+++ b/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/_index.md
@@ -3,3 +3,7 @@ title: Backup and Restore
 description: User guides covering how to backup and restore in Vitess
 weight: 1
 ---
+
+{{< warning >}}
+Vitess 12.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}

--- a/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
+++ b/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Backup and Restore
 weight: 1
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Vitess 12.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 Backup and Restore are integrated features provided by tablets managed by Vitess. As well as using _backups_ for data integrity, Vitess will also create and restore backups for provisioning new tablets in an existing shard.
 

--- a/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/12.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Creating a Backup
 weight: 2
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Vitess 12.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 ## Creating a backup
 

--- a/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/_index.md
+++ b/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/_index.md
@@ -3,3 +3,7 @@ title: Backup and Restore
 description: User guides covering how to backup and restore in Vitess
 weight: 1
 ---
+
+{{< warning >}}
+Vitess 13.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}

--- a/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
+++ b/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Backup and Restore
 weight: 1
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Vitess 13.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 Backup and Restore are integrated features provided by tablets managed by Vitess. As well as using _backups_ for data integrity, Vitess will also create and restore backups for provisioning new tablets in an existing shard.
 

--- a/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/13.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Creating a Backup
 weight: 2
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Vitess 13.0 does not support backups of MySQL 8.0.30 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 ## Creating a backup
 

--- a/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/_index.md
+++ b/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/_index.md
@@ -3,3 +3,7 @@ title: Backup and Restore
 description: User guides covering how to backup and restore in Vitess
 weight: 1
 ---
+
+{{< warning >}}
+Backups of MySQL 8.0.30 and later are only supported in Vitess 14.0.2 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}

--- a/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
+++ b/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/backup-and-restore.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Backup and Restore
 weight: 1
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Backups of MySQL 8.0.30 and later are only supported in Vitess 14.0.2 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 Backup and Restore are integrated features provided by tablets managed by Vitess. As well as using _backups_ for data integrity, Vitess will also create and restore backups for provisioning new tablets in an existing shard.
 

--- a/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/14.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -1,8 +1,12 @@
-	---
+---
 title: Creating a Backup
 weight: 2
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
+
+{{< warning >}}
+Backups of MySQL 8.0.30 and later are only supported in Vitess 14.0.2 and later. You can see additional details [here](https://github.com/vitessio/vitess/pull/10847).
+{{< /warning >}}
 
 ## Creating a backup
 


### PR DESCRIPTION
You can see the changes from here:
  - https://deploy-preview-1129--vitess.netlify.app/docs/12.0/user-guides/operating-vitess/backup-and-restore/

You can use the left hand navigation to see the 3 backup and restore pages. You can change the version number in the URL to see the changes for 13.0 and 14.0 (15.0 needs none as it will support 8.0.30 in all releases).