### PR TITLE
Track Lunr search queries and search-result clicks

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -26,6 +26,8 @@ $versions.current}}
       "use strict";
       let index;
       let debounceTimer = null;
+      const _debug = true;
+      const debugLog = _debug ? console.log : () => { };
       const currentUrl = window.location.pathname;
       const currentLocation = String(currentUrl).split("/");
       const currentVersion = currentLocation[2];
@@ -139,6 +141,7 @@ $versions.current}}
           }
         });
         search(query);
+        trackSearchEvent(query);
       }
 
       function search(keywords) {
@@ -169,21 +172,49 @@ $versions.current}}
           // show the matched result
           results.forEach(function (result) {
             const doc = parse[result.ref];
-            const element = template.content.cloneNode(true);
-            element.querySelector(".title").textContent = doc.title;
-            element.querySelector(".subtitle").textContent = doc.summary;
-            element.querySelector(".subtitle").setAttribute("href", doc.href);
-            element
-              .querySelector(".is-read-more")
-              .setAttribute("href", doc.href);
-            element.querySelector(".search-path").textContent = doc.path;
-            element
-              .querySelector(".search-path")
-              .setAttribute("href", doc.href);
+            const searchResultItem = template.content.cloneNode(true)
+              .querySelector('.search-result-item');
 
-            target.appendChild(element);
+            const searchPath = searchResultItem.querySelector('a.search-path');
+            searchPath.setAttribute('href', doc.href);
+            searchPath.textContent = doc.path;
+
+            const title = searchResultItem.querySelector('a.title');
+            title.setAttribute('href', doc.href);
+            title.textContent = doc.title;
+
+            const subtitle = searchResultItem.querySelector('a.subtitle');
+            subtitle.setAttribute('href', doc.href);
+            subtitle.textContent = doc.summary;
+
+            searchResultItem.addEventListener('click',
+              () => trackSearchResultClick(doc.href, query));
+            target.appendChild(searchResultItem);
           }, this);
         }
+      }
+
+      const lunrSearchEventCategory = 'Lunr Search';
+
+      function trackSearchEvent(searchTerm) {
+        debugLog('trackSearchEvent: searchTerm = ' + searchTerm);
+        if (typeof gtag !== 'function') return;
+        gtag('event', 'search', {
+          event_category: lunrSearchEventCategory,
+          event_label: 'Search Input',
+          search_term: searchTerm,
+        });
+      }
+
+      function trackSearchResultClick(searchResultURL, searchTerm) {
+        debugLog(`trackSearchResultClick: searchTerm = ${searchTerm}, link = ${searchResultURL}`);
+        if (typeof gtag !== 'function') return;
+        gtag('event', 'click', {
+          event_category: lunrSearchEventCategory,
+          event_label: 'Search-result Click',
+          search_term: searchTerm,
+          value: searchResultURL,
+        });
       }
 
       // click outside the search modal to close

--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -26,7 +26,7 @@ $versions.current}}
       "use strict";
       let index;
       let debounceTimer = null;
-      const _debug = true;
+      const _debug = false;
       const debugLog = _debug ? console.log : () => { };
       const currentUrl = window.location.pathname;
       const currentLocation = String(currentUrl).split("/");

--- a/layouts/partials/search-results.html
+++ b/layouts/partials/search-results.html
@@ -6,7 +6,7 @@
     <template id="is-search-template">
       <article class="search-result-item">
         <a class="search-path"></a>
-        <h6 class="search-title ">
+        <h6 class="search-title">
           <a class="title is-5 is-read-more"></a>
         </h6>
         <p>


### PR DESCRIPTION
- Closes #1518
- Contributes to #1289
- Adds an event handler to send search terms as a `search` event to GA4 with the search term as an attribute, at no more than the debounce rate.
- Adds a `click` event handler to each search-result item. When a user clicks on a search result, a `click` event is sent to GA4 with the destination link and associated search term as attributes.

A note about the **[deploy preview]**: the site preview will allow you to confirm that search is still functional, but it won't generate GA4 events, since analytics is only enabled in production. When `_debug` is enabled (which it was for my original commit, but has since been disabled), you can at least see that the tracking functions get called, like this:

```
trackSearchEvent: searchTerm = installation
trackSearchResultClick: searchTerm = installation, link = https://deploy-preview-1519--vitess.netlify.app/docs/17.0/get-started/local-mac/
```

---

I've locally built a "production" version of the site, and can confirm that GA4 is receiving both `search` and `click` (related to search) events. Notice the `search_term` attribute in both events:

| Event | Event attributes |
|--------|--------|
| **Notice the `search` event with event count of 1:** <img width="300" alt="Screen Shot 2023-07-01 at 11 33 43" src="https://github.com/vitessio/website/assets/4140793/e1ef22f3-55b9-4ce2-85c6-22a8193bdf96"> | <img width="300" alt="Screen Shot 2023-07-01 at 11 34 04" src="https://github.com/vitessio/website/assets/4140793/5b88a93b-aa6b-41cd-95bb-759bfe8c842e"> | 
|  Oops forgot to get a `click`-event screenshot | <img width="300" alt="Screen Shot 2023-07-01 at 11 34 24" src="https://github.com/vitessio/website/assets/4140793/ba057ce1-d239-4a1d-b7ca-f0a85b9f49c4">

/cc @harshit-gangal @thisisobate @nate-double-u 

[deploy preview]: https://deploy-preview-1519--vitess.netlify.app/