### PR TITLE
Fix the download file links after the release of `v16.0.4` and `v17.0.2`

### DIFF
--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -90,7 +90,7 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 
 ```sh
 version=16.0.4
-file=vitess-${version}-<TODO>.tar.gz
+file=vitess-${version}-87ea735.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -66,7 +66,7 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 
 ```sh
 version=17.0.2
-file=vitess-${version}-<TODO>.tar.gz
+file=vitess-${version}-96ac0a6.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}


### PR DESCRIPTION
### Description

This PR updates the download links for `v16.0.4` and `v17.0.2` post release.

### Release Issue
https://github.com/vitessio/vitess/issues/13787
https://github.com/vitessio/vitess/issues/13786