### PR TITLE
adding general and developer channels to faq

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -18,6 +18,8 @@ Please do note that we request that you do not ask individual project members fo
 
 There are many channels available and we encourage you to join as many or as few as interest you. Some of the most popular channels are listed below:
 
+* #general
+* #developers
 * #kubernetes
 * #monitoring
 * #operator


### PR DESCRIPTION
Signed-off-by: Rameez Sajwani <rameezwazirali@hotmail.com>

Adding 'developer' and 'general' channels under FAQs.

## Related Issues
- https://github.com/vitessio/website/issues/1251