### PR TITLE
Docs: Online DDL postpone-launch strategy flag

### DIFF
--- a/content/en/docs/15.0/user-guides/schema-changes/ddl-strategy-flags.md
+++ b/content/en/docs/15.0/user-guides/schema-changes/ddl-strategy-flags.md
@@ -19,6 +19,8 @@ Vitess respects the following flags. They can be combined unless specifically in
 
   `--declarative` migrations are only evaluated when scheduled to run. If a migrations is both `--declarative` and `--postpone-completion` then it will remain in `queued` state until the user issues a `ALTER VITESS_MIGRATION ... COMPLETE`. If it turns out that Vitess should run the migration as an `ALTER` then it is only at that time that the migration starts.
 
+- `--postpone-launch`: initiate a migration that remains `queued` and only launches per user command. See [postponed migrations](../postponed-migrations).
+
 - `--singleton`: only allow a single pending migration to be submitted at a time. From the moment the migration is queued, and until either completion, failure or cancellation, no other new `--singleton` migration can be submitted. New requests will be rejected with error. `--singleton` works as a an exclusive lock for pending migrations. Note that this only affects migrations with `--singleton` flag. Migrations running without that flag are unaffected and unblocked.
 
 - `--singleton-context`: only allow migrations submitted under same _context_ to be pending at any given time. Migrations submitted with a different _context_ are rejected for as long as at least one of the initially submitted migrations is pending.

--- a/content/en/docs/15.0/user-guides/schema-changes/postponed-migrations.md
+++ b/content/en/docs/15.0/user-guides/schema-changes/postponed-migrations.md
@@ -4,18 +4,25 @@ weight: 12
 aliases: ['/docs/user-guides/schema-changes/postponed-migrations/']
 ---
 
-Postponed migrations await final cut-over until the user manually issues a completion statement.
+Postponed migrations allow:
 
-Normally, migrations are executed by Vitess and completed automatically. For example, an `ALTER` on a large table can take hours or more to complete. Vitess automatically instates the new schema in place whenever it is satisfied that the `ALTER` is complete. Or, a `DROP` statement could wait in queue while other statements are running, only to actually execute hours later.
+- Postponing the launch of a migration, and/or
+- Postponing the final cut-over/completion of a migration.
 
-Some engineers wish to have more control over the cut-over time. With postponed migrations, it is possible to:
+In both cases, it takes an explicit user interaction to launch or to complete the migration.
+
+Normally, migrations are executed by Vitess and are launched and completed automatically. For example, an `ALTER` on a large table can take hours or more to complete. Vitess automatically instates the new schema in place whenever it is satisfied that the `ALTER` is complete. Or, a `DROP` statement could wait in queue while other statements are running, only to actually execute hours later.
+
+We begin discussing the latter of the two: postponed completion, as it solves a widely known problem.
+
+## Postpone completion
+
+A common requirement by engineers is to have more control over the cut-over time. With postponed completion migrations, it is possible to:
 
 - Invoke a migration that postpones completion
 - Manually `COMPLETE` a migration
 
 This lets an engineer observe the change of schema at a point when they're comfortably at their console and prepared to take action should any issue occur.
