### PR TITLE
Add tooling and makefile target for autogenerating `vtctldclient` for N versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,11 @@ check-internal-links: clean build link-checker-setup run-link-checker
 
 check-all-links: clean build link-checker-setup
 	bin/htmltest --conf .htmltest.external.yml
+
+ifndef VTCTLDCLIENT_VERSION_PAIRS
+export VTCTLDCLIENT_VERSION_PAIRS="main:16.0,v15.0.2:15.0"
+endif
+
+# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtctldclient-docs
+vtctldclient-docs:
+	go run ./tools/vtctldclientdocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${VTCTLDCLIENT_VERSION_PAIRS}"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module vitess.io/website
+
+go 1.19

--- a/tools/vtctldclientdocs/fsutil.go
+++ b/tools/vtctldclientdocs/fsutil.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/tools/vtctldclientdocs/fsutil.go
+++ b/tools/vtctldclientdocs/fsutil.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+func isDir(path string) error {
+	dir, err := os.Stat(path)
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return err
+	case err != nil:
+		return fmt.Errorf("failed to stat %s: %w", path, err)
+	case !dir.IsDir():
+		return fmt.Errorf("%s is not a directory", path)
+	}
+
+	return nil
+}

--- a/tools/vtctldclientdocs/main.go
+++ b/tools/vtctldclientdocs/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/tools/vtctldclientdocs/main.go
+++ b/tools/vtctldclientdocs/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	debug       = flag.Bool("debug", false, "log debug info")
+	vitessDir   = flag.String("vitess-dir", "", "path to vitess checkout")
+	docGenPath  = flag.String("vtctldclientdocgen-path", "./go/cmd/vtctldclient/docgen", "path to the vtctldclient doc generator, **relative to** --vitess-dir")
+	versionStrs = flag.String("version-pairs", "main:16.0", "CSV of <gitref>:<version> pairs to generate docs for; for example, 'v15.0.2:15.0' will generate docs from the v15.0.2 tag into the content/en/15.0 subtree. ensure your vitess checkout is up-to-date (git fetch --all) before running.")
+)
+
+func getValidWorkdir() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine working directory, bailing: %w", err)
+	}
+
+	if err := isDir(filepath.Join(wd, "content", "en")); err != nil {
+		return "", fmt.Errorf("cannot find content/en dir in %s: %w", wd, err)
+	}
+
+	return wd, nil
+}
+
+func debugf(msg string, args ...any) {
+	if !*debug {
+		return
+	}
+
+	log.Printf(msg, args...)
+}
+
+func must(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+func unwrap[T any](t T, err error) T {
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return t
+}
+
+func main() {
+	flag.Parse()
+
+	wd := unwrap(getValidWorkdir())
+
+	if *vitessDir == "" {
+		log.Fatalf("--vitess-dir must be specified")
+	}
+
+	debugf("workdir: %s\tvitess-dir: %s\t\n", wd, *vitessDir)
+
+	var versions []version
+
+	for i, pair := range strings.Split(*versionStrs, ",") {
+		parts := strings.Split(pair, ":")
+		if len(parts) < 2 {
+			log.Fatalf("bad version spec (index=%d) %s", i, pair)
+		}
+
+		version := version{
+			Ref:        strings.Join(parts[:len(parts)-1], ":"),
+			DocVersion: parts[len(parts)-1],
+		}
+
+		if err := isDir(version.Dir(wd)); err != nil {
+			log.Fatalf("cannot find directory for doc version %s (index=%d): %v", pair, i, err)
+		}
+
+		versions = append(versions, version)
+	}
+
+	for _, version := range versions {
+		must(version.GenerateDocs(wd, *vitessDir, *docGenPath))
+	}
+}

--- a/tools/vtctldclientdocs/main.go
+++ b/tools/vtctldclientdocs/main.go
@@ -10,6 +10,7 @@ import (
 )
 
 var (
+	usage       = "Generates website documentation for the `vtctldclient` binary for a given set of <vitessio/vitess-gitref>:<vitessio/website-version> pairs."
 	debug       = flag.Bool("debug", false, "log debug info")
 	vitessDir   = flag.String("vitess-dir", "", "path to vitess checkout")
 	docGenPath  = flag.String("vtctldclientdocgen-path", "./go/cmd/vtctldclient/docgen", "path to the vtctldclient doc generator, **relative to** --vitess-dir")
@@ -51,6 +52,11 @@ func unwrap[T any](t T, err error) T {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "\n%s\n\n", usage)
+		flag.PrintDefaults()
+	}
 	flag.Parse()
 
 	wd := unwrap(getValidWorkdir())

--- a/tools/vtctldclientdocs/version.go
+++ b/tools/vtctldclientdocs/version.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type version struct {
+	Ref        string
+	DocVersion string
+}
+
+func (v version) Dir(root string) string {
+	return filepath.Join(root, "content", "en", "docs", v.DocVersion, "reference", "programs", "vtctldclient")
+}
+
+func (v version) GenerateDocs(workdir string, vitessDir string, docgenPath string) (err error) {
+	debugf("chdir %s", vitessDir)
+	if err = os.Chdir(vitessDir); err != nil {
+		return err
+	}
+
+	defer func() {
+		debugf("chdir %s", workdir)
+		if cderr := os.Chdir(workdir); cderr != nil {
+			if err == nil {
+				err = cderr
+			}
+		}
+	}()
+
+	gitCheckout := exec.Command("git", "checkout", v.Ref)
+	debugf(gitCheckout.String())
+	if err = gitCheckout.Run(); err != nil {
+		return err
+	}
+
+	defer func() {
+		gitCheckout := exec.Command("git", "checkout", "-")
+		debugf(gitCheckout.String())
+		if checkoutErr := gitCheckout.Run(); checkoutErr != nil {
+			if err == nil {
+				err = checkoutErr
+			}
+		}
+	}()
+
+	if err = isDir(filepath.Join(vitessDir, docgenPath)); err != nil {
+		err = fmt.Errorf("cannot find docgen tool directory: %w", err)
+		return err
+	}
+
+	docgen := exec.Command("go", "run", docgenPath, "-d", v.Dir(workdir))
+	debugf(docgen.String())
+	if err = docgen.Run(); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/tools/vtctldclientdocs/version.go
+++ b/tools/vtctldclientdocs/version.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Vitess Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (


### PR DESCRIPTION
I ran this against #1177 and it produced no diffs. I then made some edits:

```
$ git diff content/
diff --git a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
index c900a8ac..d8ca2907 100644
--- a/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/15.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -6,6 +6,8 @@ series: vtctldclient
 
 Defines a group of cells that can be referenced by a single name (the alias).
 
+This is some extra text in 15.0 docs.
+
 ### Synopsis
 
 Defines a group of cells that can be referenced by a single name (the alias).
diff --git a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
index c616a5f8..89df1a68 100644
--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -6,6 +6,8 @@ series: vtctldclient
 
 Registers a local topology service in a new cell by creating the CellInfo.
 
+This is some extra text in 16.0 docs.
+
 ### Synopsis
 
 Registers a local topology service in a new cell by creating the CellInfo
```

Ran the tool:

```
$ VITESS_DIR=$(realpath ../vitess) make vtctldclient-docs
```

And the diff was gone:

```
$ git diff content/ | wc -l
       0
```