### PR TITLE
Correct env.sh path in v16+ local examples docs

### DIFF
--- a/content/en/docs/15.0/get-started/local-mac.md
+++ b/content/en/docs/15.0/get-started/local-mac.md
@@ -13,9 +13,9 @@ A pure [homebrew setup](../local-brew/) is also available.
 For the purposes of installing software you will need to have brew installed. This will also install curl and git which will also be needed:
 
 ```sh
-$ curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
+curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
 
-$ bash brew-install.sh
+bash brew-install.sh
 ```
 
 ## Install MySQL and etcd
@@ -23,21 +23,21 @@ $ bash brew-install.sh
 Once brew is installed you will need to install some dependencies for Vitess. Vitess supports the databases listed [here](../../overview/supported-databases/): 
 
 ```sh
-$ brew install automake go mysql@5.7 mysql-client etcd
+brew install automake go mysql@5.7 mysql-client etcd
 ```
 
 When MySQL installs with brew it will startup, you will want to shut this process down, as Vitess will be managing the startup and shutdown of MySQL:
 
 ```sh
-$ brew services stop mysql@5.7
+brew services stop mysql@5.7
 ```
 
 ### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+brew install nvm
+nvm install --lts 16.13.0
+nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -47,15 +47,15 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 With the tools you’ve just installed via brew, you will next update your PATH variable so your shell knows where to find the binaries:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql@5.7/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
-$ source ~/.zshrc
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql@5.7/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you’re using bash for your shell you’ll have to update the paths in `.bash_profile` or `.bashrc` instead. Mac does not read `.bashrc` by default:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql@5.7/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
-$ source ~/.bash_profile
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql@5.7/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 ## System Check
@@ -63,12 +63,12 @@ $ source ~/.bash_profile
 Before going further, you should check to confirm your shell has access to `go`, `mysql`, and `mysqld`. If versions are not returned when you run the following commands you should check that the programs are installed and the path is correct for your shell: 
 
 ```sh
-$ mysqld --version
-$ mysql --version
-$ go version
-$ etcd --version
-$ node --version
-$ npm --version
+mysqld --version
+mysql --version
+go version
+etcd --version
+node --version
+npm --version
 ```
 
 ## Install Vitess
@@ -76,25 +76,25 @@ $ npm --version
 With everything now in place you can clone and build Vitess.
 
 ```sh
-$ git clone https://github.com/vitessio/vitess.git
-$ cd vitess
-$ make build
+git clone https://github.com/vitessio/vitess.git
+cd vitess
+make build
 ```
 
 It will take some time for Vitess to build. Once it completes you should see a bin folder which will hold the Vitess binaries. You will need to add this folder to your `PATH` variable as well: 
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
-$ source ~/.zshrc
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you are using bash this will need to be your `.bash_profile` or `.bashrc` file instead:
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
-$ source ~/.bash_profile
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 You are now ready to start your first cluster! Open a new terminal window to ensure your `.bashrc` file changes take effect. 
@@ -104,20 +104,19 @@ You are now ready to start your first cluster! Open a new terminal window to ens
 You are now ready to stand up your first Vitess cluster, using the example scripts provided in the source code. Assuming you are still in the bin directory you will need to navigate to the sample files:
 
 ```sh
-$ cd ../examples/local/
+cd ../examples/local/
 ```
 
 From here you can startup the cluster and source the env file which will help set environment variables used when working with this local cluster: 
 
 ```sh
-$ ./101_initial_cluster.sh
-$ source env.sh
+./101_initial_cluster.sh
+source env.sh
 ```
 
 You should see an output similar to the following:
 
 ```text
-~/my-vitess-example> ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1
@@ -268,7 +267,7 @@ user@computer:~/Github/vitess/examples/local$ rm -rf ./vtdataroot
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```sh
-$ mysql -P 15306 -u root --protocol tcp
+mysql -P 15306 -u root --protocol tcp
 ```
 
 You can also browse to the vtctld console using the following URL:
@@ -321,13 +320,13 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
 
 ```sh
-$ ./401_teardown.sh
-$ rm -rf ./vtdataroot
+./401_teardown.sh
+rm -rf ./vtdataroot
 ```
 
 Sometimes you will still need to manually kill processes if there are errors in the environment:
 
 ```sh
