### PR TITLE
Mention Ubuntu as the only compatible OS in `Install Vitess` page

### DIFF
--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -80,7 +80,7 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 15:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux, note that only Ubuntu is fully supported, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images. For example with Vitess 15:
 
 **Notes:**
 

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -80,12 +80,13 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux, note that only Ubuntu is fully supported, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images. For example with Vitess 15:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 15:
 
 **Notes:**
 
 * Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
 * Please use release [15.0.2](https://github.com/vitessio/vitess/releases/tag/v15.0.2) instead.
+* Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
 version=15.0.2


### PR DESCRIPTION
This PR adds a mention in the `Install Vitess` page to invite people to build Vitess on their own if they want to install Vitess binaries on other OSs than Ubuntu. In facts, during the release process, the binaries are built using GitHub Actions, which runs on Ubuntu latest.