### PR TITLE
Update resharding.md to match with example docs

### DIFF
--- a/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/resharding.md
@@ -128,10 +128,10 @@ Applying the new VSchema instructs Vitess that the keyspace is sharded, which ma
 ### Using Operator
 
 ```bash
-vtctldclient ApplySchema --sql="$(cat create_commerce_seq.sql)" commerce
-vtctldclient ApplyVSchema --vschema="$(cat vschema_commerce_seq.json)" commerce
-vtctldclient ApplyVSchema --vschema="$(cat vschema_customer_sharded.json)" customer
-vtctldclient ApplySchema --sql="$(cat create_customer_sharded.sql)" customer
+vtctlclient ApplySchema -- --sql="$(cat create_commerce_seq.sql)" commerce
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_commerce_seq.json)" commerce
+vtctlclient ApplySchema -- --sql="$(cat create_customer_sharded.sql)" customer
+vtctlclient ApplyVSchema -- --vschema="$(cat vschema_customer_sharded.json)" customer
 ```
 
 ### Using a Local Deployment
@@ -139,8 +139,8 @@ vtctldclient ApplySchema --sql="$(cat create_customer_sharded.sql)" customer
 ``` sh
 vtctldclient ApplySchema --sql-file create_commerce_seq.sql commerce
 vtctldclient ApplyVSchema --vschema_file vschema_commerce_seq.json commerce
-vtctldclient ApplyVSchema --vschema_file vschema_customer_sharded.json customer
 vtctldclient ApplySchema --sql-file create_customer_sharded.sql customer
+vtctldclient ApplyVSchema --vschema_file vschema_customer_sharded.json customer
 ```
 
 ## Create new shards


### PR DESCRIPTION
Current docs for resharding:

Following are where this fix came from: https://github.com/vitessio/vitess/tree/main/examples/operator

```sh
vtctldclient ApplySchema --sql="$(cat create_commerce_seq.sql)" commerce
vtctldclient ApplyVSchema --vschema="$(cat vschema_commerce_seq.json)" commerce
vtctldclient ApplyVSchema --vschema="$(cat vschema_customer_sharded.json)" customer
vtctldclient ApplySchema --sql="$(cat create_customer_sharded.sql)" customer
```

The above fails with the following error:

```sh
E1213 22:38:11.843995   70431 main.go:56] rpc error: code = Unknown desc = failed to parse sql: create table customer_seq(id int, got error: Code: INVALID_ARGUMENT
syntax error at position 33
```

Using `vtctlclient` instead of `vtctldclient` works.


Signed-off-by: Sourav Singh Rawat <aidenfrostbite@gmail.com>