### PR TITLE
[VTAdmin] Update node version to 18.16.0

### DIFF
--- a/content/en/docs/17.0/get-started/local-brew.md
+++ b/content/en/docs/17.0/get-started/local-brew.md
@@ -37,12 +37,12 @@ Already downloaded: /Users/askdba/Library/Caches/Homebrew/downloads/45991b27589a
 ```
 At this point Vitess binaries installed under default Homebrew install location at /usr/local/share/vitess.
 
-### Install Node 18.16.0+ (required to run VTAdmin)
+### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 18.16.0
-$ nvm use 18.16.0
+$ nvm install --lts 16.13.0
+$ nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -136,15 +136,6 @@ vtadmin-api is running!
   - API: http://localhost:14200
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
-
-Installing nvm...
-
-nvm is already installed!
-
-Configuring Node.js 18.16.0
-
-v18.16.0 is already installed.
-Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/17.0/get-started/local-brew.md
+++ b/content/en/docs/17.0/get-started/local-brew.md
@@ -37,12 +37,12 @@ Already downloaded: /Users/askdba/Library/Caches/Homebrew/downloads/45991b27589a
 ```
 At this point Vitess binaries installed under default Homebrew install location at /usr/local/share/vitess.
 
-### Install Node 16.13.0+ (required to run VTAdmin)
+### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+$ nvm install --lts 18.16.0
+$ nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -137,6 +137,14 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is already installed!
+
+Configuring Node.js 18.16.0
+
+v18.16.0 is already installed.
+Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/17.0/get-started/local-mac.md
+++ b/content/en/docs/17.0/get-started/local-mac.md
@@ -32,12 +32,12 @@ When MySQL installs with brew it will startup, you will want to shut this proces
 $ brew services stop mysql
 ```
 
-### Install Node 16.13.0+ (required to run VTAdmin)
+### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+$ nvm install --lts 18.16.0
+$ nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -203,6 +203,14 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is already installed!
+
+Configuring Node.js 18.16.0
+
+v18.16.0 is already installed.
+Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/17.0/get-started/local-mac.md
+++ b/content/en/docs/17.0/get-started/local-mac.md
@@ -32,12 +32,12 @@ When MySQL installs with brew it will startup, you will want to shut this proces
 $ brew services stop mysql
 ```
 
-### Install Node 18.16.0+ (required to run VTAdmin)
+### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 18.16.0
-$ nvm use 18.16.0
+$ nvm install --lts 16.13.0
+$ nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -202,15 +202,6 @@ vtadmin-api is running!
   - API: http://localhost:14200
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
-
-Installing nvm...
-
-nvm is already installed!
-
-Configuring Node.js 18.16.0
-
-v18.16.0 is already installed.
-Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/18.0/get-started/local-brew.md
+++ b/content/en/docs/18.0/get-started/local-brew.md
@@ -37,12 +37,12 @@ Already downloaded: /Users/askdba/Library/Caches/Homebrew/downloads/45991b27589a
 ```
 At this point Vitess binaries installed under default Homebrew install location at /usr/local/share/vitess.
 
-### Install Node 16.13.0+ (required to run VTAdmin)
+### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+$ nvm install --lts 18.16.0
+$ nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -137,6 +137,14 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is already installed!
+
+Configuring Node.js 18.16.0
+
+v18.16.0 is already installed.
+Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/18.0/get-started/local-mac.md
+++ b/content/en/docs/18.0/get-started/local-mac.md
@@ -209,7 +209,9 @@ nvm is already installed!
 
 Configuring Node.js 18.16.0
 
-v18.16.0 is already installed.
+Downloading and installing node v18.16.0...
+Local cache found: ${NVM_DIR}/.cache/bin/node-v18.16.0-darwin-x64/node-v18.16.0-darwin-x64.tar.xz
+Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v18.16.0-darwin-x64/node-v18.16.0-darwin-x64.tar.xz
 Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build

--- a/content/en/docs/18.0/get-started/local-mac.md
+++ b/content/en/docs/18.0/get-started/local-mac.md
@@ -32,12 +32,12 @@ When MySQL installs with brew it will startup, you will want to shut this proces
 $ brew services stop mysql
 ```
 
-### Install Node 16.13.0+ (required to run VTAdmin)
+### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
 $ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+$ nvm install --lts 18.16.0
+$ nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -203,6 +203,14 @@ vtadmin-api is running!
   - Logs: /Users/manangupta/vitess/vtdataroot/tmp/vtadmin-api.out
   - PID: 74039
 
+Installing nvm...
+
+nvm is already installed!
+
+Configuring Node.js 18.16.0
+
+v18.16.0 is already installed.
+Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build

--- a/content/en/docs/18.0/get-started/local.md
+++ b/content/en/docs/18.0/get-started/local.md
@@ -189,7 +189,9 @@ nvm is already installed!
 
 Configuring Node.js 18.16.0
 
-v18.16.0 is already installed.
+Downloading and installing node v18.16.0...
+Local cache found: ${NVM_DIR}/.cache/bin/node-v18.16.0-darwin-x64/node-v18.16.0-darwin-x64.tar.xz
+Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v18.16.0-darwin-x64/node-v18.16.0-darwin-x64.tar.xz
 Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build

--- a/content/en/docs/18.0/get-started/local.md
+++ b/content/en/docs/18.0/get-started/local.md
@@ -185,14 +185,12 @@ vtadmin-api is running!
 
 Installing nvm...
 
-nvm is installed!
+nvm is already installed!
 
-Configuring Node.js 16
+Configuring Node.js 18.16.0
 
-Downloading and installing node v16.19.1...
-Local cache found: ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
-Checksums match! Using existing downloaded archive ${NVM_DIR}/.cache/bin/node-v16.19.1-darwin-x64/node-v16.19.1-darwin-x64.tar.xz
-Now using node v16.19.1 (npm v8.19.3)
+v18.16.0 is already installed.
+Now using node v18.16.0 (npm v9.5.1)
 
 > vtadmin@0.1.0 build
 > vite build


### PR DESCRIPTION
This PR updates the referenced node versions for VTAdmin to 18.16.0 following [this PR](https://github.com/vitessio/vitess/pull/13288). It also adds the `nvm` script example to local-brew.md and local-mac.md.