### PR TITLE
Update link in MySQL Compatibility doc

### DIFF
--- a/content/en/docs/12.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/12.0/reference/compatibility/mysql-compatibility.md
@@ -12,7 +12,7 @@ Vitess provides `READ COMMITTED` semantics when executing cross-shard queries. T
 
 ## SQL Syntax
 
-The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt).
+The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json).
 
 ### DDL                                                                      
 
@@ -165,6 +165,3 @@ type DBDDLPlugin interface {
 It must then register itself calling `DBDDLRegister`. 
 You can take a look at the `dbddl_plugin.go` in the engine package for an example of how it's done.
 Finally, you need to add a command line flag to vtgate to have it use the new plugin: `-dbddl_plugin=myPluginName`
-
-
-

--- a/content/en/docs/13.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/13.0/reference/compatibility/mysql-compatibility.md
@@ -12,7 +12,7 @@ Vitess provides `READ COMMITTED` semantics when executing cross-shard queries. T
 
 ## SQL Syntax
 
-The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt).
+The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json).
 
 ### DDL                                                                      
 
@@ -165,6 +165,3 @@ type DBDDLPlugin interface {
 It must then register itself calling `DBDDLRegister`. 
 You can take a look at the `dbddl_plugin.go` in the engine package for an example of how it's done.
 Finally, you need to add a command line flag to vtgate to have it use the new plugin: `-dbddl_plugin=myPluginName`
-
-
-

--- a/content/en/docs/14.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/14.0/reference/compatibility/mysql-compatibility.md
@@ -14,7 +14,7 @@ Vitess provides MySQL default semantics i.e. `REPEATABLE READ` for single-shard 
 ## SQL Support
 
 The following describes some differences in query handling between Vitess and MySQL.
-The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt) which is kept up-to-date as we add support for new constructs. 
+The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json) which is kept up-to-date as we add support for new constructs. 
 
 This is an area of active development in Vitess. Any unsupported query can be raised as an issue in the [Vitess GitHub Project](https://github.com/vitessio/vitess/issues).
 

--- a/content/en/docs/15.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/15.0/reference/compatibility/mysql-compatibility.md
@@ -14,7 +14,7 @@ Vitess provides MySQL default semantics i.e. `REPEATABLE READ` for single-shard 
 ## SQL Support
 
 The following describes some differences in query handling between Vitess and MySQL.
-The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt) which is kept up-to-date as we add support for new constructs. 
+The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json) which is kept up-to-date as we add support for new constructs. 
 
 This is an area of active development in Vitess. Any unsupported query can be raised as an issue in the [Vitess GitHub Project](https://github.com/vitessio/vitess/issues).
 

--- a/content/en/docs/16.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/16.0/reference/compatibility/mysql-compatibility.md
@@ -14,7 +14,7 @@ Vitess provides MySQL default semantics i.e. `REPEATABLE READ` for single-shard 
 ## SQL Support
 
 The following describes some differences in query handling between Vitess and MySQL.
-The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt) which is kept up-to-date as we add support for new constructs. 
+The Vitess team maintains a list of [unsupported queries](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json) which is kept up-to-date as we add support for new constructs. 
 
 This is an area of active development in Vitess. Any unsupported query can be raised as an issue in the [Vitess GitHub Project](https://github.com/vitessio/vitess/issues).
 

--- a/content/en/docs/archive/11.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/archive/11.0/reference/compatibility/mysql-compatibility.md
@@ -12,7 +12,7 @@ Vitess provides `READ COMMITTED` semantics when executing cross-shard queries. T
 
 ## SQL Syntax
 
-The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.txt).
+The following describes some of the major differences in SQL Syntax handling between Vitess and MySQL. For a list of unsupported queries, check out the [test-suite cases](https://github.com/vitessio/vitess/blob/main/go/vt/vtgate/planbuilder/testdata/unsupported_cases.json).
 
 ### DDL                                                                      
 
@@ -165,6 +165,3 @@ type DBDDLPlugin interface {
 It must then register itself calling `DBDDLRegister`. 
 You can take a look at the `dbddl_plugin.go` in the engine package for an example of how it's done.
 Finally, you need to add a command line flag to vtgate to have it use the new plugin: `-dbddl_plugin=myPluginName`
-
-
-


### PR DESCRIPTION
The link to the `unsupported_cases.txt` file in the [MySQL Compatibility doc](https://vitess.io/docs/15.0/reference/compatibility/mysql-compatibility/) currently 404's as its format and file extension appears to have been changed to JSON. This PR fixes that.