### PR TITLE
Add chart highlighting naming diffs between legacy and new vtctl clients

### DIFF
--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -1,0 +1,51 @@
+---
+title: Command Diff
+weight: 3
+---
+
+The following table highlights the main differences in naming between `vtctlclient` and `vtctldclient`.
+
+Unless noted here, command names have a one-to-one mapping between the legacy `vtctlclient` and `vtctldclient`, though output formats may have changed (e.g. `GetKeyspace` now outputs valid JSON).
+For stronger guarantees of compatibility, we highly encourage programming directly against the [`VtctldServer` gRPC API][grpc_api_def].
+
+[grpc_api_def]: https://github.com/vitessio/vitess/blob/04870fc27499ac64dcf6050c41fe9c44aea7099c/proto/vtctlservice.proto#L32-L33.
+
+### Command name differences
+
+| | `vtctldclient` command name (NEW) | `vtctlclient` command name (OLD) |
+|-|-|-|
+| | `ApplyShardRoutingRules` | N/A |
+| | `CreateKeyspace` | N/A |
+| | (not yet migrated) | `CopySchemaShard` |
+| | (not yet migrated) | `CreateLookupVindex` |
+| | `DeleteShards` | `DeleteShard` |
+| | `DeleteTablets` | `DeleteTablet` |
+| | `ExecuteFetchAsDBA` | `ExecuteFetchAsDba` |
+| | (not yet migrated) | `ExternalVindex` |
+| | `GetBackups` | `ListBackups` |
+| | `GetFullStatus` | N/A |
+| | `GetShardRoutingRules` | N/A |
+| | N/A | `GetShardReplication` |
+| | `GetSrvKeyspaces` | `GetSrvKeyspace` |
+| | `GetSrvVSchemas` | N/A |
+| | `GetTabletVersion` | N/A |
+| | `GetTablets` | `ListAllTablets`, `ListShardTablets`, `ListTablets` |
+| | `GetTopologyPath` | N/A |
+| | `GetWorkflows` | N/A |
+| | (deleted) | `InitShardPrimary` |
+| | (not yet migrated) | `Migrate` |
+| | (not yet migrated) | `Mount` |
+| | (not yet migrated) | `OnlineDDL` |
+| | `PingTablet` | `Ping` |
+| | `SetKeyspaceDurabilityPolicy` | N/A |
+| | `SetWritable` | `SetReadOnly`, `SetReadWrite` |
+| | `SleepTablet` | `Sleep` |
+| | N/A | `TopoCat`, `TopoCp` |
+| | N/A | `UpdateSrvKeyspacePartition` |
+| | (deleted) | `UpdateTabletAddrs` |
+| | (not yet migrated) | `VReplicationExec` |
+| | `ValidatePermissionsKeyspace`, `ValidatePermissionsShard` | N/A |
+| | `ValidateSchemaShard` | N/A |
+| | N/A | `VtctldCommand` |
+| | N/A | `WaitForFilteredReplication` |
+| | N/A | `Workflow` |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -15,13 +15,12 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | `vtctldclient` command name (NEW) | `vtctlclient` command name (OLD) |
 |-|-|-|
 | | `ApplyShardRoutingRules` | N/A |
-| | `CreateKeyspace` | N/A |
 | | (not yet migrated) | `CopySchemaShard` |
 | | (not yet migrated) | `CreateLookupVindex` |
 | | `DeleteShards` | `DeleteShard` |
 | | `DeleteTablets` | `DeleteTablet` |
 | | `ExecuteFetchAsDBA` | `ExecuteFetchAsDba` |
-| | (not yet migrated) | `ExternalVindex` |
+| | (not yet migrated) | `ExternalizeVindex` |
 | | `GetBackups` | `ListBackups` |
 | | `GetFullStatus` | N/A |
 | | `GetShardRoutingRules` | N/A |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -24,7 +24,7 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | `ListBackups` | [`GetBackups`](../../programs/vtctldclient/vtctldclient_getbackups/) |
 | | N/A | [`GetFullStatus`](../../programs/vtctldclient/vtctldclient_getfullstatus/) |
 | | N/A | [`GetShardRoutingRules`](../../programs/vtctldclient/vtctldclient_getshardroutingrules/) |
-| | `GetShardReplication` | N/A |
+| | `GetShardReplication` | (not yet migrated) |
 | | `GetSrvKeyspace` | [`GetSrvKeyspaces`](../../programs/vtctldclient/vtctldclient_getsrvkeyspaces/) |
 | | N/A | [`GetSrvVSchemas`](../../programs/vtctldclient/vtctldclient_getsrvvschemas/) |
 | | N/A | [`GetTabletVersion`](../../programs/vtctldclient/vtctldclient_gettabletversion/) |
