### PR TITLE
Update the `build-on-*` pages with proper Golang instructions

### DIFF
--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -13,14 +13,17 @@ The following has been verified to work on __CentOS 7__. If you are new to Vites
 
 ## Install Dependencies
 
-### Install Go 1.19+
+### Install Go
 
-[Download and install](http://golang.org/doc/install) Golang 1.19.4. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
 
 ```
-curl -LO https://golang.org/dl/go1.19.4.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz
+curl -LO https://golang.org/dl/go1.20.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.20.2.linux-amd64.tar.gz
 ```
+
+> Vitess is tested and shipped using a specific Golang version for each release.
+> For maximum compatibility we encourage you to use the same Golang version as [the one mentioned in our `build.env` file](https://github.com/vitessio/vitess/blob/d1ba6258ea2462d5d28d67661aace7b79bb7e27b/build.env#L20).
 
 Make sure to add go to your bashrc:
 ```

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -15,7 +15,7 @@ The following has been verified to work on __CentOS 7__. If you are new to Vites
 
 ### Install Go
 
-[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang. For example for `go1.20.2`, at writing:
 
 ```
 curl -LO https://golang.org/dl/go1.20.2.linux-amd64.tar.gz

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -30,11 +30,14 @@ Add `mysql` to your `PATH`:
 echo 'export PATH="/usr/local/opt/mysql/bin:$PATH"' >> ~/.bash_profile
 ```
 
-[Download and install](http://golang.org/doc/install) Golang 1.19.4. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
 ```shell
-curl -LO https://golang.org/dl/go1.19.4.darwin-amd64.pkg
-sudo installer -pkg go1.19.4.darwin-amd64.pkg -target /
+curl -LO https://golang.org/dl/go1.20.2.darwin-amd64.pkg
+sudo installer -pkg go1.20.2.darwin-amd64.pkg -target /
 ```
+
+> Vitess is tested and shipped using a specific Golang version for each release.
+> For maximum compatibility we encourage you to use the same Golang version as [the one mentioned in our `build.env` file](https://github.com/vitessio/vitess/blob/d1ba6258ea2462d5d28d67661aace7b79bb7e27b/build.env#L20).
 
 Do not install etcd via brew otherwise it will not be the version that is supported. Let it be installed when running make build.
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -30,7 +30,7 @@ Add `mysql` to your `PATH`:
 echo 'export PATH="/usr/local/opt/mysql/bin:$PATH"' >> ~/.bash_profile
 ```
 
-[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang. For example for `go1.20.2`, at writing:
 ```shell
 curl -LO https://golang.org/dl/go1.20.2.darwin-amd64.pkg
 sudo installer -pkg go1.20.2.darwin-amd64.pkg -target /

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -13,14 +13,17 @@ The following has been verified to work on __Ubuntu 19.10__ and __Debian 10__. I
 
 ## Install Dependencies
 
-### Install Go 1.19+
+### Install Go
 
-[Download and install](http://golang.org/doc/install) Golang 1.19. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
 
 ```
-curl -LO https://dl.google.com/go/go1.19.4.linux-amd64.tar.gz
-sudo tar -C /usr/local -xzf go1.19.4.linux-amd64.tar.gz
+curl -LO https://dl.google.com/go/go1.20.2.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.20.2.linux-amd64.tar.gz
 ```
+
+> Vitess is tested and shipped using a specific Golang version for each release.
+> For maximum compatibility we encourage you to use the same Golang version as [the one mentioned in our `build.env` file](https://github.com/vitessio/vitess/blob/d1ba6258ea2462d5d28d67661aace7b79bb7e27b/build.env#L20).
 
 Make sure to add go to your bashrc:
 ```

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -15,7 +15,7 @@ The following has been verified to work on __Ubuntu 19.10__ and __Debian 10__. I
 
 ### Install Go
 
-[Download and install](http://golang.org/doc/install) Golang 1.20. For example, at writing:
+[Download and install](http://golang.org/doc/install) Golang. For example for `go1.20.2`, at writing:
 
 ```
 curl -LO https://dl.google.com/go/go1.20.2.linux-amd64.tar.gz


### PR DESCRIPTION
This PR changes the `Install Dependencies` our of `build-on-*` pages. They were mentioning an old Golang version which is no longer compatible with `main` and `v16.0.*`. Instead, I changed the doc to be more dynamic and include a note saying it is best to build vitess using the recommended golang version.