### PR TITLE
Update partial MoveTables vtgate flag name after v15 flag work

### DIFF
--- a/content/en/docs/15.0/reference/programs/vtgate.md
+++ b/content/en/docs/15.0/reference/programs/vtgate.md
@@ -54,7 +54,7 @@ The following global options apply to `vtgate`:
 | --emit_stats | boolean | true iff we should emit stats to push-based monitoring/stats backends |
 | --enable_buffer | boolean | Enable buffering (stalling) of primary traffic during failovers. |
 | --enable_buffer_dry_run | boolean | Detect and log failover events, but do not actually buffer requests. |
-| --enable_partial_keyspace_migration | boolean | (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See the documentation on [shard level migrations](../../vreplication/shardlevelmigrations/) for more information. (default false) |
+| --enable-partial-keyspace-migration | boolean | (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See the documentation on [shard level migrations](../../vreplication/shardlevelmigrations/) for more information. (default false) |
 | --enable_system_settings | boolean | Enables the system settings to be changed per session at the database connection level. Override with @@enable_system_settings session variable. |
 | --enable_set_var | boolean | This will enable the use of MySQL's SET_VAR query hint for certain system variables instead of using reserved connections. |
 | --gate_query_cache_size | int | gate server query cache size, maximum number of queries to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 10000) |

--- a/content/en/docs/15.0/reference/vreplication/shardlevelmigrations.md
+++ b/content/en/docs/15.0/reference/vreplication/shardlevelmigrations.md
@@ -31,7 +31,7 @@ number of primaries that need to be synced when writes are switched.
 Supporting shard level migrations allows you to move very large keyspaces from one Vitess cluster 
 to another in an incremental way, cutting over traffic and reverting as needed 
 on a per-shard basis. When using this method, there is also a 
-new [`vtgate`](../../programs/vtgate/) `--enable_partial_keyspace_migration` 
+new [`vtgate`](../../programs/vtgate/) `--enable-partial-keyspace-migration` 
 flag that enables support for shard level query routing so that individual 
 shards can be routed to one side of the migration or the other during the 
 migration period — *including when shard targeting is used*.
@@ -69,7 +69,7 @@ to switch *read and write traffic* all at once for the shard(s)
 ## Related Vitess Flags
 
 In order to support the shard level query routing during the migration, 
-the `--enable_partial_keyspace_migration` flag must be set for all of the 
+the `--enable-partial-keyspace-migration` flag must be set for all of the 
 [`vtgate`](../../programs/vtgate/) instances in the target Vitess cluster.
 
 {{< warning >}}

--- a/content/en/docs/16.0/reference/vreplication/shardlevelmigrations.md
+++ b/content/en/docs/16.0/reference/vreplication/shardlevelmigrations.md
@@ -31,7 +31,7 @@ number of primaries that need to be synced when writes are switched.
 Supporting shard level migrations allows you to move very large keyspaces from one Vitess cluster 
 to another in an incremental way, cutting over traffic and reverting as needed 
 on a per-shard basis. When using this method, there is also a 
-new [`vtgate`](../../programs/vtgate/) `--enable_partial_keyspace_migration` 
+new [`vtgate`](../../programs/vtgate/) `--enable-partial-keyspace-migration` 
 flag that enables support for shard level query routing so that individual 
 shards can be routed to one side of the migration or the other during the 
 migration period — *including when shard targeting is used*.
@@ -69,7 +69,7 @@ to switch *read and write traffic* all at once for the shard(s)
 ## Related Vitess Flags
 
 In order to support the shard level query routing during the migration, 
-the `--enable_partial_keyspace_migration` flag must be set for all of the 
+the `--enable-partial-keyspace-migration` flag must be set for all of the 
 [`vtgate`](../../programs/vtgate/) instances in the target Vitess cluster.
 
 {{< warning >}}

--- a/content/en/docs/17.0/reference/vreplication/shardlevelmigrations.md
+++ b/content/en/docs/17.0/reference/vreplication/shardlevelmigrations.md
@@ -31,7 +31,7 @@ number of primaries that need to be synced when writes are switched.
 Supporting shard level migrations allows you to move very large keyspaces from one Vitess cluster 
 to another in an incremental way, cutting over traffic and reverting as needed 
 on a per-shard basis. When using this method, there is also a 
-new [`vtgate`](../../programs/vtgate/) `--enable_partial_keyspace_migration` 
+new [`vtgate`](../../programs/vtgate/) `--enable-partial-keyspace-migration` 
 flag that enables support for shard level query routing so that individual 
 shards can be routed to one side of the migration or the other during the 
 migration period — *including when shard targeting is used*.
@@ -69,7 +69,7 @@ to switch *read and write traffic* all at once for the shard(s)
 ## Related Vitess Flags
 
 In order to support the shard level query routing during the migration, 
-the `--enable_partial_keyspace_migration` flag must be set for all of the 
+the `--enable-partial-keyspace-migration` flag must be set for all of the 
 [`vtgate`](../../programs/vtgate/) instances in the target Vitess cluster.
 
 {{< warning >}}


### PR DESCRIPTION
The underscore based name was replaced with a dash based one but the docs were not updated.