### PR TITLE
Fix make targets to run npm install before proxying through npx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 HUGO?=npx hugo
 DEPLOY_PRIME_URL?=/
 
-production-build:
+production-build: install
 	$(HUGO) --cleanDestinationDir \
 	--minify \
 	--verbose
 
-preview-build:
+preview-build: install
 	$(HUGO) --cleanDestinationDir \
 	--buildDrafts \
 	--buildFuture \
 	--baseURL $(DEPLOY_PRIME_URL) \
 	--minify
 
-serve:
+serve: install
 	$(HUGO) server \
 	--buildDrafts \
 	--buildFuture \
@@ -21,10 +21,13 @@ serve:
 	--disableFastRender \
 	--verbose
 
+install:
+	npm install
+
 clean:
 	rm -rf public
 
-build:
+build: install
 	$(HUGO) --cleanDestinationDir -e dev -DFE
 
 link-checker-setup:


### PR DESCRIPTION
In #1107, we changed our binary from `hugo` directly to `npx hugo`. This works only if you've run `npm install` at some point, so this updates the Makefile to handle that for any case we're invoking `$(HUGO)`