### PR TITLE
[v17] Update from create-react-app to vite

### DIFF
--- a/content/en/docs/17.0/get-started/local-brew.md
+++ b/content/en/docs/17.0/get-started/local-brew.md
@@ -139,34 +139,38 @@ vtadmin-api is running!
 
 
 > vtadmin@0.1.0 build
-> react-scripts build
+> vite build
 
-Creating an optimized production build...
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Compiled successfully.
+vite v4.2.1 building for production...
+transforming (1218) src/icons/alertFail.svgUse of eval in "node_modules/@protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause issues with minification.
+✓ 1231 modules transformed.
+build/assets/chevronUp-3d6782a5.svg              0.18 kB
+build/assets/chevronDown-02f94e73.svg            0.19 kB
+build/assets/download-8ef290b4.svg               0.21 kB
+build/assets/delete-a9184ef9.svg                 0.23 kB
+build/assets/info-2617ee9d.svg                   0.34 kB
+build/assets/circleAdd-cfd7e5db.svg              0.35 kB
+build/assets/alertFail-8056b6e4.svg              0.35 kB
+build/assets/checkSuccess-f8fd1dbb.svg           0.36 kB
+build/assets/search-3261bac7.svg                 0.41 kB
+build/assets/question-a67b2492.svg               0.46 kB
+build/assets/runQuery-edfab4ed.svg               0.49 kB
+build/assets/open-405dd348.svg                   0.49 kB
+build/index.html                                 0.90 kB
+build/assets/bug-5b6edb54.svg                    0.99 kB
+build/assets/topology-0032b65e.svg               1.62 kB
+build/assets/NotoMono-Regular-41fd7ccc.ttf     107.85 kB
+build/assets/NotoSans-Regular-c8cff31f.ttf     313.14 kB
+build/assets/NotoSans-SemiBold-43207822.ttf    313.72 kB
+build/assets/NotoSans-Bold-c6a598dd.ttf        313.79 kB
+build/assets/index-ef40fbc9.css                 87.78 kB │ gzip:  15.02 kB
+build/assets/index-4ddb52ed.js               2,811.88 kB │ gzip: 492.59 kB
 
-File sizes after gzip:
-
-  385.49 kB  build/static/js/main.044e444c.js
-  15.4 kB    build/static/css/main.a46ccb6f.css
-
-The project was built assuming it is hosted at /.
-You can control this with the homepage field in your package.json.
-
-The build folder is ready to be deployed.
-You may serve it with a static server:
-
-  npm install -g serve
-  serve -s build
-
-Find out more about deployment here:
-
-  https://cra.link/deployment
+(!) Some chunks are larger than 500 kBs after minification. Consider:
+- Using dynamic import() to code-split the application
+- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
+- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+✓ built in 10.85s
 
 vtadmin-web is running!
   - Browser: http://localhost:14201

--- a/content/en/docs/17.0/get-started/local-mac.md
+++ b/content/en/docs/17.0/get-started/local-mac.md
@@ -205,34 +205,38 @@ vtadmin-api is running!
 
 
 > vtadmin@0.1.0 build
-> react-scripts build
+> vite build
 
-Creating an optimized production build...
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Compiled successfully.
+vite v4.2.1 building for production...
+transforming (1218) src/icons/alertFail.svgUse of eval in "node_modules/@protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause issues with minification.
+✓ 1231 modules transformed.
+build/assets/chevronUp-3d6782a5.svg              0.18 kB
+build/assets/chevronDown-02f94e73.svg            0.19 kB
+build/assets/download-8ef290b4.svg               0.21 kB
+build/assets/delete-a9184ef9.svg                 0.23 kB
+build/assets/info-2617ee9d.svg                   0.34 kB
+build/assets/circleAdd-cfd7e5db.svg              0.35 kB
+build/assets/alertFail-8056b6e4.svg              0.35 kB
+build/assets/checkSuccess-f8fd1dbb.svg           0.36 kB
+build/assets/search-3261bac7.svg                 0.41 kB
+build/assets/question-a67b2492.svg               0.46 kB
+build/assets/runQuery-edfab4ed.svg               0.49 kB
+build/assets/open-405dd348.svg                   0.49 kB
+build/index.html                                 0.90 kB
+build/assets/bug-5b6edb54.svg                    0.99 kB
+build/assets/topology-0032b65e.svg               1.62 kB
+build/assets/NotoMono-Regular-41fd7ccc.ttf     107.85 kB
+build/assets/NotoSans-Regular-c8cff31f.ttf     313.14 kB
+build/assets/NotoSans-SemiBold-43207822.ttf    313.72 kB
+build/assets/NotoSans-Bold-c6a598dd.ttf        313.79 kB
+build/assets/index-ef40fbc9.css                 87.78 kB │ gzip:  15.02 kB
+build/assets/index-4ddb52ed.js               2,811.88 kB │ gzip: 492.59 kB
 
