### PR TITLE
Change instructions for local install

### DIFF
--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -85,11 +85,11 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 **Notes:**
 
 * Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
-* Please use release 15.0.1 instead.
+* Please use release [15.0.1](https://github.com/vitessio/vitess/releases/tag/v15.0.1) instead.
 
 ```sh
-version=15.0.0
-file=vitess-${version}-e8c7e27.tar.gz
+version=15.0.1
+file=vitess-${version}-13ee9c8.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -80,11 +80,16 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 15:
+
+**Notes:**
+
+* Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
+* Please use release 15.0.1 instead.
 
 ```sh
-version=13.0.0
-file=vitess-${version}-bc4a960.tar.gz
+version=15.0.0
+file=vitess-${version}-e8c7e27.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}
@@ -105,8 +110,10 @@ You are now ready to start your first cluster! Open a new terminal window to ens
 Start by copying the local examples included with Vitess to your preferred location. For our first example we will deploy a [single unsharded keyspace](../../concepts/keyspace). The file `101_initial_cluster.sh` is for example `1` phase `01`. Lets execute it now:
 
 ```sh
-cp -r /usr/local/vitess/examples/local ~/my-vitess-example
-cd ~/my-vitess-example
+mkdir -p ~/my-vitess-example/examples/local
+cp -r /usr/local/vitess/examples/local ~/my-vitess-example/examples
+cp -r /usr/local/vitess/web ~/my-vitess-example
+cd ~/my-vitess-example/examples/local
 ./101_initial_cluster.sh
 ```
 

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -80,11 +80,11 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 13:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 15:
 
 ```sh
-version=13.0.0
-file=vitess-${version}-bc4a960.tar.gz
+version=15.0.0
+file=vitess-${version}-e8c7e27.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}
@@ -105,8 +105,10 @@ You are now ready to start your first cluster! Open a new terminal window to ens
 Start by copying the local examples included with Vitess to your preferred location. For our first example we will deploy a [single unsharded keyspace](../../concepts/keyspace). The file `101_initial_cluster.sh` is for example `1` phase `01`. Lets execute it now:
 
 ```sh
-cp -r /usr/local/vitess/examples/local ~/my-vitess-example
-cd ~/my-vitess-example
+mkdir -p ~/my-vitess-example/examples/local
+cp -r /usr/local/vitess/examples/local ~/my-vitess-example/examples
+cp -r /usr/local/vitess/web ~/my-vitess-example
+cd ~/my-vitess-example/examples/local
 ./101_initial_cluster.sh
 ```
 

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -82,9 +82,14 @@ sudo setenforce 0
 
 Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 15:
 
+**Notes:**
+
+* Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
+* Please use release [15.0.1](https://github.com/vitessio/vitess/releases/tag/v15.0.1) instead.
+
 ```sh
-version=15.0.0
-file=vitess-${version}-e8c7e27.tar.gz
+version=15.0.1
+file=vitess-${version}-13ee9c8.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

There is a a bug in v15.0 where local install fails when it tries to local vtadmin web locally. [PR#11683](https://github.com/vitessio/vitess/pull/11683) will fix the issue but we need to reflect these changes in our local install instructions as well. This PR focus on changing the instructions as needed. 

[Issue#11679](https://github.com/vitessio/vitess/issues/11679)