### PR TITLE
Docs: UpdateThrottlerConfig new --throttle-app* flags

### DIFF
--- a/content/en/docs/17.0/reference/features/tablet-throttler.md
+++ b/content/en/docs/17.0/reference/features/tablet-throttler.md
@@ -102,6 +102,12 @@ It is possible to _restrict_ the throttler's response to one or more apps. For e
 
 It is _not possible_ to give an app more way than the throttler's standard behavior. That is, if the throttler is set to throttler at `5s` replication lag, it is _not possible_ to respond wih `HTTP 200` to a specific app with replication lag at `7s`.
 
+Vitess has a granular breakdown for its own throttler apps. Generally, the user should not change throttling configuration for internal apps. However, some of the apps are user-facing or user-initiated, and it makes sense for the user to restrict them. These apps include:
+
+- `online-ddl`: affecting all schema migrations of all strategies.
+- `vreplication`: all VReplication operations, for example: MoveTables, Reshard, Online DDL via `vitess/online` strategy.
+- `vplayer`: the VPlayer component of VReplication, which tails, processes and applies events from the bianry logs.
+- `vcopier`: the VCopier component of VReplication, which copies over the mass of table rows from source to target tables.
 ## Configuration
 
 {{< warning >}}

--- a/content/en/docs/18.0/reference/features/tablet-throttler.md
+++ b/content/en/docs/18.0/reference/features/tablet-throttler.md
@@ -129,6 +129,7 @@ Updating the throttler config is done via `vtctlclient` or `vtctldclient`. For e
 ```sh
 $ vtctlclient -- UpdateThrottlerConfig --enable --threshold 3.0 commerce
 $ vtctldclient UpdateThrottlerConfig --disable commerce
+$ vtctldclient UpdateThrottlerConfig --throttle-app="vreplication" --throttle-app-ratio 0.5 --throttle-app-duration "30m" commerce
 ```
 
 See [vtctl UpdateThrottlerConfig](../../programs/vtctl/throttler#updatethrottlerconfig).

--- a/content/en/docs/18.0/reference/programs/vtctl/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctl/_index.md
@@ -157,7 +157,7 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 
 | Name | Example Usage |
 | :-------- | :--------------- |
-| [UpdateThrottlerConfig](../vtctl/throttler#updatethrottlerconfig) | `UpdateThrottlerConfig  -- [--enable\|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self\|--check-as-check-shard] <keyspace>`
+| [UpdateThrottlerConfig](../vtctl/throttler#updatethrottlerconfig) | `UpdateThrottlerConfig  -- [--enable\|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self\|--check-as-check-shard] [--throttle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] <keyspace>`
 
 ## Options
 

--- a/content/en/docs/18.0/reference/programs/vtctl/throttler.md
+++ b/content/en/docs/18.0/reference/programs/vtctl/throttler.md
@@ -10,17 +10,19 @@ The following `vtctl` commands are available for controlling the tablet throttle
 
 ### UpdateThrottlerConfig
 
-Update tablet throttler configuration for all tablets of a given throttler.
+Update tablet throttler configuration for all tablets of a given keyspace.
 
 #### Usage
 
-<pre class="command-example">UpdateThrottlerConfig -- [--enable|--disable] [--threshold=&lt;float64&gt;] [--custom-query=&lt;query&gt;] [--check-as-check-self|--check-as-check-shard] &lt;keyspace&gt;</pre>
+<pre class="command-example">UpdateThrottlerConfig -- [--enable|--disable] [--threshold=&lt;float64&gt;] [--custom-query=&lt;query&gt;] [--check-as-check-self|--check-as-check-shard] [--throttle-app=&lt;name&gt;] [--throttle-app-ratio=&lt;float, range [0..1]&gt;] [--throttle-app-duration=&lt;duration&gt;] &lt;keyspace&gt;</pre>
 
 #### Examples
 
 ```UpdateThrottlerConfig -- --enable --threshold "3.0" commerce```
 
 ```UpdateThrottlerConfig -- --disable commerce```
+
+```UpdateThrottlerConfig -- --throttle-app="vreplication" --throttle-app-ratio=0.5 --throttle-app-duration="30m" commerce```
 
 
 #### Flags

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -7,19 +7,22 @@ series: vtctldclient
 Update the tablet throttler configuration for all tablets in the given keyspace (across all cells)
 
 ```
-vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self|--check-as-check-shard] <keyspace>
+vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self|--check-as-check-shard] [--throttle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] <keyspace>
 ```
 
 ### Options
 
 ```
-      --check-as-check-self    /throttler/check requests behave as is /throttler/check-self was called
-      --check-as-check-shard   use standard behavior for /throttler/check requests
-      --custom-query string    custom throttler check query
-      --disable                Disable the throttler
-      --enable                 Enable the throttler
-  -h, --help                   help for UpdateThrottlerConfig
-      --threshold float        threshold for the either default check (replication lag seconds) or custom check
+      --check-as-check-self             /throttler/check requests behave as is /throttler/check-self was called
+      --check-as-check-shard            use standard behavior for /throttler/check requests
+      --custom-query string             custom throttler check query
+      --disable                         Disable the throttler
+      --enable                          Enable the throttler
+  -h, --help                            help for UpdateThrottlerConfig
+      --threshold float                 threshold for the either default check (replication lag seconds) or custom check
+      --throttle-app string             set a specific throttling rule for the given app
+      --throttle-app-ratio float        set a throttling ratio for app indicated by --throttle-app. 0 means not throttled, 1.0 means fully throttled.
+      --throttle-app-duration duration  time limit after which throttling rule expires. Set as 0 to cancel an existing rule
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Documenting the three new flags introduced in https://github.com/vitessio/vitess/pull/13351:


- `--throttle-app`
- `--throttle-app-ratio`
- `--throttle-app-duration`

It also replaces some examples and suggested commands to reflect the new `vtctldclient UpdateThrottlerCommand` approach as opposed to old curl-the-primary-tablet approach.

## Only merge when https://github.com/vitessio/vitess/pull/13351 is merged