### PR TITLE
document reference table source field

### DIFF
--- a/content/en/docs/16.0/reference/features/global-routing.md
+++ b/content/en/docs/16.0/reference/features/global-routing.md
@@ -7,7 +7,7 @@ weight: 23
 Vitess has an implicit feature of routing the queries to the appropriate keyspace based on the table specified in the `from` list.
 This differs from the standard mysql, in mysql unqualified tables will fail if the correct database is not set on the connection.
 
-This feature works only for unique table names provided in the [VSchema](https://vitess.io/docs/concepts/vschema/), and only when no default keyspace is set on the connection.
+This feature works only for unique table names provided in the [VSchema](https://vitess.io/docs/concepts/vschema/), and only when no default keyspace is set on the connection. One exception to the uniqueness rule is [Reference Tables](../../../user-guides/vschema-guide/advanced-vschema/#reference-tables) that share a name with an explicitly specified `source` table.
 
 Example:
 ```sql

--- a/content/en/docs/16.0/reference/features/global-routing.md
+++ b/content/en/docs/16.0/reference/features/global-routing.md
@@ -7,7 +7,7 @@ weight: 23
 Vitess has an implicit feature of routing the queries to the appropriate keyspace based on the table specified in the `from` list.
 This differs from the standard mysql, in mysql unqualified tables will fail if the correct database is not set on the connection.
 
-This feature works only for unique table names provided in the [VSchema](https://vitess.io/docs/concepts/vschema/), and only when no default keyspace is set on the connection. One exception to the uniqueness rule is [Reference Tables](../../../user-guides/vschema-guide/advanced-vschema/#reference-tables) that share a name with an explicitly specified `source` table.
+This feature works only for unique table names provided in the [VSchema](../../../vschema/), and only when no default keyspace is set on the connection. One exception to the uniqueness rule is [Reference Tables](../../../user-guides/vschema-guide/advanced-vschema/#reference-tables) that explicitly specify a `source` table.
 
 Example:
 ```sql

--- a/content/en/docs/16.0/user-guides/vschema-guide/advanced-vschema.md
+++ b/content/en/docs/16.0/user-guides/vschema-guide/advanced-vschema.md
@@ -48,12 +48,13 @@ A reference table should not have any vindex, and is defined in the VSchema as a
 ```
 <br/>
 
-#### Global Routing
+#### Source Tables
 
-By default, [Global Routing](../../../reference/features/global-routing) will not disambiguate between a reference table and an identically-named table in another keyspace. Setting the optional `source` field enables unqualified queries for a reference (or source) table to be routed to the appropriate keyspace:
+Vitess will optimize reference tables routing when joined to a table within the same keyspace. Additional routing optimizations can be enabled by specifying the `source` of a reference table. When a reference table specifies a `source` table:
 
- * A `SELECT ... JOIN` (or equivalent `SELECT ... WHERE`) uses the keyspace of
-   the table to which the reference (or source) table is being joined.
+ * A `SELECT ... JOIN` (or equivalent `SELECT ... WHERE`) will try to route the
+   query to the keyspace of the table to which the reference (or source) table
+   is being joined.
  * An `INSERT`, `UPDATE`, or `DELETE` uses the keyspace of the source table.
 
 For example:
@@ -74,7 +75,6 @@ For example:
 There are some constraints on `source`:
 
  * It must be a keyspace-qualified table name, e.g. `unsharded_ks.zip_detail`.
- * The source and reference table must have the same name.
  * It must refer to an existing table in an existing keyspace.
  * It must refer to a table in a different keyspace.
  * It must refer to a table in an unsharded keyspace.

--- a/content/en/docs/16.0/user-guides/vschema-guide/advanced-vschema.md
+++ b/content/en/docs/16.0/user-guides/vschema-guide/advanced-vschema.md
@@ -40,10 +40,47 @@ A reference table should not have any vindex, and is defined in the VSchema as a
 {
   "sharded": true,
   "tables": {
-    "zip_detail": { "type": "reference" }
+    "zip_detail": {
+      "type": "reference"
+    }
   }
 }
 ```
+<br/>
+
+#### Global Routing
+
+By default, [Global Routing](../../../reference/features/global-routing) will not disambiguate between a reference table and an identically-named table in another keyspace. Setting the optional `source` field enables unqualified queries for a reference (or source) table to be routed to the appropriate keyspace:
+
+ * A `SELECT ... JOIN` (or equivalent `SELECT ... WHERE`) uses the keyspace of
+   the table to which the reference (or source) table is being joined.
+ * An `INSERT`, `UPDATE`, or `DELETE` uses the keyspace of the source table.
+
+For example:
+
+```json
+{
+  "sharded": true,
+  "tables": {
+    "zip_detail": {
+      "type": "reference",
+      "source": "unsharded_is.zip_detail"
+    }
+  }
+}
+```
+<br/>
+
+There are some constraints on `source`:
+
+ * It must be a keyspace-qualified table name, e.g. `unsharded_ks.zip_detail`.
+ * The source and reference table must have the same name.
+ * It must refer to an existing table in an existing keyspace.
+ * It must refer to a table in a different keyspace.
+ * It must refer to a table in an unsharded keyspace.
+ * Any given value for `source` may appear at most once per-keyspace.
+
+#### Materialization
 
 It may become a challenge to keep a reference table correctly updated across all shards. Vitess supports the [Materialize](../../migration/materialize) feature that allows you to maintain the original table in an unsharded keyspace and automatically propagate changes to that table in real-time across all shards.
 


### PR DESCRIPTION
Accompanies vitessio/vitess#11875.

Document improvements to routing for [reference tables](https://vitess.io/docs/15.0/user-guides/vschema-guide/advanced-vschema/#reference-tables):
 * Support for [globally routing](https://vitess.io/docs/15.0/reference/features/global-routing) reference tables that are identically named with their source.
 * Optimize joining so that reference tables are joined with the optimal keyspace.
 * Redirect DML for reference tables back to their source.

Given:
    
* An unsharded keyspace `k1` and an sharded keyspace `k2`.
* Source table `k1.r` and reference table `k2.r`.
* Unsharded table `k1.a`
* Sharded table `k2.b`.

And these queries:

1. `SELECT k2.b JOIN k1.r`
2. `SELECT a JOIN r`
3. `SELECT b JOIN r`
4. `INSERT INTO r`
       
The first query will succeed but will issue queries to both `k1` and `k2`, even though the query _could_ be satisifed just by routing to `k2`.

The next three queries will fail with https://github.com/vitessio/vitess/blob/4ff02c0f7af35a520bfc90d32e77fc13810dfdd9/go/vt/vtgate/vindexes/vschema.go#L566

This PR documents new support for optimally joining and globally routing these three queries:

1. The first query is routed exclusively to `k2`.
2. The second query will join `k1.a` to `k1.r`.
3. The third query will join `k2.b` to `k2.r`.
4. The fourth query will be routed to the unsharded source table `r`.