### PR TITLE
Update with nvm + node install

### DIFF
--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -56,7 +56,7 @@ nvm install 16
 nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/release-14.0/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically attempts adds these there:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -52,11 +52,11 @@ export NVM_DIR="$HOME/.nvm"
 Finally, install [node](https://nodejs.org/):
 
 ```
-nvm install --lts 16.13.0
-nvm use 16.13.0
+nvm install 16
+nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -36,7 +36,7 @@ sudo systemctl disable mysql
 sudo systemctl disable etcd
 ```
 
-### Install Node 16.13.0+
+### Install Node 16+
 
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash

--- a/content/en/docs/14.0/get-started/local.md
+++ b/content/en/docs/14.0/get-started/local.md
@@ -36,6 +36,28 @@ sudo systemctl disable mysql
 sudo systemctl disable etcd
 ```
 
+### Install Node 16.13.0+
+
+```
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+```
+
+Ensure the following is in your bashrc/zshrc or similar:
+```
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+```
+
+Finally, install [node](https://nodejs.org/):
+
+```
+nvm install --lts 16.13.0
+nvm use 16.13.0
+```
+
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
+
 ## Disable AppArmor or SELinux
 
 AppArmor/SELinux will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:

--- a/content/en/docs/15.0/get-started/local-docker.md
+++ b/content/en/docs/15.0/get-started/local-docker.md
@@ -41,7 +41,6 @@ This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `
 
 - `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
 - `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
-- Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -56,7 +56,7 @@ nvm install 16
 nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/release-15.0/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -36,7 +36,7 @@ sudo systemctl disable mysql
 sudo systemctl disable etcd
 ```
 
-### Install Node 16.13.0+
+### Install Node 16+
 
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
@@ -52,8 +52,8 @@ export NVM_DIR="$HOME/.nvm"
 Finally, install [node](https://nodejs.org/):
 
 ```
-nvm install --lts 16.13.0
-nvm use 16.13.0
+nvm install 16
+nvm use 16
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -202,18 +202,6 @@ vtadmin-api is running!
   - API: http://localhost:14200
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
-
-Installing nvm...
-
-nvm is installed!
-
-Configuring Node.js 16
-
-Downloading and installing node v16.19.1...
-Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
-Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
-Now using node v16.19.1 (npm v8.19.3)
-Now using node v16.19.1 (npm v8.19.3)
 
 > vtadmin@0.1.0 build
 > react-scripts build

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically attempts adds these there:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -56,7 +56,7 @@ nvm install 16
 nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -203,6 +203,17 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is installed!
+
+Configuring Node.js 16
+
+Downloading and installing node v16.19.1...
+Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Now using node v16.19.1 (npm v8.19.3)
+Now using node v16.19.1 (npm v8.19.3)
 
 > vtadmin@0.1.0 build
 > react-scripts build

--- a/content/en/docs/16.0/get-started/local-docker.md
+++ b/content/en/docs/16.0/get-started/local-docker.md
@@ -41,7 +41,6 @@ This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `
 
 - `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
 - `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
-- Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
 - `VTOrc` page is available at [http://localhost:16000](http://localhost:16000)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically attempts adds these there:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
@@ -52,11 +52,11 @@ export NVM_DIR="$HOME/.nvm"
 Finally, install [node](https://nodejs.org/):
 
 ```
-nvm install --lts 16
+nvm install 16
 nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -42,7 +42,7 @@ sudo systemctl disable etcd
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ```
 
-Ensure the following is in your bashrc/zshrc or similar:
+Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically adds these:
 ```
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -56,7 +56,7 @@ nvm install 16
 nvm use 16
 ```
 
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/f928f8a211bf352a4272eed84e76bb064df154c2/web/vtadmin/README.md) for more details.
+See the [vtadmin README](https://github.com/vitessio/vitess/blob/release-16.0/web/vtadmin/README.md) for more details.
 
 ## Disable AppArmor or SELinux
 

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -204,6 +204,17 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is installed!
+
+Configuring Node.js 16
+
+Downloading and installing node v16.19.1...
+Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Now using node v16.19.1 (npm v8.19.3)
+Now using node v16.19.1 (npm v8.19.3)
 
 > vtadmin@0.1.0 build
 > react-scripts build

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -36,7 +36,7 @@ sudo systemctl disable mysql
 sudo systemctl disable etcd
 ```
 
-### Install Node 16.13.0+
+### Install Node 16
 
 ```
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
@@ -52,8 +52,8 @@ export NVM_DIR="$HOME/.nvm"
 Finally, install [node](https://nodejs.org/):
 
 ```
-nvm install --lts 16.13.0
-nvm use 16.13.0
+nvm install --lts 16
+nvm use 16
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.

--- a/content/en/docs/17.0/get-started/local-docker.md
+++ b/content/en/docs/17.0/get-started/local-docker.md
@@ -41,7 +41,6 @@ This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `
 
 - `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
 - `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
-- Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
 - `VTOrc` page is available at [http://localhost:16000](http://localhost:16000)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -36,28 +36,6 @@ sudo systemctl disable mysql
 sudo systemctl disable etcd
 ```
 
-### Install Node 16.13.0+
-
-```
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
-```
-
-Ensure the following is in your bashrc/zshrc or similar:
-```
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-```
-
-Finally, install [node](https://nodejs.org/):
-
-```
-nvm install --lts 16.13.0
-nvm use 16.13.0
-```
-
-See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
-
 ## Disable AppArmor or SELinux
 
 AppArmor/SELinux will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:
@@ -204,6 +182,17 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is installed!
+
+Configuring Node.js 16
+
+Downloading and installing node v16.19.1...
+Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
+Now using node v16.19.1 (npm v8.19.3)
+Now using node v16.19.1 (npm v8.19.3)
 
 > vtadmin@0.1.0 build
 > react-scripts build


### PR DESCRIPTION
This PR updates the docs with changes from https://github.com/vitessio/vitess/pull/12439 that add installing nvm to `vtadmin-up.sh`.

- Adds nvm install instructions to v14 local.md
- Removes nvm install instruction from v17 local.md
- Updates the local script updates in v15, v16, and v17 to include the added nvm step