### PR TITLE
remove inapplicable references to table equivalence

### DIFF
--- a/content/en/docs/13.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/13.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/13.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/13.0/reference/vreplication/vreplication.md
@@ -94,10 +94,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 <a name="exec"></a>
 

--- a/content/en/docs/14.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/14.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/14.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/14.0/reference/vreplication/vreplication.md
@@ -94,10 +94,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 <a name="exec"></a>
 

--- a/content/en/docs/15.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/15.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/15.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/15.0/reference/vreplication/vreplication.md
@@ -94,10 +94,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 <a name="exec"></a>
 

--- a/content/en/docs/16.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/16.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/16.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/16.0/reference/vreplication/vreplication.md
@@ -90,9 +90,6 @@ VReplication performs the following essential functions:
   automatically manages sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
   it is used to control the cut-over during [`MoveTables`](../movetables/).
-  In the case of materialized views, they can be used to establish
-  equivalence of tables, which will allow [`VTGate`](../../../concepts/vtgate/)
-  to compute the most optimal plans given the available options.
 
 <a name="exec"></a>
 

--- a/content/en/docs/archive/11.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/archive/11.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/archive/11.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/archive/11.0/reference/vreplication/vreplication.md
@@ -94,10 +94,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 <a name="exec"></a>
 

--- a/content/en/docs/archive/12.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/archive/12.0/reference/features/schema-routing-rules.md
@@ -10,9 +10,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -56,30 +53,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/en/docs/archive/12.0/reference/vreplication/vreplication.md
+++ b/content/en/docs/archive/12.0/reference/vreplication/vreplication.md
@@ -94,10 +94,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 <a name="exec"></a>
 

--- a/content/zh/docs/11.0/reference/vreplication.md
+++ b/content/zh/docs/11.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/11.0/schema-management/routing-rules.md
+++ b/content/zh/docs/11.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/zh/docs/12.0/reference/vreplication.md
+++ b/content/zh/docs/12.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/12.0/schema-management/routing-rules.md
+++ b/content/zh/docs/12.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/zh/docs/13.0/reference/vreplication.md
+++ b/content/zh/docs/13.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/13.0/schema-management/routing-rules.md
+++ b/content/zh/docs/13.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/zh/docs/14.0/reference/vreplication.md
+++ b/content/zh/docs/14.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/14.0/schema-management/routing-rules.md
+++ b/content/zh/docs/14.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/zh/docs/15.0/reference/vreplication.md
+++ b/content/zh/docs/15.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/15.0/schema-management/routing-rules.md
+++ b/content/zh/docs/15.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.

--- a/content/zh/docs/16.0/reference/vreplication.md
+++ b/content/zh/docs/16.0/reference/vreplication.md
@@ -91,10 +91,7 @@ VReplication performs the following essential functions:
   functionality of VReplication, it works hand in hand with it. It allows
   you to specify sophisticated rules about where to route queries
   depending on the type of workflow being performed. For example,
-  it can be used to control the cut-over during resharding. In
-  the case of materialized views, it can be used to establish
-  equivalence of tables, which will allow VTGate to compute the most optimal
-  plans given the available options.
+  it can be used to control the cut-over during resharding.
 
 ## VReplicationExec
 

--- a/content/zh/docs/16.0/schema-management/routing-rules.md
+++ b/content/zh/docs/16.0/schema-management/routing-rules.md
@@ -9,9 +9,6 @@ It fulfils the following use cases:
 * **Routing traffic during resharding**: During resharding, you can specify rules that decide where to send reads and writes. For example,
   you can move traffic from the source shard to the destination shards, but only for the `rdonly` or `replica` types. This gives you
   the option to try out the new shards and make sure they will work as intended before committing to move the rest of the traffic.
-* **Table equivalence**: The new VReplication feature allows you to materialize tables in different keyspaces. In this situation,
-  you can specify that two tables are 'equivalent'. This will allow VTGate to use the best possible plan depending on the input
-  query.
 
 ## ApplyRoutingRules
 
@@ -54,30 +51,3 @@ for just the `rdonly` tablet types.
 By updating these rules, you can eventually move all traffic to `target.t`
 
 The rules are applied only once. The resulting targets need to specify fully qualified table names.
-
-### Table equivalence
-
-The routing rules allow you to specify table equivalence. Here's an example:
-
-``` json
-{"rules": [
-  {
-    "from_table": "product",
-    "to_tables": ["lookup.product", "user.uproduct"]
-  }
-]}
-```
-
-In the above case, we are declaring that the `product` table is present in both `lookup` and `user`. If a query is issued
-using the unqualified `product` table, then VTGate will consider sending the query to both `lookup.product` as well
-as `user.uproduct` (note the name change).
-
-For example, if `user` was a sharded keyspace, and the query joined a `user` table with `product`, then vtgate will
-know that it's better to send the query to the `user` keyspace instead of `lookup`.
-
-Typically, table equivalence makes sense when a view table is materialized from a source table using VReplication.
-
-### Orthogonality
-
-The tablet type targeting and table equivalence features are orthogonal to each other and can be combined. Although
-there's no immediate use case for this, it's a possibility we can consider if the use case arises.


### PR DESCRIPTION
@harshit-gangal [said](https://github.com/vitessio/vitess/issues/11863#issuecomment-1333788324):

> Table Equivalence was removed in 8.0. It was an experimental feature at that time. We should remove it from all our current documents.

Addresses vitessio/vitess#11863.