### PR TITLE
Updated Getting Started to include vtadmin link.

### DIFF
--- a/content/en/docs/14.0/get-started/local-docker.md
+++ b/content/en/docs/14.0/get-started/local-docker.md
@@ -37,11 +37,13 @@ In your shell, execute:
 make docker_run_local
 ```
 
-This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 
+This will set up a MySQL replication topology, as well as `etcd`, `vtctld`, `vtgate`,
+`vtadmin` services.
 
-- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
-- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
+- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status)
+- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status)
 - Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
+- `VTadmin` web application is available [http://localhost:14201](http://localhost:14201)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 

--- a/content/en/docs/14.0/get-started/local-docker.md
+++ b/content/en/docs/14.0/get-started/local-docker.md
@@ -38,7 +38,7 @@ make docker_run_local
 ```
 
 This will set up a MySQL replication topology, as well as `etcd`, `vtctld`, `vtgate`,
-`vtadmin` services.
+and `vtadmin` services.
 
 - `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status)
 - `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status)

--- a/content/en/docs/15.0/get-started/local-docker.md
+++ b/content/en/docs/15.0/get-started/local-docker.md
@@ -37,11 +37,13 @@ In your shell, execute:
 make docker_run_local
 ```
 
-This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 
+This will set up a MySQL replication topology, as well as `etcd`, `vtctld`, `vtgate`,
+and `vtadmin` services.
 
-- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
-- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
+- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status)
+- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status)
 - Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
+- `VTadmin` web application is available [http://localhost:14201](http://localhost:14201)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 

--- a/content/en/docs/16.0/get-started/local-docker.md
+++ b/content/en/docs/16.0/get-started/local-docker.md
@@ -37,12 +37,14 @@ In your shell, execute:
 make docker_run_local
 ```
 
-This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 
+This will set up a MySQL replication topology, as well as `etcd`, `vtctld`, `vtgate`,
+`vtorc`, and `vtadmin` services.
 
-- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
-- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
+- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status)
+- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status)
 - Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
 - `VTOrc` page is available at [http://localhost:16000](http://localhost:16000)
+- `VTadmin` web application is available [http://localhost:14201](http://localhost:14201)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 

--- a/content/en/docs/17.0/get-started/local-docker.md
+++ b/content/en/docs/17.0/get-started/local-docker.md
@@ -37,12 +37,14 @@ In your shell, execute:
 make docker_run_local
 ```
 
-This will set up a MySQL replication topology, as well as `etcd`, `vtctld` and `vtgate` services. 
+This will set up a MySQL replication topology, as well as `etcd`, `vtctld`, `vtgate`,
+`vtorc`, and `vtadmin` services.
 
-- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status) 
-- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status) 
+- `vtgate` listens on [http://127.0.0.1:15001/debug/status](http://127.0.0.1:15001/debug/status)
+- `vtctld` listens on [http://127.0.0.1:15000/debug/status](http://127.0.0.1:15000/debug/status)
 - Control panel is available at [http://localhost:15000/app/](http://localhost:15000/app/)
 - `VTOrc` page is available at [http://localhost:16000](http://localhost:16000)
+- `VTadmin` web application is available [http://localhost:14201](http://localhost:14201)
 
 From within the docker shell, aliases are set up for your convenience. Try the following `mysql` commands to connect to various tablets:
 


### PR DESCRIPTION
### Description
This PR updates the Getting Started documentation for the [Local Install Via Docker](http://localhost:1313/docs/16.0/get-started/local-docker/) page. This update is related to [PR #12467](https://github.com/vitessio/vitess/pull/12467) on the vitess project.

### Testing
The update was manually verified and shown in the screen capture below:

![The-Vitess-Docs-Local-Install-via-Docker](https://user-images.githubusercontent.com/125596831/221207849-bf22f682-bd52-4371-aaa1-d73ca1b72bff.png)
