### PR TITLE
Use `link_url` in Lunr search-result click events, only in production

### DIFF
--- a/layouts/partials/javascript.html
+++ b/layouts/partials/javascript.html
@@ -197,6 +197,7 @@ $versions.current}}
       const lunrSearchEventCategory = 'Lunr Search';
 
       function trackSearchEvent(searchTerm) {
+      {{ if hugo.IsProduction -}}
         debugLog('trackSearchEvent: searchTerm = ' + searchTerm);
         if (typeof gtag !== 'function') return;
         gtag('event', 'search', {
@@ -204,17 +205,21 @@ $versions.current}}
           event_label: 'Search Input',
           search_term: searchTerm,
         });
+      {{ end -}}
       }
 
       function trackSearchResultClick(searchResultURL, searchTerm) {
+      {{ if hugo.IsProduction -}}
         debugLog(`trackSearchResultClick: searchTerm = ${searchTerm}, link = ${searchResultURL}`);
         if (typeof gtag !== 'function') return;
         gtag('event', 'click', {
           event_category: lunrSearchEventCategory,
           event_label: 'Search-result Click',
           search_term: searchTerm,
-          value: searchResultURL,
+          link_url: searchResultURL,
+          outbound: false,
         });
+      {{ end -}}
       }
 
       // click outside the search modal to close


### PR DESCRIPTION
- Contributes to #1570
- For search click events:
  - Switches to using event param `link_url` rather than `value` to pass the `searchResultURL`
  - Sets `outbound` to false
- Ensures that GA4 search and search-result-click events are emitted only from production built sites

/cc @nate-double-u @harshit-gangal 