-File sizes after gzip:
-
-  385.49 kB  build/static/js/main.044e444c.js
-  15.4 kB    build/static/css/main.a46ccb6f.css
-
-The project was built assuming it is hosted at /.
-You can control this with the homepage field in your package.json.
-
-The build folder is ready to be deployed.
-You may serve it with a static server:
-
-  npm install -g serve
-  serve -s build
-
-Find out more about deployment here:
-
-  https://cra.link/deployment
+(!) Some chunks are larger than 500 kBs after minification. Consider:
+- Using dynamic import() to code-split the application
+- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
+- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+✓ built in 10.85s
 
 vtadmin-web is running!
   - Browser: http://localhost:14201

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -193,37 +193,40 @@ Downloading and installing node v16.19.1...
 Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
 Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
 Now using node v16.19.1 (npm v8.19.3)
-Now using node v16.19.1 (npm v8.19.3)
 
 > vtadmin@0.1.0 build
-> react-scripts build
+> vite build
 
-Creating an optimized production build...
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Browserslist: caniuse-lite is outdated. Please run:
-  npx browserslist@latest --update-db
-  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
-Compiled successfully.
+vite v4.2.1 building for production...
+transforming (1218) src/icons/alertFail.svgUse of eval in "node_modules/@protobufjs/inquire/index.js" is strongly discouraged as it poses security risks and may cause issues with minification.
+✓ 1231 modules transformed.
+build/assets/chevronUp-3d6782a5.svg              0.18 kB
+build/assets/chevronDown-02f94e73.svg            0.19 kB
+build/assets/download-8ef290b4.svg               0.21 kB
+build/assets/delete-a9184ef9.svg                 0.23 kB
+build/assets/info-2617ee9d.svg                   0.34 kB
+build/assets/circleAdd-cfd7e5db.svg              0.35 kB
+build/assets/alertFail-8056b6e4.svg              0.35 kB
+build/assets/checkSuccess-f8fd1dbb.svg           0.36 kB
+build/assets/search-3261bac7.svg                 0.41 kB
+build/assets/question-a67b2492.svg               0.46 kB
+build/assets/runQuery-edfab4ed.svg               0.49 kB
+build/assets/open-405dd348.svg                   0.49 kB
+build/index.html                                 0.90 kB
+build/assets/bug-5b6edb54.svg                    0.99 kB
+build/assets/topology-0032b65e.svg               1.62 kB
+build/assets/NotoMono-Regular-41fd7ccc.ttf     107.85 kB
+build/assets/NotoSans-Regular-c8cff31f.ttf     313.14 kB
+build/assets/NotoSans-SemiBold-43207822.ttf    313.72 kB
+build/assets/NotoSans-Bold-c6a598dd.ttf        313.79 kB
+build/assets/index-ef40fbc9.css                 87.78 kB │ gzip:  15.02 kB
+build/assets/index-4ddb52ed.js               2,811.88 kB │ gzip: 492.59 kB
 
-File sizes after gzip:
-
-  385.49 kB  build/static/js/main.044e444c.js
-  15.4 kB    build/static/css/main.a46ccb6f.css
-
-The project was built assuming it is hosted at /.
-You can control this with the homepage field in your package.json.
-
-The build folder is ready to be deployed.
-You may serve it with a static server:
-
-  npm install -g serve
-  serve -s build
-
-Find out more about deployment here:
-
-  https://cra.link/deployment
+(!) Some chunks are larger than 500 kBs after minification. Consider:
+- Using dynamic import() to code-split the application
+- Use build.rollupOptions.output.manualChunks to improve chunking: https://rollupjs.org/configuration-options/#output-manualchunks
+- Adjust chunk size limit for this warning via build.chunkSizeWarningLimit.
+✓ built in 10.85s
 
 vtadmin-web is running!
   - Browser: http://localhost:14201

--- a/content/en/docs/17.0/reference/programs/vtadmin-web.md
+++ b/content/en/docs/17.0/reference/programs/vtadmin-web.md
@@ -4,34 +4,33 @@ title: vtadmin-web
 
 ## Environment Variables
 
