### PR TITLE
Use https protocol in git clone for operator quick start

### DIFF
--- a/content/en/docs/12.0/get-started/operator.md
+++ b/content/en/docs/12.0/get-started/operator.md
@@ -29,7 +29,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 Change to the operator example directory:
 
 ```bash
-git clone git@github.com:vitessio/vitess.git
+git clone https://github.com/vitessio/vitess
 cd vitess/examples/operator
 ```
 

--- a/content/en/docs/13.0/get-started/operator.md
+++ b/content/en/docs/13.0/get-started/operator.md
@@ -29,7 +29,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 Change to the operator example directory:
 
 ```bash
-git clone git@github.com:vitessio/vitess.git
+git clone https://github.com/vitessio/vitess
 cd vitess/examples/operator
 ```
 

--- a/content/en/docs/14.0/get-started/operator.md
+++ b/content/en/docs/14.0/get-started/operator.md
@@ -29,7 +29,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 Change to the operator example directory:
 
 ```bash
-git clone git@github.com:vitessio/vitess.git
+git clone https://github.com/vitessio/vitess
 cd vitess/examples/operator
 ```
 

--- a/content/en/docs/15.0/get-started/operator.md
+++ b/content/en/docs/15.0/get-started/operator.md
@@ -29,7 +29,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 Change to the operator example directory:
 
 ```bash
-git clone git@github.com:vitessio/vitess.git
+git clone https://github.com/vitessio/vitess
 cd vitess/examples/operator
 ```
 

--- a/content/en/docs/16.0/get-started/operator.md
+++ b/content/en/docs/16.0/get-started/operator.md
@@ -29,7 +29,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 Change to the operator example directory:
 
 ```bash
-git clone git@github.com:vitessio/vitess.git
+git clone https://github.com/vitessio/vitess
 cd vitess/examples/operator
 ```
 


### PR DESCRIPTION
By default github SSH is not configured and it failed for me. But HTTPS always works. Can HTTPS be used by default?

Signed-off-by: Sergey Pronin <spron-in@users.noreply.github.com>