### PR TITLE
Improve the operator getting started guide

### DIFF
--- a/content/en/docs/15.0/get-started/operator.md
+++ b/content/en/docs/15.0/get-started/operator.md
@@ -15,7 +15,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
     ```bash
-    minikube start --kubernetes-version=v1.19.16 --cpus=4 --memory=4000 --disk-size=32g
+    minikube start --kubernetes-version=v1.24.0 --cpus=4 --memory=8000 --disk-size=32g
     ```
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and ensure it is in your `PATH`.

--- a/content/en/docs/16.0/get-started/operator.md
+++ b/content/en/docs/16.0/get-started/operator.md
@@ -15,7 +15,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
     ```bash
-    minikube start --kubernetes-version=v1.19.16 --cpus=4 --memory=4000 --disk-size=32g
+    minikube start --kubernetes-version=v1.24.0 --cpus=4 --memory=8000 --disk-size=32g
     ```
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and ensure it is in your `PATH`.

--- a/layouts/partials/home/hero.html
+++ b/layouts/partials/home/hero.html
@@ -12,7 +12,7 @@
       <br />
 
       <div class="buttons has-addons is-centered">
-        <a class="button is-black is-medium has-text-weight-bold" href="{{ "/docs/get-started/kubernetes" | relLangURL }}">
+        <a class="button is-black is-medium has-text-weight-bold" href="{{ "/docs/get-started/operator" | relLangURL }}">
           <span class="icon">
             <img src="/img/logos/kubernetes.svg">
           </span>


### PR DESCRIPTION
this PR fixes the link to the operator getting started guide on the home page and increase the memory required by minikube.

during my own tests with the operator i found that 4Gb was not enough to do the entire operator getting started guide. some components would fail with an out of memory error.