### PR TITLE
fix: bash commands for applying SQL and VSchema

### DIFF
--- a/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
@@ -128,10 +128,10 @@ Applying the new VSchema instructs Vitess that the keyspace is sharded, which ma
 ### Using Operator
 
 ```bash
-vtctldclient ApplySchema --sql="$(cat create_commerce_seq.sql)" commerce
-vtctldclient ApplyVSchema --vschema="$(cat vschema_commerce_seq.json)" commerce
-vtctldclient ApplyVSchema --vschema="$(cat vschema_customer_sharded.json)" customer
-vtctldclient ApplySchema --sql="$(cat create_customer_sharded.sql)" customer
+vtctldclient ApplySchema -- --sql="$(cat create_commerce_seq.sql)" commerce
+vtctldclient ApplyVSchema -- --vschema="$(cat vschema_commerce_seq.json)" commerce
+vtctldclient ApplyVSchema -- --vschema="$(cat vschema_customer_sharded.json)" customer
+vtctldclient ApplySchema -- --sql="$(cat create_customer_sharded.sql)" customer
 ```
 
 ### Using a Local Deployment


### PR DESCRIPTION
Fixes the typo in Operator commands that does not use the `--` in the command.