### PR TITLE
moved to design docs

### DIFF
--- a/content/en/docs/16.0/reference/query-serving/reserved-conn.md
+++ b/content/en/docs/16.0/reference/query-serving/reserved-conn.md
@@ -49,7 +49,7 @@ If a user changes a system variable and reserved connections are enabled,
 the user connection will be marked as needing reserved connections.
 For all subsequent calls to Vitess, connection pooling is turned off for
 a particular session. This only applies to certain system settings. For more
-details see [here](../../../reference/query-serving/set-stmt/). Any queries to a
+details see [here](../../../../design-docs/query-serving/set-stmt/). Any queries to a
 tablet from this session will create a reserved connection on that tablet. This 
 means a connection is reserved only for that session.
 
@@ -119,7 +119,7 @@ the locks are tied to the connection, and the lock must be released in the
 same connection as it was acquired, use of these functions will force a
 connection to become a reserved connection. This connection is also kept alive
 so it does not time out due to inactivity.  More information can be found
-[here](../../../reference/query-serving/locking-functions/).
+[here](../../../../design-docs/query-serving/locking-functions/).
 
 ### Shutting down reserved connections
 

--- a/content/en/docs/design-docs/query-serving/clookup-vindex.md
+++ b/content/en/docs/design-docs/query-serving/clookup-vindex.md
@@ -1,7 +1,7 @@
 ---
 title: Consistent lookup vindexes
 description:
-weight: 1
+weight: 2
 ---
 ## Problem
 

--- a/content/en/docs/design-docs/query-serving/locking-functions.md
+++ b/content/en/docs/design-docs/query-serving/locking-functions.md
@@ -1,7 +1,7 @@
 ---
 title: Locking functions
 description:
-weight: 1
+weight: 4
 ---
 # Locking Functions
 

--- a/content/en/docs/design-docs/query-serving/replicatx.md
+++ b/content/en/docs/design-docs/query-serving/replicatx.md
@@ -1,7 +1,7 @@
 ---
 title: Replica Transactions
 description:
-weight: 1
+weight: 3
 aliases: ['/docs/design-docs/query-serving/replicatx/'] 
 ---
 

--- a/content/en/docs/design-docs/query-serving/set-stmt.md
+++ b/content/en/docs/design-docs/query-serving/set-stmt.md
@@ -1,7 +1,7 @@
 ---
 title: Set Statements
 description:
-weight: 1
+weight: 5
 ---
 
 ## Use Case


### PR DESCRIPTION
There were RFCs which were present in Reference -> Query Serving. Moved them to Design Docs -> Query Serving.

Closes https://github.com/vitessio/website/issues/1241