### PR TITLE
Add maintainers team as codeowners for everything

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @vitessio/maintainers


### PR DESCRIPTION
Then we can require approval from a codeowner for the prod branch. This will make it easier for vitess
contributors to contribute to the docs. This is
important as we want to require accompanying docs for PRs.

We will need to update the branch protection rules to require codeowner approval.

Signed-off-by: Matt Lord <mattalord@gmail.com>