### PR TITLE
update help text for schema_change_check_interval to match what it was at each version

### DIFF
--- a/content/en/docs/15.0/reference/programs/vtctld.md
+++ b/content/en/docs/15.0/reference/programs/vtctld.md
@@ -179,7 +179,7 @@ vtctld \
 | --s3_backup_storage_bucket | string | S3 bucket to use for backups |
 | --s3_backup_storage_root | string | root prefix for all backup-related object names |
 | --s3_backup_tls_skip_verify_cert | boolean | skip the 'certificate is valid' check for SSL connections |
-| --schema_change_check_interval | int | this value decides how often we check schema change dir, in seconds (default 60) |
+| --schema_change_check_interval | duration | How often the schema change dir is checked for schema changes (deprecated: if passed as a bare integer, the duration will be in seconds). |
 | --schema_change_controller | string | schema change controller is responsible for finding schema changes and responding to schema change events |
 | --schema_change_dir | string | directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change |
 | --schema_change_replicas_timeout | duration | how long to wait for replicas to receive the schema change (default 10s) |

--- a/content/en/docs/16.0/reference/programs/vtctld.md
+++ b/content/en/docs/16.0/reference/programs/vtctld.md
@@ -121,7 +121,7 @@ vtctld \
 | --s3_backup_storage_bucket | string | S3 bucket to use for backups |
 | --s3_backup_storage_root | string | root prefix for all backup-related object names |
 | --s3_backup_tls_skip_verify_cert | boolean | skip the 'certificate is valid' check for SSL connections |
-| --schema_change_check_interval | int | this value decides how often we check schema change dir, in seconds (default 60) |
+| --schema_change_check_interval | duration | How often the schema change dir is checked for schema changes (deprecated: if passed as a bare integer, the duration will be in seconds). |
 | --schema_change_controller | string | schema change controller is responsible for finding schema changes and responding to schema change events |
 | --schema_change_dir | string | directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change |
 | --schema_change_replicas_timeout | duration | how long to wait for replicas to receive the schema change (default 10s) |

--- a/content/en/docs/17.0/reference/programs/vtctld.md
+++ b/content/en/docs/17.0/reference/programs/vtctld.md
@@ -124,7 +124,7 @@ vtctld \
 | --s3_backup_storage_bucket | string | S3 bucket to use for backups |
 | --s3_backup_storage_root | string | root prefix for all backup-related object names |
 | --s3_backup_tls_skip_verify_cert | boolean | skip the 'certificate is valid' check for SSL connections |
-| --schema_change_check_interval | int | this value decides how often we check schema change dir, in seconds (default 60) |
+| --schema_change_check_interval | duration | How often the schema change dir is checked for schema changes. This value must be positive; if zero or lower, the default of 1m is used. |
 | --schema_change_controller | string | schema change controller is responsible for finding schema changes and responding to schema change events |
 | --schema_change_dir | string | directory contains schema changes for all keyspaces. Each keyspace has its own directory and schema changes are expected to live in '$KEYSPACE/input' dir. e.g. test_keyspace/input/*sql, each sql file represents a schema change |
 | --schema_change_replicas_timeout | duration | how long to wait for replicas to receive the schema change (default 10s) |


### PR DESCRIPTION
looks like this got missed in 15.0, so it's been getting incorrectly copied since.

so, i went and back-fixed it

see https://github.com/vitessio/vitess/pull/12860