-$ pkill -9 -f ./vtdataroot
-$ rm -rf ./vtdataroot
+pkill -9 -f ./vtdataroot
+rm -rf ./vtdataroot
 ```

--- a/content/en/docs/15.0/get-started/local.md
+++ b/content/en/docs/15.0/get-started/local.md
@@ -120,7 +120,6 @@ cd ~/my-vitess-example/examples/local
 You should see an output similar to the following:
 
 ```text
-~/my-vitess-example> ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1

--- a/content/en/docs/15.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/region-sharding.md
@@ -107,7 +107,7 @@ Now start the cluster:
 You should see output similar to the following:
 
 ```text
-~/my-vitess-example> ./101_initial_cluster.sh
+$ ./101_initial_cluster.sh
 add /vitess/global
 add /vitess/zone1
 add zone1 CellInfo
@@ -193,7 +193,7 @@ vtadmin-web is running!
 You can also verify that the processes have started with `pgrep`:
 
 ```bash
-~/my-vitess-example> pgrep -fl vitess
+$ pgrep -fl vitess
 9160 etcd
 9222 vtctld
 9280 mysqld_safe
@@ -227,7 +227,7 @@ Setting up aliases changes `mysql` to always connect to Vitess for your current 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```bash
-~/my-vitess-example> mysql
+$ mysql
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2
 Server version: 5.7.9-Vitess (Ubuntu)
@@ -252,13 +252,13 @@ mysql> show tables;
 ## Insert some data into the cluster
 
 ```bash
-~/my-vitess-example> mysql < insert_customers.sql
+mysql < insert_customers.sql
 ```
 
 ## Examine the data we just inserted
 
 ```bash
-~/my-vitess-example> mysql --table < show_initial_data.sql
+mysql --table < show_initial_data.sql
 ```
 
 ```text
@@ -342,15 +342,18 @@ Here is the lookup vindex definition. Here we both define the lookup vindex, and
   }
 }
 ```
+
 Once the vindex is available, we have to `Externalize` it for it to be usable.
 Putting this all together, we run the script that combines the above steps.
 
 ```sh
 ./201_main_sharded.sh
 ```
+
 Once this is complete, we can view the new vschema. Note that it now includes both region_vdx and a lookup vindex.
+
 ```text
