### PR TITLE
added connection pooling blog to be not accessible by webcrawlers

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Disallow: /zh/docs/
+Disallow: /blog/2023-03-27-connection-pooling-in-vitess/
 
 SITEMAP: https://vitess.io/sitemap.xml


### PR DESCRIPTION
This PR adds the connection pooling blog to be not accessible by web crawlers to make the PlanetScale blog version canonical.