### PR TITLE
[docs] Update go version in macos build instructions

### DIFF
--- a/content/en/docs/15.0/contributing/build-on-macos.md
+++ b/content/en/docs/15.0/contributing/build-on-macos.md
@@ -30,10 +30,10 @@ Add `mysql@5.7` to your `PATH`:
 echo 'export PATH="/usr/local/opt/mysql@5.7/bin:$PATH"' >> ~/.bash_profile
 ```
 
-[Download and install](http://golang.org/doc/install) Golang 1.17. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.18.5. For example, at writing:
 ```shell
-curl -LO https://golang.org/dl/go1.17.darwin-amd64.pkg
-sudo installer -pkg go1.17.darwin-amd64.pkg -target /
+curl -LO https://golang.org/dl/go1.18.5.darwin-amd64.pkg
+sudo installer -pkg go1.18.5.darwin-amd64.pkg -target /
 ```
 
 Do not install etcd via brew otherwise it will not be the version that is supported. Let it be installed when running make build.


### PR DESCRIPTION
Got the following error when following the latest instructions so figured it'd be worthwhile to update:

```
$ make build
Wed Aug 31 11:25:56 PDT 2022: Building source tree
ERROR: Go version reported: go version go1.17.13 darwin/amd64. Version 1.18.4+ required. See https://vitess.io/contributing/build-from-source for install instructions.
make: *** [build] Error 1
```