-~/my-vitess-example> vtctldclient GetVSchema main
+$ vtctldclient GetVSchema main
 {
   "sharded": true,
   "vindexes": {

--- a/content/en/docs/15.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/15.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -27,10 +27,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source env.sh
+
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -38,8 +38,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | customer              |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 +------------------+
 | Tables_in_legacy |
@@ -100,7 +100,7 @@ vtctldclient TabletExternallyReparented zone1-401
 VTGate should now be able to route queries to your unmanaged MySQL server:
 
 ```bash
-~/vitess/examples/local$ mysql legacy -e 'show tables'
+$ mysql legacy -e 'show tables'
 +------------------+
 | Tables_in_legacy |
 +------------------+
@@ -159,10 +159,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source env.sh
+
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -171,8 +171,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | legacytable           |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 ```
 

--- a/content/en/docs/16.0/get-started/local-brew.md
+++ b/content/en/docs/16.0/get-started/local-brew.md
@@ -215,7 +215,7 @@ rm -rf /usr/local/Cellar/vitess/9.0.0/share/vitess/examples/local/vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql` and `vtctlclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient` or close your session.

--- a/content/en/docs/16.0/get-started/local-brew.md
+++ b/content/en/docs/16.0/get-started/local-brew.md
@@ -40,9 +40,9 @@ At this point Vitess binaries installed under default Homebrew install location 
 ### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+brew install nvm
+nvm install --lts 16.13.0
+nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -50,6 +50,7 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 ## Start a Single Keyspace Cluster
 
 For testing purposes initiate following example;
+
 ```bash
 $ cd /usr/local/share/vitess/examples/local/
 $ ./101_initial_cluster.sh
@@ -171,7 +172,9 @@ vtadmin-web is running!
   - PID: 74070
 
 ```
+
 Verify your initial cluster:
+
 ```sql
 $ mysql -e "show vitess_tablets"
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
@@ -182,6 +185,7 @@ $ mysql -e "show vitess_tablets"
 | zone1 | commerce | 0     | RDONLY     | SERVING | zone1-0000000102 | localhost |                      |
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
 ```
+
 You can also verify that the processes have started with `pgrep`:
 
 ```bash

--- a/content/en/docs/16.0/get-started/local-mac.md
+++ b/content/en/docs/16.0/get-started/local-mac.md
@@ -13,9 +13,9 @@ A pure [homebrew setup](../local-brew/) is also available.
 For the purposes of installing software you will need to have brew installed. This will also install curl and git which will also be needed:
 
 ```sh
-$ curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
+curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
 
-$ bash brew-install.sh
+bash brew-install.sh
 ```
 
 ## Install MySQL and etcd
@@ -23,21 +23,21 @@ $ bash brew-install.sh
 Once brew is installed you will need to install some dependencies for Vitess. Vitess supports the databases listed [here](../../overview/supported-databases/): 
 
 ```sh
-$ brew install automake go mysql mysql-client etcd
+brew install automake go mysql mysql-client etcd
 ```
 
 When MySQL installs with brew it will startup, you will want to shut this process down, as Vitess will be managing the startup and shutdown of MySQL:
 
 ```sh
-$ brew services stop mysql
+brew services stop mysql
 ```
 
 ### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+brew install nvm
+nvm install --lts 16.13.0
+nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -47,15 +47,15 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 With the tools you’ve just installed via brew, you will next update your PATH variable so your shell knows where to find the binaries:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
-$ source ~/.zshrc
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you’re using bash for your shell you’ll have to update the paths in `.bash_profile` or `.bashrc` instead. Mac does not read `.bashrc` by default:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
-$ source ~/.bash_profile
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 ## System Check
@@ -63,12 +63,12 @@ $ source ~/.bash_profile
 Before going further, you should check to confirm your shell has access to `go`, `mysql`, and `mysqld`. If versions are not returned when you run the following commands you should check that the programs are installed and the path is correct for your shell: 
 
 ```sh
-$ mysqld --version
-$ mysql --version
-$ go version
-$ etcd --version
-$ node --version
-$ npm --version
+mysqld --version
+mysql --version
+go version
+etcd --version
+node --version
+npm --version
 ```
 
 ## Install Vitess
@@ -76,25 +76,25 @@ $ npm --version
 With everything now in place you can clone and build Vitess.
 
 ```sh
-$ git clone https://github.com/vitessio/vitess.git
-$ cd vitess
-$ make build
+git clone https://github.com/vitessio/vitess.git
+cd vitess
+make build
 ```
 
 It will take some time for Vitess to build. Once it completes you should see a bin folder which will hold the Vitess binaries. You will need to add this folder to your `PATH` variable as well: 
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
-$ source ~/.zshrc
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you are using bash this will need to be your `.bash_profile` or `.bashrc` file instead:
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
-$ source ~/.bash_profile
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 You are now ready to start your first cluster! Open a new terminal window to ensure your `.bashrc` file changes take effect. 
@@ -104,20 +104,19 @@ You are now ready to start your first cluster! Open a new terminal window to ens
 You are now ready to stand up your first Vitess cluster, using the example scripts provided in the source code. Assuming you are still in the bin directory you will need to navigate to the sample files:
 
 ```sh
-$ cd ../examples/local/
+cd ../examples/local/
 ```
 
 From here you can startup the cluster and source the env file which will help set environment variables used when working with this local cluster: 
 
 ```sh
-$ ./101_initial_cluster.sh
-$ source env.sh
+./101_initial_cluster.sh
+source env.sh
 ```
 
 You should see an output similar to the following:
 
 ```text
-~/my-vitess-example> ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1
@@ -268,7 +267,7 @@ user@computer:~/Github/vitess/examples/local$ rm -rf ./vtdataroot
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```sh
-$ mysql -P 15306 -u root --protocol tcp
+mysql -P 15306 -u root --protocol tcp
 ```
 
 </br>
@@ -325,13 +324,13 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
 
 ```sh
-$ ./401_teardown.sh
-$ rm -rf ./vtdataroot
+./401_teardown.sh
+rm -rf ./vtdataroot
 ```
 
 Sometimes you will still need to manually kill processes if there are errors in the environment:
 
 ```sh
-$ pkill -9 -f ./vtdataroot
-$ rm -rf ./vtdataroot
+pkill -9 -f ./vtdataroot
+rm -rf ./vtdataroot
 ```

--- a/content/en/docs/16.0/get-started/local-mac.md
+++ b/content/en/docs/16.0/get-started/local-mac.md
@@ -111,7 +111,7 @@ From here you can startup the cluster and source the env file which will help se
 
 ```sh
 ./101_initial_cluster.sh
-source env.sh
+source ../common/env.sh
 ```
 
 You should see an output similar to the following:

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -121,7 +121,6 @@ cd ~/my-vitess-example/examples/local
 You should see an output similar to the following:
 
 ```text
-~/my-vitess-example> ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1
@@ -255,7 +254,7 @@ vtadmin-web is running!
 You can also verify that the processes have started with `pgrep`:
 
 ```bash
-~/my-vitess-example> pgrep -fl vitess
+$ pgrep -fl vitess
 14119 etcd
 14176 vtctld
 14251 mysqld_safe
@@ -295,7 +294,7 @@ Setting up aliases changes `mysql` to always connect to Vitess for your current 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```bash
-~/my-vitess-example> mysql
+$ mysql
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2
 Server version: 8.0.31-Vitess (Ubuntu)

--- a/content/en/docs/16.0/get-started/local.md
+++ b/content/en/docs/16.0/get-started/local.md
@@ -285,7 +285,7 @@ rm -rf vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql`, `vtctlclient` and `vtcltdclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient && unalias vtctldclient` or close your session.

--- a/content/en/docs/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -15,7 +15,7 @@ This guide uses the Vitess components vtctld, Topology Service and VTGate which 
 You should have previously executed `./101_initial_cluster.sh` in the get-started guide. This will ensure that you have a Topology Service, vtgate, vtctld. For the unmanaged MySQL instance, I will be using an instance running on `127.0.0.1:5726`:
 
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -27,7 +27,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 
@@ -148,7 +148,7 @@ vtctlclient MoveTables Complete commerce.legacy2commerce
 ```
 <br>Verify that the table was moved:
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -159,7 +159,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 

--- a/content/en/docs/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -27,10 +27,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -38,8 +38,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | customer              |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 +------------------+
 | Tables_in_legacy |
@@ -100,7 +100,7 @@ vtctldclient TabletExternallyReparented zone1-401
 VTGate should now be able to route queries to your unmanaged MySQL server:
 
 ```bash
-~/vitess/examples/local$ mysql legacy -e 'show tables'
+$ mysql legacy -e 'show tables'
 +------------------+
 | Tables_in_legacy |
 +------------------+
@@ -159,10 +159,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+$ 
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -171,8 +171,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | legacytable           |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 ```
 

--- a/content/en/docs/17.0/get-started/local-brew.md
+++ b/content/en/docs/17.0/get-started/local-brew.md
@@ -40,9 +40,9 @@ At this point Vitess binaries installed under default Homebrew install location 
 ### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 18.16.0
-$ nvm use 18.16.0
+brew install nvm
+nvm install --lts 18.16.0
+nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -50,9 +50,10 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 ## Start a Single Keyspace Cluster
 
 For testing purposes initiate following example;
+
 ```bash
-$ cd /usr/local/share/vitess/examples/local/
-$ ./101_initial_cluster.sh
+cd /usr/local/share/vitess/examples/local/
+./101_initial_cluster.sh
 add /vitess/global
 add /vitess/zone1
 add zone1 CellInfo
@@ -146,7 +147,9 @@ vtadmin-web is running!
   - Logs: /Users/florentpoinsard/Code/vitess/vtdataroot/tmp/vtadmin-web.out
   - PID: 49698
 ```
+
 Verify your initial cluster:
+
 ```sql
 $ mysql -e "show vitess_tablets"
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
@@ -157,6 +160,7 @@ $ mysql -e "show vitess_tablets"
 | zone1 | commerce | 0     | RDONLY     | SERVING | zone1-0000000102 | localhost |                      |
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
 ```
+
 You can also verify that the processes have started with `pgrep`:
 
 ```bash

--- a/content/en/docs/17.0/get-started/local-brew.md
+++ b/content/en/docs/17.0/get-started/local-brew.md
@@ -190,7 +190,7 @@ rm -rf /usr/local/Cellar/vitess/9.0.0/share/vitess/examples/local/vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql` and `vtctlclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient` or close your session.

--- a/content/en/docs/17.0/get-started/local-mac.md
+++ b/content/en/docs/17.0/get-started/local-mac.md
@@ -111,7 +111,7 @@ From here you can startup the cluster and source the env file which will help se
 
 ```sh
 ./101_initial_cluster.sh
-source env.sh
+source ../common/env.sh
 ```
 
 You should see an output similar to the following:

--- a/content/en/docs/17.0/get-started/local-mac.md
+++ b/content/en/docs/17.0/get-started/local-mac.md
@@ -13,9 +13,9 @@ A pure [homebrew setup](../local-brew/) is also available.
 For the purposes of installing software you will need to have brew installed. This will also install curl and git which will also be needed:
 
 ```sh
-$ curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
+curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
 
-$ bash brew-install.sh
+bash brew-install.sh
 ```
 
 ## Install MySQL and etcd
@@ -23,21 +23,21 @@ $ bash brew-install.sh
 Once brew is installed you will need to install some dependencies for Vitess. Vitess supports the databases listed [here](../../overview/supported-databases/): 
 
 ```sh
-$ brew install automake go mysql mysql-client etcd
+brew install automake go mysql mysql-client etcd
 ```
 
 When MySQL installs with brew it will startup, you will want to shut this process down, as Vitess will be managing the startup and shutdown of MySQL:
 
 ```sh
-$ brew services stop mysql
+brew services stop mysql
 ```
 
 ### Install Node 16.13.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 16.13.0
-$ nvm use 16.13.0
+brew install nvm
+nvm install --lts 16.13.0
+nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -47,15 +47,15 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 With the tools you’ve just installed via brew, you will next update your PATH variable so your shell knows where to find the binaries:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
-$ source ~/.zshrc
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you’re using bash for your shell you’ll have to update the paths in `.bash_profile` or `.bashrc` instead. Mac does not read `.bashrc` by default:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
-$ source ~/.bash_profile
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:/opt/homebrew/bin” >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 ## System Check
@@ -63,12 +63,12 @@ $ source ~/.bash_profile
 Before going further, you should check to confirm your shell has access to `go`, `mysql`, and `mysqld`. If versions are not returned when you run the following commands you should check that the programs are installed and the path is correct for your shell: 
 
 ```sh
-$ mysqld --version
-$ mysql --version
-$ go version
-$ etcd --version
-$ node --version
-$ npm --version
+mysqld --version
+mysql --version
+go version
+etcd --version
+node --version
+npm --version
 ```
 
 ## Install Vitess
@@ -76,25 +76,25 @@ $ npm --version
 With everything now in place you can clone and build Vitess.
 
 ```sh
-$ git clone https://github.com/vitessio/vitess.git
-$ cd vitess
-$ make build
+git clone https://github.com/vitessio/vitess.git
+cd vitess
+make build
 ```
 
 It will take some time for Vitess to build. Once it completes you should see a bin folder which will hold the Vitess binaries. You will need to add this folder to your `PATH` variable as well: 
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
-$ source ~/.zshrc
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you are using bash this will need to be your `.bash_profile` or `.bashrc` file instead:
 
 ```sh
-$ cd bin
-$ echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
-$ source ~/.bash_profile
+cd bin
+echo "$(printf 'export PATH="${PATH}:'; echo "$(pwd)\"")" >> ~/.bash_profile
+source ~/.bash_profile
 ```
 
 You are now ready to start your first cluster! Open a new terminal window to ensure your `.bashrc` file changes take effect. 
@@ -104,21 +104,20 @@ You are now ready to start your first cluster! Open a new terminal window to ens
 You are now ready to stand up your first Vitess cluster, using the example scripts provided in the source code. Assuming you are still in the bin directory you will need to navigate to the sample files:
 
 ```sh
-$ cd ../examples/local/
+cd ../examples/local/
 ```
 
 From here you can startup the cluster and source the env file which will help set environment variables used when working with this local cluster: 
 
 ```sh
-$ ./101_initial_cluster.sh
-$ source env.sh
+./101_initial_cluster.sh
+source env.sh
 ```
 
 You should see an output similar to the following:
 
 ```bash
-~/my-vitess-example> ./101_initial_cluster.sh
-$ ./101_initial_cluster.sh 
+$./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1
 add zone1 CellInfo
@@ -247,10 +246,10 @@ If you encounter any errors, such as ports already in use, you can kill the proc
 This data directory `vtdataroot` will get recreated when you run the 101_initial_cluster.sh startup script again.
 
 ```sh
-user@computer:~/Github/vitess/examples/local$ pwd
+user@computer:~/Github/vitess/examples/local$pwd
 /home/user/Github/vitess/examples/local
 
-user@computer:~/Github/vitess/examples/local$ pkill -9 -f '(vtdataroot|VTDATAROOT|vitess|vtadmin)'
+user@computer:~/Github/vitess/examples/local$pkill -9 -f '(vtdataroot|VTDATAROOT|vitess|vtadmin)'
 etcd killed (pid 224091)
 vtctld killed (pid 224154)
 mysqld_safe killed (pid 224247)
@@ -266,7 +265,7 @@ vtgate killed (pid 226204)
 vtadmin killed (pid 226391)
 vtorc killed (pid 226397)
 
-user@computer:~/Github/vitess/examples/local$ rm -rf ./vtdataroot
+user@computer:~/Github/vitess/examples/local$rm -rf ./vtdataroot
 ```
 
 ## Connect to your cluster
@@ -274,7 +273,7 @@ user@computer:~/Github/vitess/examples/local$ rm -rf ./vtdataroot
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```sh
-$ mysql -P 15306 -u root --protocol tcp
+mysql -P 15306 -u root --protocol tcp
 ```
 
 </br>
@@ -331,13 +330,13 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
 
 ```sh
-$ ./401_teardown.sh
-$ rm -rf ./vtdataroot
+./401_teardown.sh
+rm -rf ./vtdataroot
 ```
 
 Sometimes you will still need to manually kill processes if there are errors in the environment:
 
 ```sh
-$ pkill -9 -f ./vtdataroot
-$ rm -rf ./vtdataroot
+pkill -9 -f ./vtdataroot
+rm -rf ./vtdataroot
 ```

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -97,7 +97,6 @@ cd ~/my-vitess-example/examples/local
 You should see an output similar to the following:
 
 ```bash
-~/my-vitess-example> ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1
@@ -237,7 +236,7 @@ vtadmin-web is running!
 You can also verify that the processes have started with `pgrep`:
 
 ```bash
-~/my-vitess-example> pgrep -fl vitess
+$ pgrep -fl vitess
 14119 etcd
 14176 vtctld
 14251 mysqld_safe
@@ -277,7 +276,7 @@ Setting up aliases changes `mysql` to always connect to Vitess for your current 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```bash
-~/my-vitess-example> mysql
+$ mysql
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2
 Server version: 8.0.31-Vitess (Ubuntu)

--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -267,7 +267,7 @@ rm -rf vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql`, `vtctlclient` and `vtcltdclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient && unalias vtctldclient` or close your session.

--- a/content/en/docs/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -27,10 +27,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -38,8 +38,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | customer              |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 +------------------+
 | Tables_in_legacy |
@@ -99,7 +99,7 @@ vtctldclient TabletExternallyReparented zone1-401
 VTGate should now be able to route queries to your unmanaged MySQL server:
 
 ```bash
-~/vitess/examples/local$ mysql legacy -e 'show tables'
+$ mysql legacy -e 'show tables'
 +------------------+
 | Tables_in_legacy |
 +------------------+
@@ -158,10 +158,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+$ 
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -170,8 +170,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | legacytable           |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 ```
 

--- a/content/en/docs/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -15,7 +15,7 @@ This guide uses the Vitess components vtctld, Topology Service and VTGate which 
 You should have previously executed `./101_initial_cluster.sh` in the get-started guide. This will ensure that you have a Topology Service, vtgate, vtctld. For the unmanaged MySQL instance, I will be using an instance running on `127.0.0.1:5726`:
 
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -27,7 +27,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 
@@ -147,7 +147,7 @@ vtctlclient MoveTables Complete commerce.legacy2commerce
 ```
 <br>Verify that the table was moved:
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -158,7 +158,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 

--- a/content/en/docs/18.0/get-started/local-brew.md
+++ b/content/en/docs/18.0/get-started/local-brew.md
@@ -40,9 +40,9 @@ At this point Vitess binaries installed under default Homebrew install location 
 ### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 18.16.0
-$ nvm use 18.16.0
+brew install nvm
+nvm install --lts 18.16.0
+nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -50,6 +50,7 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 ## Start a Single Keyspace Cluster
 
 For testing purposes initiate following example;
+
 ```bash
 $ cd /usr/local/share/vitess/examples/local/
 $ ./101_initial_cluster.sh
@@ -146,7 +147,9 @@ vtadmin-web is running!
   - Logs: /Users/florentpoinsard/Code/vitess/vtdataroot/tmp/vtadmin-web.out
   - PID: 49698
 ```
+
 Verify your initial cluster:
+
 ```sql
 $ mysql -e "show vitess_tablets"
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
@@ -157,6 +160,7 @@ $ mysql -e "show vitess_tablets"
 | zone1 | commerce | 0     | RDONLY     | SERVING | zone1-0000000102 | localhost |                      |
 +-------+----------+-------+------------+---------+------------------+-----------+----------------------+
 ```
+
 You can also verify that the processes have started with `pgrep`:
 
 ```bash

--- a/content/en/docs/18.0/get-started/local-brew.md
+++ b/content/en/docs/18.0/get-started/local-brew.md
@@ -190,7 +190,7 @@ rm -rf /usr/local/Cellar/vitess/9.0.0/share/vitess/examples/local/vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql` and `vtctlclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient` or close your session.

--- a/content/en/docs/18.0/get-started/local-mac.md
+++ b/content/en/docs/18.0/get-started/local-mac.md
@@ -111,7 +111,7 @@ From here you can startup the cluster and source the env file which will help se
 
 ```sh
 $ ./101_initial_cluster.sh
-$ source env.sh
+$ source ../common/env.sh
 ```
 
 You should see an output similar to the following:

--- a/content/en/docs/18.0/get-started/local-mac.md
+++ b/content/en/docs/18.0/get-started/local-mac.md
@@ -13,9 +13,9 @@ A pure [homebrew setup](../local-brew/) is also available.
 For the purposes of installing software you will need to have brew installed. This will also install curl and git which will also be needed:
 
 ```sh
-$ curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
+curl https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh > brew-install.sh
 
-$ bash brew-install.sh
+bash brew-install.sh
 ```
 
 ## Install MySQL and etcd
@@ -23,7 +23,7 @@ $ bash brew-install.sh
 Once brew is installed you will need to install some dependencies for Vitess. Vitess supports the databases listed [here](../../overview/supported-databases/): 
 
 ```sh
-$ brew install automake go mysql mysql-client etcd
+brew install automake go mysql mysql-client etcd
 ```
 
 When MySQL installs with brew it will startup, you will want to shut this process down, as Vitess will be managing the startup and shutdown of MySQL:
@@ -35,9 +35,9 @@ $ brew services stop mysql
 ### Install Node 18.16.0+ (required to run VTAdmin)
 
 ```bash
-$ brew install nvm
-$ nvm install --lts 18.16.0
-$ nvm use 18.16.0
+brew install nvm
+nvm install --lts 18.16.0
+nvm use 18.16.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
@@ -47,8 +47,8 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 With the tools you’ve just installed via brew, you will next update your PATH variable so your shell knows where to find the binaries:
 
 ```sh
-$ echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
-$ source ~/.zshrc
+echo “export PATH=${PATH}:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/opt/mysql/bin:~/Github/vitess/bin:/Users/jason/go/bin:​​/opt/homebrew/bin” >> ~/.zshrc
+source ~/.zshrc
 ```
 
 If you’re using bash for your shell you’ll have to update the paths in `.bash_profile` or `.bashrc` instead. Mac does not read `.bashrc` by default:
@@ -117,7 +117,7 @@ $ source env.sh
 You should see an output similar to the following:
 
 ```bash
-~/my-vitess-example> ./101_initial_cluster.sh
+$ ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1

--- a/content/en/docs/18.0/get-started/local.md
+++ b/content/en/docs/18.0/get-started/local.md
@@ -97,8 +97,7 @@ cd ~/my-vitess-example/examples/local
 You should see an output similar to the following:
 
 ```bash
-~/my-vitess-example> ./101_initial_cluster.sh
-$ ./101_initial_cluster.sh 
+$ ./101_initial_cluster.sh
 add /vitess/global
 add /vitess/zone1
 add zone1 CellInfo
@@ -196,7 +195,7 @@ vtadmin-web is running!
 You can also verify that the processes have started with `pgrep`:
 
 ```bash
-~/my-vitess-example> pgrep -fl vitess
+$ pgrep -fl vitess
 14119 etcd
 14176 vtctld
 14251 mysqld_safe
@@ -236,7 +235,7 @@ Setting up aliases changes `mysql` to always connect to Vitess for your current 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 
 ```bash
-~/my-vitess-example> mysql
+$ mysql
 Welcome to the MySQL monitor.  Commands end with ; or \g.
 Your MySQL connection id is 2
 Server version: 8.0.31-Vitess (Ubuntu)

--- a/content/en/docs/18.0/get-started/local.md
+++ b/content/en/docs/18.0/get-started/local.md
@@ -226,7 +226,7 @@ rm -rf vtdataroot
 For ease-of-use, Vitess provides aliases for `mysql`, `vtctlclient` and `vtcltdclient`:
 
 ```bash
-source ./env.sh
+source ../common/env.sh
 ```
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctlclient && unalias vtctldclient` or close your session.

--- a/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -27,10 +27,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -38,8 +38,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | customer              |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 +------------------+
 | Tables_in_legacy |
@@ -99,7 +99,7 @@ vtctldclient TabletExternallyReparented zone1-401
 VTGate should now be able to route queries to your unmanaged MySQL server:
 
 ```bash
-~/vitess/examples/local$ mysql legacy -e 'show tables'
+$ mysql legacy -e 'show tables'
 +------------------+
 | Tables_in_legacy |
 +------------------+
@@ -158,10 +158,10 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source ../common/env.sh
-~/vitess/examples/local$ 
-~/vitess/examples/local$ # verify vtgate/vitess is up and running
-~/vitess/examples/local$ mysql commerce -e 'show tables' 
+$ source ../common/env.sh
+$ 
+$ # verify vtgate/vitess is up and running
+$ mysql commerce -e 'show tables' 
 +-----------------------+
 | Tables_in_vt_commerce |
 +-----------------------+
@@ -170,8 +170,8 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 | legacytable           |
 | product               |
 +-----------------------+
-~/vitess/examples/local$ # verify my unmanaged mysql is running 
-~/vitess/examples/local$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
+$ # verify my unmanaged mysql is running 
+$ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 mysql: [Warning] Using a password on the command line interface can be insecure.
 ```
 

--- a/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -15,7 +15,7 @@ This guide uses the Vitess components vtctld, Topology Service and VTGate which 
 You should have previously executed `./101_initial_cluster.sh` in the get-started guide. This will ensure that you have a Topology Service, vtgate, vtctld. For the unmanaged MySQL instance, I will be using an instance running on `127.0.0.1:5726`:
 
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -27,7 +27,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 
@@ -147,7 +147,7 @@ vtctlclient MoveTables Complete commerce.legacy2commerce
 ```
 <br>Verify that the table was moved:
 ```bash
-source env.sh
+source ../common/env.sh
 
 # verify vtgate/vitess is up and running
 mysql commerce -e 'show tables'
@@ -158,7 +158,7 @@ mysql -h 127.0.0.1 -P 5726 -umsandbox -pmsandbox legacy -e 'show tables'
 <br>Output:
 
 ```text
-~/vitess/examples/local$ source env.sh
+~/vitess/examples/local$ source ../common/env.sh
 ~/vitess/examples/local$ 
 ~/vitess/examples/local$ # verify vtgate/vitess is up and running
 ~/vitess/examples/local$ mysql commerce -e 'show tables' 


### PR DESCRIPTION
We also simplify and unify the prompt usage in the commands:
- Use `$ ` as the static prompt
- Only show the prompt when including the output (otherwise the commands are easier to cut and paste w/o it)

Fixes: https://github.com/vitessio/website/issues/1523