@@ -39,11 +39,11 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | N/A | [`SetKeyspaceDurabilityPolicy`](../../programs/vtctldclient/vtctldclient_setkeyspacedurabilitypolicy/) |
 | | `SetReadOnly`, `SetReadWrite` | [`SetWritable`](../../programs/vtctldclient/vtctldclient_setwritable/) |
 | | `Sleep` | [`SleepTablet`](../../programs/vtctldclient/vtctldclient_sleeptablet/) |
-| | `TopoCat`, `TopoCp` | N/A |
-| | `UpdateSrvKeyspacePartition` | N/A |
+| | `TopoCat`, `TopoCp` | (not yet migrated) |
+| | `UpdateSrvKeyspacePartition` | (not yet migrated) |
 | | `UpdateTabletAddrs` | (deleted) |
 | | `VReplicationExec` | (not yet migrated) |
-| | `ValidatePermissionsKeyspace`, `ValidatePermissionsShard` | N/A |
+| | `ValidatePermissionsKeyspace`, `ValidatePermissionsShard` | (deleted) |
 | | `VtctldCommand` | N/A |
-| | `WaitForFilteredReplication` | N/A |
-| | `Workflow` | N/A |
+| | `WaitForFilteredReplication` | (deleted) |
+| | `Workflow` | (deleted) |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -14,31 +14,31 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 
 | | `vtctlclient` command name (OLD) | `vtctldclient` command name (NEW) |
 |-|-|-|
-| | N/A | `ApplyShardRoutingRules` |
+| | N/A | [`ApplyShardRoutingRules`](../../programs/vtctldclient/vtctldclient_applyroutingrules/) |
 | | `CopySchemaShard` | (not yet migrated) |
 | | `CreateLookupVindex` | (not yet migrated) |
-| | `DeleteShard` | `DeleteShards` |
-| | `DeleteTablet` | `DeleteTablets` |
-| | `ExecuteFetchAsDba` | `ExecuteFetchAsDBA` |
+| | `DeleteShard` | [`DeleteShards`](../../programs/vtctldclient/vtctldclient_deleteshards/) |
+| | `DeleteTablet` | [`DeleteTablets`](../../programs/vtctldclient/vtctldclient_deletetablets/) |
+| | `ExecuteFetchAsDba` | [`ExecuteFetchAsDBA`](../../programs/vtctldclient/vtctldclient_executefetchasdba/) |
 | | `ExternalizeVindex` | (not yet migrated) |
-| | `ListBackups` | `GetBackups` |
-| | N/A | `GetFullStatus` |
-| | N/A | `GetShardRoutingRules` |
+| | `ListBackups` | [`GetBackups`](../../programs/vtctldclient/vtctldclient_getbackups/) |
+| | N/A | [`GetFullStatus`](../../programs/vtctldclient/vtctldclient_getfullstatus/) |
+| | N/A | [`GetShardRoutingRules`](../../programs/vtctldclient/vtctldclient_getshardroutingrules/) |
 | | `GetShardReplication` | N/A |
-| | `GetSrvKeyspace` | `GetSrvKeyspaces` |
-| | N/A | `GetSrvVSchemas` |
-| | N/A | `GetTabletVersion` |
-| | `ListAllTablets`, `ListShardTablets`, `ListTablets` | `GetTablets` |
-| | N/A | `GetTopologyPath` |
-| | N/A | `GetWorkflows` |
+| | `GetSrvKeyspace` | [`GetSrvKeyspaces`](../../programs/vtctldclient/vtctldclient_getsrvkeyspaces/) |
+| | N/A | [`GetSrvVSchemas`](../../programs/vtctldclient/vtctldclient_getsrvvschemas/) |
+| | N/A | [`GetTabletVersion`](../../programs/vtctldclient/vtctldclient_gettabletversion/) |
+| | `ListAllTablets`, `ListShardTablets`, `ListTablets` | [`GetTablets`](../../programs/vtctldclient/vtctldclient_gettablets/) |
+| | N/A | [`GetTopologyPath`](../../programs/vtctldclient/vtctldclient_gettopologypath/) |
+| | N/A | [`GetWorkflows`](../../programs/vtctldclient/vtctldclient_getworkflows/) |
 | | `InitShardPrimary` | (deleted) |
 | | `Migrate` | (not yet migrated) |
 | | `Mount` | (not yet migrated) |
 | | `OnlineDDL` | (not yet migrated) |