-These environment variables configure VTAdmin, most commonly when creating a `vtadmin-web` production build as described in the [VTAdmin Operator's Guide][operators_guide]. These environment variables also enumerated in [web/vtadmin/src/react-app-env.d.ts][vtadmin_env_ref].
+These environment variables configure VTAdmin, most commonly when creating a `vtadmin-web` production build as described in the [VTAdmin Operator's Guide][operators_guide]. These environment variables also enumerated in [web/vtadmin/vite-env.d.ts][vtadmin_env_ref].
 
-Under the hood, `vtadmin-web` uses [create-react-app][cra], which requires all environment variables to be prefixed with `REACT_APP` to avoid accidentally including secrets in the static build. For more on custom environment variables with create-react-app, see ["Adding Custom Environment Variables"][cra_env_ref].
+Under the hood, `vtadmin-web` uses [vite][vite], which requires all environment variables to be prefixed with `VITE` to avoid accidentally including secrets in the static build. For more on custom environment variables with vite, see ["Env Variables and Modes"][vite_env_ref].
 
-These environment variables can be passed inline to the `npm run build` command or [added to a .env file][cra_env_file_ref].
+These environment variables can be passed inline to the `npm run build` command or [added to a .env file][vite_env_file_ref].
 
 
 | Name | Required | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |--------- |
-| `REACT_APP_VTADMIN_API_ADDRESS` | **Required** | string | - | The full address of vtadmin-api's HTTP(S) interface. Example: "https://vtadmin.example.com:12345" | 
-| `REACT_APP_BUGSNAG_API_KEY` | Optional | string | - | An API key for https://bugsnag.com. If defined, the @bugsnag/js client will be initialized. Your Bugsnag API key can be found in your Bugsnag Project Settings. | 
-| `REACT_APP_BUILD_BRANCH` | Optional | string | - | The branch vtadmin-web was built with. Used only for debugging; will appear on the (secret) /settings route in the UI. |
-| `REACT_APP_BUILD_SHA` | Optional | string | - | The SHA vtadmin-web was built with. Used only for debugging; will appear on the (secret) /settings route in the UI. |
-| `REACT_APP_DOCUMENT_TITLE` | Optional | string | "VTAdmin" | Used for the document.title property. Overriding this can be useful to differentiate between multiple VTAdmin deployments, e.g., "VTAdmin (staging)". |
-| `REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS` | Optional | string | - | Optional, but recommended. When `"true"`, enables front-end components that query vtadmin-api's /api/experimental/tablet/{tablet}/debug/vars endpoint. | 
-| `REACT_APP_FETCH_CREDENTIALS` | Optional | string | - | Configures the `credentials` property for fetch requests  made against vtadmin-api. If unspecified, uses fetch defaults. See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included |
-| `REACT_APP_READONLY_MODE` | Optional | string | "false" | If "true", UI controls that correspond to write actions (PUT, POST, DELETE) will be hidden. Note that this *only* affects the UI. If write actions are a concern, Vitess operators are encouraged to also [configure vtadmin-api for role-based access control (RBAC)][rbac] if needed. | 
+| `VITE_VTADMIN_API_ADDRESS` | **Required** | string | - | The full address of vtadmin-api's HTTP(S) interface. Example: "https://vtadmin.example.com:12345" | 
+| `VITE_BUGSNAG_API_KEY` | Optional | string | - | An API key for https://bugsnag.com. If defined, the @bugsnag/js client will be initialized. Your Bugsnag API key can be found in your Bugsnag Project Settings. | 
+| `VITE_BUILD_BRANCH` | Optional | string | - | The branch vtadmin-web was built with. Used only for debugging; will appear on the (secret) /settings route in the UI. |
+| `VITE_BUILD_SHA` | Optional | string | - | The SHA vtadmin-web was built with. Used only for debugging; will appear on the (secret) /settings route in the UI. |
+| `VITE_DOCUMENT_TITLE` | Optional | string | "VTAdmin" | Used for the document.title property. Overriding this can be useful to differentiate between multiple VTAdmin deployments, e.g., "VTAdmin (staging)". |
+| `VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS` | Optional | string | - | Optional, but recommended. When `"true"`, enables front-end components that query vtadmin-api's /api/experimental/tablet/{tablet}/debug/vars endpoint. | 
+| `VITE_FETCH_CREDENTIALS` | Optional | string | - | Configures the `credentials` property for fetch requests  made against vtadmin-api. If unspecified, uses fetch defaults. See https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#sending_a_request_with_credentials_included |
+| `VITE_READONLY_MODE` | Optional | string | "false" | If "true", UI controls that correspond to write actions (PUT, POST, DELETE) will be hidden. Note that this *only* affects the UI. If write actions are a concern, Vitess operators are encouraged to also [configure vtadmin-api for role-based access control (RBAC)][rbac] if needed. | 
 
-[cra]: https://create-react-app.dev/
-[cra_env_ref]: https://create-react-app.dev/docs/adding-custom-environment-variables/
-[cra_env_file_ref]: https://create-react-app.dev/docs/adding-custom-environment-variables/#adding-development-environment-variables-in-env
+[vite]: https://vitejs.dev/
+[vite_env_ref]: https://vitejs.dev/guide/env-and-mode.html
+[vite_env_file_ref]: https://vitejs.dev/guide/env-and-mode.html#env-files#adding-development-environment-variables-in-env
 [operators_guide]: ../../vtadmin/operators_guide
 [rbac]: ../../vtadmin/role-based-access-control
-[vtadmin_env_ref]: https://github.com/vitessio/vitess/blob/main/web/vtadmin/src/react-app-env.d.ts
+[vtadmin_env_ref]: https://github.com/vitessio/vitess/blob/main/web/vtadmin/vite-env.d.ts
 
-These environment variables are automatically [filled in by create-react-app](https://create-react-app.dev/docs/adding-custom-environment-variables/#:~:text=By%20default%20you%20will%20have,by%20inspecting%20your%20app's%20files.) and you do not have to provide them. They are available in the `process.env` object at run time, and listed here for full coverage of environment variables:
+These environment variables are automatically [filled in by vite](https://vitejs.dev/guide/env-and-mode.html#env-variables) and you do not have to provide them. They are available in the `import.meta.env` object at run time, and listed here for full coverage of environment variables:
 
 | Name | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |
-| `NODE_ENV` | string | "production", "staging", or "test" | The current node environment set by create-react-app | 
-| `PUBLIC_URL` | string | - | The path to the `public` folder within the build files |
+| `MODE` | string | "production", "staging", or "development" | The current mode in which vite is running | 

--- a/content/en/docs/17.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/17.0/reference/vtadmin/operators_guide.md
@@ -59,13 +59,13 @@ To optionally configure role-based access control (RBAC), refer to the [RBAC doc
 
 Environment variables can be defined in a `.env` file or passed inline to the `npm run build` command. The full list of flags is given in the [`vtadmin-web` reference documentation][vtadmin_web_env_ref].
 
-The following is from the [local example][local_example] showing a minimal set of environment variables. `$web_dir`, in this case, refers to the [`vtadmin-web` source directory][vtadmin_web_src] but could equally apply to the `web/vtadmin/` directory copied into a Docker container, for example. `REACT_APP_VTADMIN_API_ADDRESS` uses the same hostname as the `--addr` flag passed to `vtadmin` in the previous step. 
+The following is from the [local example][local_example] showing a minimal set of environment variables. `$web_dir`, in this case, refers to the [`vtadmin-web` source directory][vtadmin_web_src] but could equally apply to the `web/vtadmin/` directory copied into a Docker container, for example. `VITE_VTADMIN_API_ADDRESS` uses the same hostname as the `--addr` flag passed to `vtadmin` in the previous step. 
 
 ```
 npm --prefix $web_dir --silent install
 
-REACT_APP_VTADMIN_API_ADDRESS="https://vtadmin-api.example.com:14200" \
-  REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
+VITE_VTADMIN_API_ADDRESS="https://vtadmin-api.example.com:14200" \
+  VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS="true" \
   npm run --prefix $web_dir build
 ```
 
@@ -74,16 +74,16 @@ For example:
 
 ```javascript
 window.env = {
-    'REACT_APP_VTADMIN_API_ADDRESS': "https://vtadmin-api.example.com:14200",
-    'REACT_APP_FETCH_CREDENTIALS': "omit",
-    'REACT_APP_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS': true,
-    'REACT_APP_BUGSNAG_API_KEY': "",
-    'REACT_APP_DOCUMENT_TITLE': "",
-    'REACT_APP_READONLY_MODE': false,
+    'VITE_VTADMIN_API_ADDRESS': "https://vtadmin-api.example.com:14200",
+    'VITE_FETCH_CREDENTIALS': "omit",
+    'VITE_ENABLE_EXPERIMENTAL_TABLET_DEBUG_VARS': true,
+    'VITE_BUGSNAG_API_KEY': "",
+    'VITE_DOCUMENT_TITLE': "",
+    'VITE_READONLY_MODE': false,
 };
 ```
 
-After running `build` command, the production build of the front-end assets will be in the `$web_dir/build` directory. They can be served as any other static content; for example, [Go's embed package][go_embed] or npm's [serve package][npm_serve]. Each filename inside of `$web_dir/build/static` will contain a unique hash of the file contents. This hash in the file name enables [long term caching techniques][web_caching].
+After running `build` command, the production build of the front-end assets will be in the `$web_dir/build` directory. They can be served as any other static content; for example, [Go's embed package][go_embed] or npm's [serve package][npm_serve]. Each filename inside of `$web_dir/build/assets` will contain a unique hash of the file contents.
 
 [discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/local/vtadmin/discovery.json
 [go_embed]:https://pkg.go.dev/embed


### PR DESCRIPTION
This PR updates the v17 docs to reflect our VTAdmin migration from create-react-app to vite. Most of this is: 
- changing `REACT_APP_*` vars to `VITE_*` vars
- reflecting the change to `build` folder (from `build/static` to `build/assets`
- changing the scripts output to include `vite` logs
- updating links/references from create-react-app to their vite counterparts

**Notes**
We should merge this after https://github.com/vitessio/vitess/pull/12831 is merged.