-
-## Postpone completion
 
 Add `--postpone-completion` to any* (see [supported migrations](#supported-migrations)) of the online DDL strategies. Example:
 
@@ -103,9 +110,9 @@ mysql> alter table another_table add column ts timestamp not null;
             postpone_completion: 1
 ```
 
-## Completing a migration
+### Completing a postponed migration
 
-Completing a postponed migration is achieved by:
+Completing a postponed-completion migration is achieved by:
 
 ```sql
 mysql> alter vitess_migration 'b7d6e6fb_8a74_11eb_badd_f875a4d24e90' complete;
@@ -134,7 +141,7 @@ mysql> show vitess_migrations like '3091ef2a_4b87_11ec_a827_0a43f95f28a3' \G
             completed_timestamp: NULL
               cleanup_timestamp: NULL
                migration_status: running
-...
+                            ...
             postpone_completion: 0
 ```
 
@@ -144,7 +151,7 @@ mysql> show vitess_migrations like '3091ef2a_4b87_11ec_a827_0a43f95f28a3' \G
 *************************** 1. row ***************************
                              id: 3
                  migration_uuid: 3091ef2a_4b87_11ec_a827_0a43f95f28a3
-...
+                            ...
                        strategy: vitess
                         options: --postpone-completion
                 added_timestamp: 2021-11-22 11:27:34
@@ -159,7 +166,7 @@ mysql> show vitess_migrations like '3091ef2a_4b87_11ec_a827_0a43f95f28a3' \G
             postpone_completion: 0
 ```
 
-## Supported migrations
+### Supported migrations
 
 Postponed completion is supported for:
 
@@ -175,10 +182,127 @@ Postponed completion is not supported in:
 
 [declarative migrations](../declarative-migrations) will remain `queued` when `-postpone-migration` is specified, until `alter vitess_migration ... complete` is issued. This is true whether the declarative migration implies an eventual `CREATE`, `DROP` or `ALTER`.
 
-## Implementation details
+### Implementation details
 
 The two strong cases for postponed migrations are `DROP` and log `ALTER`s. Both carry an amount of risk to production above other migrations.
 
 Postponed `ALTER` migrations (in `vitess` and `gh-ost` strategies) are actually executed, and begin copying table data as well as track ongoing changes. But as they reach the point where cut-over is agreeable, they stall, and keep waiting until the user issues the `alter vitess_migration ... complete` statement. Assuming the user runs the statement when all data has already been copied, it is typically a matter of seconds until the migration completes and the new schema is instated.
 
 For `CREATE` and `DROP` statements, there's no such backfill process as with `ALTER`, and the migrations are simply not scheduled, until the user issues the `complete` statement. Once the statement is issued, the migrations still need to be scheduled, and may be possibly delayed by an existing queue of migrations.
+
+## Postpone launch
+
+A postponed-launch migration will remain in queued state and will not start executing, until instructed to launch.
+
+Add `--postpone-launch` to any of the online DDL strategies. Example:
+
+```sql
+
+mysql> set @@ddl_strategy='vitess --postpone-launch';
+
+-- The migration is tracked, but the ALTER process won't start running.
+mysql> alter table mytable add column i int not null;
++--------------------------------------+
+| uuid                                 |
++--------------------------------------+
+| 9e8a9249_3976_11ed_9442_0a43f95f28a3 |
++--------------------------------------+
+```
+
+Migrations executed with `--postpone-launch` are visible on `show vitess_migrations` just as normal. They will present as `queued`. The column `postpone_launch` indicates that the migration will not auto-start:
+
+
+```sql
+mysql> show vitess_migrations like '9e8a9249_3976_11ed_9442_0a43f95f28a3' \G
+*************************** 1. row ***************************
+                             id: 3
+                 migration_uuid: 9e8a9249_3976_11ed_9442_0a43f95f28a3
+                       keyspace: commerce
+                          shard: 0
+                   mysql_schema: vt_commerce
+                    mysql_table: mytable
+            migration_statement: alter table mytable add column i int not null
+                       strategy: vitess
+                        options: --postpone-launch
+                added_timestamp: 2022-09-21 06:28:34
+            requested_timestamp: 2022-09-21 06:28:34
+                ready_timestamp: NULL
+              started_timestamp: NULL
+             liveness_timestamp: NULL
+            completed_timestamp: NULL
+              cleanup_timestamp: NULL
+               migration_status: queued
+                            ...
+                postpone_launch: 1
+```
+
+### Use case
+
+The use case is specific to multi sharded environments. In some cases, a user may wish to experiment a migration on a single shard:
+
+- To see how long it takes to run.
+- To see what impact it has on production traffic.
+- To see what impact the schema change has.
+
+Postponed launch migrations make it possible to launch a migration on specific shards, while the migration remains `queued` on the rest of the shards.
+
+{{< warning >}}
+Completing a migration on a subset of the shards means different shards will have different schemas. Do not do this when adding/removing columns, because the table on affected shards will be inconsistent with that of unaffected shards. This feature can be useful to experiment with adding/removing (ideally non-unique) indexes.
+{{< /warning >}}
+
+### Launching a postponed migration
+
+Launching a postponed-launch migration is achieved by the following commands:
+
+```sql
+mysql> alter vitess_migration '9e8a9249_3976_11ed_9442_0a43f95f28a3' launch;
+```
+
+The above unblocks the specific migration on all shards. The migration will execute at the discretion of the Online DDL executor.
+
+```sql
+mysql> alter vitess_migration '9e8a9249_3976_11ed_9442_0a43f95f28a3' launch vitess_shards '-40,40-80';
+```
+
+This variation accepts a comma delimited list of shard names. The migration will only launch on the specified shards. the rest of the shards ignore the command. An empty list of shards lets the command run on all shards.
+
+```sql
+mysql> alter vitess_migration launch all;
+```
+
+Launches all currently postponed migrations on all shards.
+
+Postponed launch is supported for all migrations.
+
+## Mixing postponed launch and completion
+
+You may use both `--postpone-launch --postpone-completion` for a migration. For example, if you wanted to just see how long it takes to run a migration on a single shard and what impact it makes, but then only cut-over with all other shards, you would:
+
+
+```sql
+
+mysql> set @@ddl_strategy='vitess --postpone-launch --postpone-completion';
+
+-- The migration is tracked, but the ALTER process won't start running.
+mysql> alter table mytable add column i int not null;
++--------------------------------------+
+| uuid                                 |
++--------------------------------------+
+| 9e8a9249_3976_11ed_9442_0a43f95f28a3 |
++--------------------------------------+
+
+mysql> alter vitess_migration '9e8a9249_3976_11ed_9442_0a43f95f28a3' launch vitess_shards '-40';
+```
+
+You'd then wait until `ready_to_complete` to be `1` for that specific shard, at which time you'll have gathered all your data. You'd then:
+
+```sql
+mysql> alter vitess_migration launch all;
+```
+
+Next, you'd wait for _all_ shard to reach `ready_to_complete`, at which time you'd cut-over all of them:
+
+
+```sql
+mysql> alter vitess_migration complete all;
+```


### PR DESCRIPTION
This PR documents the new `--postpone-launch` DDL strategy flag introduced in https://github.com/vitessio/vitess/pull/10915. See also https://github.com/vitessio/vitess/issues/10899