-| | `Ping` | `PingTablet` |
-| | N/A | `SetKeyspaceDurabilityPolicy` |
-| | `SetReadOnly`, `SetReadWrite` | `SetWritable` |
-| | `Sleep` | `SleepTablet` |
+| | `Ping` | [`PingTablet`](../../programs/vtctldclient/vtctldclient_pingtablet/) |
+| | N/A | [`SetKeyspaceDurabilityPolicy`](../../programs/vtctldclient/vtctldclient_setkeyspacedurabilitypolicy/) |
+| | `SetReadOnly`, `SetReadWrite` | [`SetWritable`](../../programs/vtctldclient/vtctldclient_setwritable/) |
+| | `Sleep` | [`SleepTablet`](../../programs/vtctldclient/vtctldclient_sleeptablet/) |
 | | `TopoCat`, `TopoCp` | N/A |
 | | `UpdateSrvKeyspacePartition` | N/A |
 | | `UpdateTabletAddrs` | (deleted) |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -44,7 +44,6 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | `UpdateTabletAddrs` | (deleted) |
 | | `VReplicationExec` | (not yet migrated) |
 | | `ValidatePermissionsKeyspace`, `ValidatePermissionsShard` | N/A |
-| | `ValidateSchemaShard` | N/A |
 | | `VtctldCommand` | N/A |
 | | `WaitForFilteredReplication` | N/A |
 | | `Workflow` | N/A |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -12,39 +12,39 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 
 ### Command name differences
 
-| | `vtctldclient` command name (NEW) | `vtctlclient` command name (OLD) |
+| | `vtctlclient` command name (OLD) | `vtctldclient` command name (NEW) |
 |-|-|-|
-| | `ApplyShardRoutingRules` | N/A |
-| | (not yet migrated) | `CopySchemaShard` |
-| | (not yet migrated) | `CreateLookupVindex` |
-| | `DeleteShards` | `DeleteShard` |
-| | `DeleteTablets` | `DeleteTablet` |
-| | `ExecuteFetchAsDBA` | `ExecuteFetchAsDba` |
-| | (not yet migrated) | `ExternalizeVindex` |
-| | `GetBackups` | `ListBackups` |
-| | `GetFullStatus` | N/A |
-| | `GetShardRoutingRules` | N/A |
-| | N/A | `GetShardReplication` |
-| | `GetSrvKeyspaces` | `GetSrvKeyspace` |
-| | `GetSrvVSchemas` | N/A |
-| | `GetTabletVersion` | N/A |
-| | `GetTablets` | `ListAllTablets`, `ListShardTablets`, `ListTablets` |
-| | `GetTopologyPath` | N/A |
-| | `GetWorkflows` | N/A |
-| | (deleted) | `InitShardPrimary` |
-| | (not yet migrated) | `Migrate` |
-| | (not yet migrated) | `Mount` |
-| | (not yet migrated) | `OnlineDDL` |
-| | `PingTablet` | `Ping` |
-| | `SetKeyspaceDurabilityPolicy` | N/A |
-| | `SetWritable` | `SetReadOnly`, `SetReadWrite` |
-| | `SleepTablet` | `Sleep` |
-| | N/A | `TopoCat`, `TopoCp` |
-| | N/A | `UpdateSrvKeyspacePartition` |
-| | (deleted) | `UpdateTabletAddrs` |
-| | (not yet migrated) | `VReplicationExec` |
+| | N/A | `ApplyShardRoutingRules` |
+| | `CopySchemaShard` | (not yet migrated) |
+| | `CreateLookupVindex` | (not yet migrated) |
+| | `DeleteShard` | `DeleteShards` |
+| | `DeleteTablet` | `DeleteTablets` |
+| | `ExecuteFetchAsDba` | `ExecuteFetchAsDBA` |
+| | `ExternalizeVindex` | (not yet migrated) |
+| | `ListBackups` | `GetBackups` |
+| | N/A | `GetFullStatus` |
+| | N/A | `GetShardRoutingRules` |
+| | `GetShardReplication` | N/A |
+| | `GetSrvKeyspace` | `GetSrvKeyspaces` |
+| | N/A | `GetSrvVSchemas` |
+| | N/A | `GetTabletVersion` |
+| | `ListAllTablets`, `ListShardTablets`, `ListTablets` | `GetTablets` |
+| | N/A | `GetTopologyPath` |
+| | N/A | `GetWorkflows` |
+| | `InitShardPrimary` | (deleted) |
+| | `Migrate` | (not yet migrated) |
+| | `Mount` | (not yet migrated) |
+| | `OnlineDDL` | (not yet migrated) |
+| | `Ping` | `PingTablet` |
+| | N/A | `SetKeyspaceDurabilityPolicy` |
+| | `SetReadOnly`, `SetReadWrite` | `SetWritable` |
+| | `Sleep` | `SleepTablet` |
+| | `TopoCat`, `TopoCp` | N/A |
+| | `UpdateSrvKeyspacePartition` | N/A |
+| | `UpdateTabletAddrs` | (deleted) |
+| | `VReplicationExec` | (not yet migrated) |
 | | `ValidatePermissionsKeyspace`, `ValidatePermissionsShard` | N/A |
 | | `ValidateSchemaShard` | N/A |
