### PR TITLE
Hotfix: enable site wide search

### DIFF
--- a/layouts/_default/list.lunr.json
+++ b/layouts/_default/list.lunr.json
@@ -1,5 +1,5 @@
 {{- $index := slice -}}
 {{- range $page := $.Site.RegularPages -}}
-    {{- $index = $index | append (dict "title" $page.Title "version" (index (first 3 (split (delimit (split $page.RelPermalink "/") "," "") ",")) 2) "href" $page.Permalink  "summary" ($page.Summary | plainify | safeHTML) "path" ($page.Permalink | relURL)  ) -}}
+    {{- $index = $index | append (dict "title" $page.Title  "content" ($page.Content | plainify | safeHTML) "version" (index (first 3 (split (delimit (split $page.RelPermalink "/") "," "") ",")) 2) "href" $page.Permalink  "summary" ($page.Summary | plainify | safeHTML) "path" ($page.Permalink | relURL)  ) -}}
 {{- end -}}
 {{- $index | jsonify -}}

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -83,6 +83,12 @@ $versions.current}}
             wildcard: lunr.Query.wildcard.TRAILING,
             presence: lunr.Query.presence.REQUIRED,
           });
+          this.field("content", {
+            boost: 20,
+            usePipeline: true,
+            wildcard: lunr.Query.wildcard.TRAILING,
+            presence: lunr.Query.presence.REQUIRED,
+          });
           this.field("summary", {
             boost: 10,
           });
@@ -96,6 +102,7 @@ $versions.current}}
                   version: doc.version,
                   href: doc.href,
                   summary: doc.summary,
+                  content: doc.content,
                   path: doc.path,
                 };
               }
@@ -109,6 +116,7 @@ $versions.current}}
                   version: doc.version,
                   href: doc.href,
                   summary: doc.summary,
+                  content: doc.content,
                   path: doc.path,
                 };
               }


### PR DESCRIPTION
### Issue
Lunr depends on whatever we give it as the index to function. In the case of Vitess, we only crawl the summary of each of the docs pages. The summary is usually the first 5 or more sentences of a page hence the rest of the page/doc is not in the index.

### Solution
To solve this issue, I  created a new field containing all the page contents. This enables a complete site-wide search for content in Vitess.io

### Future Improvements
To make the vitess.io search better, we need to improve two things:

1. Reduce the search results summary to 1 or 2 sentences
2. Highlight the search keyword in the search result

### Action Item

- [x] Create an issue on Vitess.io for these different search improvements.

Fixes #1355 
