### PR TITLE
Update Local Examples output to also show debug web ui of VTOrc

### DIFF
--- a/content/en/docs/15.0/get-started/local-brew.md
+++ b/content/en/docs/15.0/get-started/local-brew.md
@@ -158,6 +158,7 @@ vtadmin-web is running!
 
 vtorc is running!
   - UI: http://localhost:16000
+  - Debug UI: http://localhost:16001
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtorc.out
   - PID: 74088
 ```

--- a/content/en/docs/15.0/get-started/local-mac.md
+++ b/content/en/docs/15.0/get-started/local-mac.md
@@ -224,6 +224,7 @@ vtadmin-web is running!
 
 vtorc is running!
   - UI: http://localhost:16000
+  - Debug UI: http://localhost:16001
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtorc.out
   - PID: 74088
 ```

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -210,6 +210,7 @@ vtadmin-web is running!
 
 vtorc is running!
   - UI: http://localhost:16000
+  - Debug UI: http://localhost:16001
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtorc.out
   - PID: 74088
 ```

--- a/content/en/docs/15.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/region-sharding.md
@@ -185,6 +185,7 @@ vtadmin-web is running!
 
 vtorc is running!
   - UI: http://localhost:16000
+  - Debug UI: http://localhost:16001
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtorc.out
   - PID: 69430
 ```


### PR DESCRIPTION
## Description

This PR updates the local-example output in reference to https://github.com/vitessio/vitess/pull/11263 which adds a debug web UI page for vtorc too.