### PR TITLE
Documenting vreplication flag: vreplication_max_time_to_retry_on_error

### DIFF
--- a/content/en/docs/14.0/reference/programs/vttablet.md
+++ b/content/en/docs/14.0/reference/programs/vttablet.md
@@ -348,6 +348,7 @@ The following global options apply to `vttablet`:
 | --vreplication_healthcheck_retry_delay | duration | healthcheck retry delay (default 5s) |
 | --vreplication_healthcheck_timeout | duration | healthcheck retry delay (default 1m0s) |
 | --vreplication_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
+| --vreplication_max_time_to_retry_on_error | duration | stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, unlimited) |
 | --vreplication_retry_delay | duration | delay before retrying a failed binlog connection (default 5s) |
 | --vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "in_order:REPLICA,PRIMARY") |
 | --vstream_packet_size | int | Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 30000) |

--- a/content/en/docs/14.0/reference/vreplication/flags.md
+++ b/content/en/docs/14.0/reference/vreplication/flags.md
@@ -128,7 +128,7 @@ stalled streams after _vreplication_retry_delay_ seconds
 #### vreplication_max_time_to_retry_on_error
 
 **Type** duration\
-**Default** 0\
+**Default** 0 (unlimited)\
 **Applicable on** target
 
 Stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, meaning no time limit).

--- a/content/en/docs/14.0/reference/vreplication/flags.md
+++ b/content/en/docs/14.0/reference/vreplication/flags.md
@@ -125,6 +125,14 @@ When enabled, vttablet will start the _tracker_ which runs a separate vstream th
 The target might encounter connection failures during a workflow. VReplication automatically retries
 stalled streams after _vreplication_retry_delay_ seconds
 
+#### vreplication_max_time_to_retry_on_error
+
+**Type** duration\
+**Default** 0\
+**Applicable on** target
+
+Stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, meaning no time limit).
+
 #### vreplication_tablet_type
 
 **Type** string\

--- a/content/en/docs/15.0/reference/programs/vttablet.md
+++ b/content/en/docs/15.0/reference/programs/vttablet.md
@@ -346,6 +346,7 @@ The following global options apply to `vttablet`:
 | --vreplication_healthcheck_retry_delay | duration | healthcheck retry delay (default 5s) |
 | --vreplication_healthcheck_timeout | duration | healthcheck retry delay (default 1m0s) |
 | --vreplication_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
+| --vreplication_max_time_to_retry_on_error | duration | stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, unlimited) |
 | --vreplication_retry_delay | duration | delay before retrying a failed binlog connection (default 5s) |
 | --vreplication_tablet_type | string | comma separated list of tablet types used as a source (default "in_order:REPLICA,PRIMARY") |
 | --vstream_packet_size | int | Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 30000) |

--- a/content/en/docs/15.0/reference/vreplication/flags.md
+++ b/content/en/docs/15.0/reference/vreplication/flags.md
@@ -128,7 +128,7 @@ stalled streams after _vreplication_retry_delay_ seconds
 #### vreplication_max_time_to_retry_on_error
 
 **Type** duration\
-**Default** 0\
+**Default** 0 (unlimited)\
 **Applicable on** target
 
 Stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, meaning no time limit).

--- a/content/en/docs/15.0/reference/vreplication/flags.md
+++ b/content/en/docs/15.0/reference/vreplication/flags.md
@@ -125,6 +125,14 @@ When enabled, vttablet will start the _tracker_ which runs a separate vstream th
 The target might encounter connection failures during a workflow. VReplication automatically retries
 stalled streams after _vreplication_retry_delay_ seconds
 
+#### vreplication_max_time_to_retry_on_error
+
+**Type** duration\
+**Default** 0\
+**Applicable on** target
+
+Stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence (default 0, meaning no time limit).
+
 #### vreplication_tablet_type
 
 **Type** string\


### PR DESCRIPTION
This PR documents the flag `--vreplication_max_time_to_retry_on_error`, introduced in https://github.com/vitessio/vitess/pull/10429. The default for this flag is modified in https://github.com/vitessio/vitess/pull/11031. https://github.com/vitessio/vitess/pull/11031 is expected to be backported to v14, and so this PR updates both `v15` and `v14`.

Related:
- https://github.com/vitessio/vitess/pull/11031
- https://github.com/vitessio/vitess/issues/10783

