### PR TITLE
Revert "content/en/docs/18.0: rework vtbackup DurationByPhase into binary valued Phase"

### DIFF
--- a/content/en/docs/18.0/reference/backup-and-restore/metrics.md
+++ b/content/en/docs/18.0/reference/backup-and-restore/metrics.md
@@ -50,11 +50,11 @@ _restore_duration_seconds_ times the duration of a restore. This metric is depre
 
 Vtbackup exports some metrics which are not available elsewhere.
 
-#### Phase
+#### DurationByPhaseSeconds
 
 Vtbackup fetches the last backup, restores it to an empty mysql installation, replicates recent changes into that installation, and then takes a backup of that installation.
 
-_Phase_ a binary-valued gauge that reports the currently active phase.
+_DurationByPhaseSeconds_ exports timings for these individual phases.
 
 <hr style="border-top: 2px dashed brown">
 
@@ -91,11 +91,11 @@ _Phase_ a binary-valued gauge that reports the currently active phase.
     "BackupEngine.Builtin.Destination:Close": 17144630,
     "BackupStorage.File.File:Write": 10743169
   },
-  "Phase": {
-    "InitialBackup": 0,
-    "RestoreLastBackup": 0,
-    "CatchUpReplication": 0,
-    "TakeNewBackup": 0
+  "DurationByPhaseSeconds": {
+    "InitMySQLd": 2,
+    "RestoreLastBackup": 6,
+    "CatchUpReplication": 1,
+    "TakeNewBackup": 4
   },
   "RestoreBytes": {
     "BackupEngine.Builtin.Source:Read": 1095,
@@ -131,6 +131,6 @@ _Phase_ a binary-valued gauge that reports the currently active phase.
 Some notes to help understand these metrics:
 
  * `BackupBytes["BackupStorage.File.File:Write"]` measures how many bytes were read from disk by the `file` Backup Storage implementation during the backup phase.
- * `Phase["CatchUpReplication"]` reports whether the catch-up replication phase is active (1) or not (0).
- * `Phase["RestoreLastBackup"]` reports whether the restore last backup phase is active (1) or not (0).
+ * `DurationByPhaseSeconds["CatchUpReplication"]` measures how long it took to catch-up replication after the restore phase.
+ * `DurationByPhaseSeconds["RestoreLastBackup"]` measures to the duration of the restore phase.
  * `RestoreDurationNanoseconds["-.-.Restore"]` also measures to the duration of the restore phase.


### PR DESCRIPTION
Reverts vitessio/website#1452 because https://github.com/vitessio/vitess/pull/12973 is unmerged yet.