### PR TITLE
content/en/docs/18.0: clarify meaning of scatter queries

### DIFF
--- a/content/en/docs/18.0/concepts/execution-plans.md
+++ b/content/en/docs/18.0/concepts/execution-plans.md
@@ -12,6 +12,16 @@ An execution plan consists of operators, each of which implements a specific pie
 
 Evaluation of the execution plan begins at the leaf nodes of the tree. Leaf nodes pull in data from VTTablet, the Topology Service, and in some cases are also able to evaluate expression values locally. Each leaf node will not have input from other operators, and pipe in any nodes they produce into their parent nodes. The parents nodes will then pipe in nodes to their parent nodes, all the way up to a root node. The root node produces the final results of the query and delivers the results to the user.
 
+### Routing Operators
+
+A routing operator in an execution plan instructs Vitess which destination to send a piece of work to. Typically a routing operator will tell Vitess which keyspace to use when executing the piece of work, whether or not the keyspace is sharded, and, in the case of sharded keyspaces, which vindex to use.
+
+### Scatter Queries
+
+A routing operator which specifies a sharded keyspace, but which does not specify a vindex, will "scatter" to all shards in a sharded keyspace. A "scatter" query contains one or more pieces of work routed to a sharded keyspace, but which cannot be routed using a vindex.
+
+Note that not all queries which are sent to multiple (or all) shards in a sharded keyspace are considered scatter queries.
+
 ### Observing Execution Plans
 
 Cached execution plans can be observed at the VTGate level by browsing the `/queryz` end point.

--- a/content/en/docs/18.0/reference/features/vindexes.md
+++ b/content/en/docs/18.0/reference/features/vindexes.md
@@ -37,7 +37,7 @@ Vindexes come in many varieties. Some of them can be used as Primary Vindex, and
 
 ### Secondary Vindexes
 
-Secondary Vindexes are additional vindexes against other columns of a table offering optimizations for WHERE clauses that do not use the Primary Vindex. Secondary Vindexes return a single or a limited set of `keyspace IDs` which will allow VTGate to only target shards where the relevant data is present. In the absence of a Secondary Vindex, VTGate would have to send the query to all shards (called a scatter query).
+Secondary Vindexes are additional vindexes against other columns of a table offering optimizations for WHERE clauses that do not use the Primary Vindex. Secondary Vindexes return a single or a limited set of `keyspace IDs` which will allow VTGate to only target shards where the relevant data is present. In the absence of a Secondary Vindex, VTGate would have to scatter the query to all shards.
 
 It is important to note that Secondary Vindexes are only used for making routing decisions. The underlying database shards will most likely need traditional indexes on those same columns, to allow efficient retrieval from the table on the underlying MySQL instances.
 

--- a/content/en/docs/18.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/comment-directives.md
@@ -67,7 +67,7 @@ The `IGNORE_MAX_MEMORY_ROWS` comment directive allows a Vitess-aware application
 
 ## Allow scatter (`ALLOW_SCATTER`)
 
-In Vitess, it is possible to use the `vtgate` parameter `--no_scatter` to prevent `vtgate` from issuing scatter queries. Thus only queries that target a single shard will be allowed.
+In Vitess, it is possible to use the `vtgate` parameter `--no_scatter` to prevent `vtgate` from issuing scatter queries. Thus only queries that do not scatter will be allowed.
 
 This comment directive is used to override that limitation, allowing application code to be customized to allow scatters for certain chosen use-cases, but not for the general case.
 


### PR DESCRIPTION
As far as I can tell, the docs do not offer a clear definition of what constitutes a scatter query, and some parts of the docs are inaccurate in regard to this term.

This PR offers a definition of scatter queries, and cleans up one place that isn't accurate.