### PR TITLE
Remove vtctld_show_topology_crud

### DIFF
--- a/content/en/docs/15.0/reference/programs/vtctld.md
+++ b/content/en/docs/15.0/reference/programs/vtctld.md
@@ -262,7 +262,6 @@ vtctld \
 | --vtctl_healthcheck_retry_delay | duration | delay before retrying a failed healthcheck (default 5s) |
 | --vtctl_healthcheck_timeout | duration | the health check timeout period (default 1m0s) |
 | --vtctl_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
-| --vtctld_show_topology_crud | boolean | Controls the display of the CRUD topology actions in the vtctld UI. (default true) |
 | --vtgate_grpc_ca | string | the server ca to use to validate servers when connecting |
 | --vtgate_grpc_cert | string | the cert to use to connect |
 | --vtgate_grpc_key | string | the key to use to connect |

--- a/content/en/docs/16.0/reference/programs/vtctld.md
+++ b/content/en/docs/16.0/reference/programs/vtctld.md
@@ -185,4 +185,3 @@ vtctld \
 | --vmodule | value | comma-separated list of pattern=N settings for file-filtered logging |
 | --vtctl_healthcheck_topology_refresh | duration | refresh interval for re-reading the topology (default 30s) |
 | --vtctld_sanitize_log_messages | | When true, vtctld sanitizes logging. |
-| --vtctld_show_topology_crud | boolean | Controls the display of the CRUD topology actions in the vtctld UI. (default true) |


### PR DESCRIPTION
Removes a flag `vtctld_show_topology_crud` that is removed in this PR: https://github.com/vitessio/vitess/pull/11851