### PR TITLE
Add vtorc page link to docker-run docs

### DIFF
--- a/content/en/docs/16.0/get-started/local-docker.md
+++ b/content/en/docs/16.0/get-started/local-docker.md
@@ -42,6 +42,7 @@ This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `
 - `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
 - `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
 - Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
+- `VTOrc` page is available at [http://localhost:16000](http://localhost:16000)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 


### PR DESCRIPTION
### Description

This PR does the docs change for https://github.com/vitessio/vitess/pull/12001