### PR TITLE
vttablet-mysql: Fix docs for init_tablet_type flag

### DIFF
--- a/content/en/docs/12.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/12.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -127,7 +127,7 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. VTTablet will infer the `cell` name from this. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
-* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
+* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Note that you are not allowed to start a tablet as a "PRIMARY".
 * `port`, `grpc_port`, and `-service_map` `'grpc-queryservice,grpc-tabletmanager'`
 
 There are some additional parameters that we recommend setting:

--- a/content/en/docs/13.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/13.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -127,7 +127,7 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. VTTablet will infer the `cell` name from this. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
-* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
+* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Note that you are not allowed to start a tablet as a "PRIMARY".
 * `port`, `grpc_port`, and `-service_map` `'grpc-queryservice,grpc-tabletmanager'`
 
 There are some additional parameters that we recommend setting:

--- a/content/en/docs/14.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/14.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -127,7 +127,7 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. VTTablet will infer the `cell` name from this. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
-* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
+* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Note that you are not allowed to start a tablet as a "PRIMARY".
 * `port`, `grpc_port`, and `--service_map` `'grpc-queryservice,grpc-tabletmanager'`
 
 There are some additional parameters that we recommend setting:

--- a/content/en/docs/15.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/15.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -127,7 +127,7 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. VTTablet will infer the `cell` name from this. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
-* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
+* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Note that you are not allowed to start a tablet as a "PRIMARY".
 * `port`, `grpc_port`, and `--service_map` `'grpc-queryservice,grpc-tabletmanager'`
 
 There are some additional parameters that we recommend setting:

--- a/content/en/docs/16.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/16.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -127,7 +127,7 @@ VTTablet should be brought up on the same machine as the MySQL instance. It need
 * `tablet-path`: This should be the cell name followed by a `-` and the tablet UID used for `mysqlctl`. VTTablet will infer the `cell` name from this. Example: `cell1-100`.
 * `init_keyspace`: The keyspace that the tablet is going to serve. This will cause a keyspace to be created if one is not present.
 * `init_shard`: The shard that the tablet is going to serve. This will cause a shard to be created if one is not present.
-* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Those tablet types will be deprecated in favor of newer ways to achieve their functionality. Note that you are not allowed to start a tablet as a MASTER.
+* `init_tablet_type`: This will typically be REPLICA. You may use other tablet types like “RDONLY”. Note that you are not allowed to start a tablet as a "PRIMARY".
 * `port`, `grpc_port`, and `--service_map` `'grpc-queryservice,grpc-tabletmanager'`
 
 There are some additional parameters that we recommend setting:


### PR DESCRIPTION
- Remove "future" language
- MASTER -> PRIMARY