### PR TITLE
Disable analytics for deploy previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules/
-public/
+/public
 resources/
 !content/en/docs/resources
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ production-build: install
 	--verbose
 
 preview-build: install
-	$(HUGO) --cleanDestinationDir \
+	$(HUGO) --cleanDestinationDir -e dev \
 	--buildDrafts \
 	--buildFuture \
 	--baseURL $(DEPLOY_PRIME_URL) \


### PR DESCRIPTION
- Closes #1164
- Git ignore rule tweak: supports `/public` being a symlink to another git-managed folder (for debugging purposes).

```console
$ curl -i https://deploy-preview-1378--vitess.netlify.app/ 2>/dev/null | grep www.google
$ 
```

/cc @nate-double-u 