### PR TITLE
Update the local install guide for `v16.0.1` and `v17`

### DIFF
--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -84,13 +84,13 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 
 **Notes:**
 
-* Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
-* Please use release [15.0.2](https://github.com/vitessio/vitess/releases/tag/v15.0.2) instead.
+* Release 16.0.0 has an issue where the VTAdmin `web` directory is missing from the release artefacts.
+* Please use release [16.0.1](https://github.com/vitessio/vitess/releases/tag/v16.0.1) instead.
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=15.0.2
-file=vitess-${version}-a914f40.tar.gz
+version=16.0.1
+file=vitess-${version}-bb768df.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -62,12 +62,10 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 
 **Notes:**
 
-* Release 15.0 has a bug because of which the local example fails when try to run vtadmin web. [Issue#11679](https://github.com/vitessio/vitess/issues/11679)
-* Please use release [15.0.2](https://github.com/vitessio/vitess/releases/tag/v15.0.2) instead.
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=15.0.2
+version=16.0.1
 file=vitess-${version}-a914f40.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}


### PR DESCRIPTION
This PR is preparing the upcoming `v16.0.1` release and updates the local install guide which were outdated on both v16 and v17.