### PR TITLE
Add deprecation and removal warnings for VExec and VReplicationExec

### DIFF
--- a/content/en/docs/13.0/reference/vreplication/vexec.md
+++ b/content/en/docs/13.0/reference/vreplication/vexec.md
@@ -4,6 +4,10 @@ description: Wrapper on VReplicationExec to run query on all participating prima
 weight: 60
 ---
 
+{{< warning >}}
+This command was deprecated in v12.0 and has been removed in v16.0.
+{{< /warning >}}
+
 ### Command
 
 ```

--- a/content/en/docs/13.0/reference/vreplication/vreplicationexec.md
+++ b/content/en/docs/13.0/reference/vreplication/vreplicationexec.md
@@ -4,6 +4,10 @@ description: Low level command to run a query on vreplication related tables
 weight: 70
 ---
 
+{{< warning >}}
+This command was deprecated in v16.0 and will be removed in a future release.
+{{< /warning >}}
+
 ### Command
 
 ```

--- a/content/en/docs/14.0/reference/vreplication/vexec.md
+++ b/content/en/docs/14.0/reference/vreplication/vexec.md
@@ -4,6 +4,10 @@ description: Wrapper on VReplicationExec to run query on all participating prima
 weight: 60
 ---
 
+{{< warning >}}
+This command was deprecated in v12.0 and has been removed in v16.0.
+{{< /warning >}}
+
 ### Command
 
 ```
@@ -11,8 +15,6 @@ VExec  -- [--dry_run] <keyspace.workflow> <query>
 ```
 
 ### Description
-
-Deprecated in version 12.0.
 
 VExec is a wrapper over [VReplicationExec](../vreplicationexec).
 Given a workflow it executes the provided query on all primary tablets in the target keyspace that participate

--- a/content/en/docs/14.0/reference/vreplication/vreplicationexec.md
+++ b/content/en/docs/14.0/reference/vreplication/vreplicationexec.md
@@ -4,6 +4,10 @@ description: Low level command to run a query on vreplication related tables
 weight: 70
 ---
 
+{{< warning >}}
+This command was deprecated in v16.0 and will be removed in a future release.
+{{< /warning >}}
+
 ### Command
 
 ```

--- a/content/en/docs/15.0/reference/vreplication/vexec.md
+++ b/content/en/docs/15.0/reference/vreplication/vexec.md
@@ -4,6 +4,10 @@ description: Wrapper on VReplicationExec to run query on all participating prima
 weight: 60
 ---
 
+{{< warning >}}
+This command was deprecated in v12.0 and has been removed in v16.0.
+{{< /warning >}}
+
 ### Command
 
 ```
@@ -11,8 +15,6 @@ VExec  -- [--dry_run] <keyspace.workflow> <query>
 ```
 
 ### Description
-
-Deprecated in version 12.0.
 
 VExec is a wrapper over [VReplicationExec](../vreplicationexec).
 Given a workflow it executes the provided query on all primary tablets in the target keyspace that participate

--- a/content/en/docs/15.0/reference/vreplication/vreplicationexec.md
+++ b/content/en/docs/15.0/reference/vreplication/vreplicationexec.md
@@ -4,6 +4,10 @@ description: Low level command to run a query on vreplication related tables
 weight: 70
 ---
 
+{{< warning >}}
+This command was deprecated in v16.0 and will be removed in a future release.
+{{< /warning >}}
+
 ### Command
 
 ```

--- a/content/en/docs/16.0/reference/vreplication/vreplicationexec.md
+++ b/content/en/docs/16.0/reference/vreplication/vreplicationexec.md
@@ -4,6 +4,10 @@ description: Low level command to run a query on vreplication related tables
 weight: 70
 ---
 
+{{< warning >}}
+This command was deprecated in v16.0 and will be removed in a future release.
+{{< /warning >}}
+
 ### Command
 
 ```


### PR DESCRIPTION
This documents https://github.com/vitessio/vitess/pull/12070 and adds a warning for https://github.com/vitessio/vitess/pull/11955.