-| | N/A | `VtctldCommand` |
-| | N/A | `WaitForFilteredReplication` |
-| | N/A | `Workflow` |
+| | `VtctldCommand` | N/A |
+| | `WaitForFilteredReplication` | N/A |
+| | `Workflow` | N/A |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -24,7 +24,7 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | `ListBackups` | [`GetBackups`](../../programs/vtctldclient/vtctldclient_getbackups/) |
 | | N/A | [`GetFullStatus`](../../programs/vtctldclient/vtctldclient_getfullstatus/) |
 | | N/A | [`GetShardRoutingRules`](../../programs/vtctldclient/vtctldclient_getshardroutingrules/) |
-| | `GetShardReplication` | (not yet migrated) |
+| | `GetShardReplication` | [`ShardReplicationPositions`](../../programs/vtctldclient/vtctldclient_shardreplicationpositions/) |
 | | `GetSrvKeyspace` | [`GetSrvKeyspaces`](../../programs/vtctldclient/vtctldclient_getsrvkeyspaces/) |
 | | N/A | [`GetSrvVSchemas`](../../programs/vtctldclient/vtctldclient_getsrvvschemas/) |
 | | N/A | [`GetTabletVersion`](../../programs/vtctldclient/vtctldclient_gettabletversion/) |

--- a/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
+++ b/content/en/docs/17.0/reference/vtctldclient-transition/command_diff.md
@@ -15,7 +15,7 @@ For stronger guarantees of compatibility, we highly encourage programming direct
 | | `vtctlclient` command name (OLD) | `vtctldclient` command name (NEW) |
 |-|-|-|
 | | N/A | [`ApplyShardRoutingRules`](../../programs/vtctldclient/vtctldclient_applyroutingrules/) |
-| | `CopySchemaShard` | (not yet migrated) |
+| | `CopySchemaShard` | (deleted) |
 | | `CreateLookupVindex` | (not yet migrated) |
 | | `DeleteShard` | [`DeleteShards`](../../programs/vtctldclient/vtctldclient_deleteshards/) |
 | | `DeleteTablet` | [`DeleteTablets`](../../programs/vtctldclient/vtctldclient_deletetablets/) |


### PR DESCRIPTION
This was the command I used to inspect the concrete differences (there were a few I ignored, which I'll talk about):

<summary> <pre>diff \
  <(vtctldclient --server ":15999" help | \
        tail +6 | \
        grep -v "[A-Z].*:" | \
        grep -v '^$' | \
        grep -v "for more information about a command." | \
        awk '{print $1}' | \
        grep -v '^-' | \
        sort) \
  <(vtctlclient --server ":15999" help | \
        grep -v "[A-Z].*:" | \
        grep -v '^$' | \
        sed 's/(DEPRECATED)//' | \
        awk '{print $1}' | \
        sort)</pre>
<details>

```
5d4
< ApplyShardRoutingRules
10c9,10
< CreateKeyspace
---
> CopySchemaShard
> CreateLookupVindex
15c15
< DeleteShards
---
> DeleteShard
17c17
< DeleteTablets
---
> DeleteTablet
20c20
< ExecuteFetchAsDBA
---
> ExecuteFetchAsDba
21a22
> ExternalizeVindex
24d24
< GetBackups
28d27
< GetFullStatus
35c34,35
< GetShardRoutingRules
---
> GetShardReplication
> GetSrvKeyspace
37d36
< GetSrvKeyspaces
39d37
< GetSrvVSchemas
41,43d38
< GetTabletVersion
< GetTablets
< GetTopologyPath
45c40,41
< GetWorkflows
---
> Help
> InitShardPrimary
47c43,50
< PingTablet
---
> ListAllTablets
> ListBackups
> ListShardTablets
> ListTablets
> Migrate
> Mount
> OnlineDDL
> Ping
62c65,66
< SetKeyspaceDurabilityPolicy
---
> SetReadOnly
> SetReadWrite
65d68
< SetWritable
68c71
< SleepTablet
---
> Sleep
73a77,78
> TopoCat
> TopoCp
75a81,82
> UpdateSrvKeyspacePartition
> UpdateTabletAddrs
76a84
> VReplicationExec
78a87,88
> ValidatePermissionsKeyspace
> ValidatePermissionsShard
79a90
> ValidateSchemaShard
83,84c94,96
< completion
< help
---
> VtctldCommand
> WaitForFilteredReplication
> Workflow
```
</details>
</summary>

- `Help` => `help`: 🤷 
- `completion`: this is a hidden cobra command that generates bash completion for the CLI, so I didn't really bother calling it out.