### PR TITLE
content/en/docs/17.0: allow ref tables to specify unqualified sources

### DIFF
--- a/content/en/docs/17.0/user-guides/vschema-guide/advanced-vschema.md
+++ b/content/en/docs/17.0/user-guides/vschema-guide/advanced-vschema.md
@@ -46,7 +46,7 @@ A reference table should not have any vindex, and is defined in the VSchema as a
 
 #### Source Tables
 
-Vitess will optimize reference tables routing when joined to a table within the same keyspace. Additional routing optimizations can be enabled by specifying the `source` of a reference table. When a reference table specifies a `source` table:
+Vitess will optimize reference table routing when joined to a table within the same keyspace. Additional routing optimizations can be enabled by specifying the `source` of a reference table. When a reference table specifies a `source` table:
 
  * A `SELECT ... JOIN` (or equivalent `SELECT ... WHERE`) will try to route the
    query to the keyspace of the table to which the reference (or source) table
@@ -70,7 +70,6 @@ For example:
 
 There are some constraints on `source`:
 
- * It must be a keyspace-qualified table name, e.g. `unsharded_ks.zip_detail`.
  * It must refer to an existing table in an existing keyspace.
  * It must refer to a table in a different keyspace.
  * It must refer to a table in an unsharded keyspace.


### PR DESCRIPTION
Accompanies vitessio/vitess#13030.

RFC vitessio/vitess#11864 aims to support unqualified sources for reference tables. When vitessio/vitess#11875 introduced support for reference table `source`, it intentionally did not allow unqualified sources for the sake of keeping the PR smaller and simpler. vitessio/vitess#13030 enables support for unqualified sources for reference tables.