### PR TITLE
vtctldclient Reshard + refactor: regenerate docs

### DIFF
--- a/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
@@ -81,6 +81,7 @@ vtctldclient [flags]
 * [vtctldclient RemoveKeyspaceCell](./vtctldclient_removekeyspacecell/)	 - Removes the specified cell from the Cells list for all shards in the specified keyspace (by calling RemoveShardCell on every shard). It also removes the SrvKeyspace for that keyspace in that cell.
 * [vtctldclient RemoveShardCell](./vtctldclient_removeshardcell/)	 - Remove the specified cell from the specified shard's Cells list.
 * [vtctldclient ReparentTablet](./vtctldclient_reparenttablet/)	 - Reparent a tablet to the current primary in the shard.
+* [vtctldclient Reshard](./vtctldclient_reshard/)	 - Perform commands related to resharding a keyspace.
 * [vtctldclient RestoreFromBackup](./vtctldclient_restorefrombackup/)	 - Stops mysqld on the specified tablet and restores the data from either the latest backup or closest before `backup-timestamp`.
 * [vtctldclient RunHealthCheck](./vtctldclient_runhealthcheck/)	 - Runs a healthcheck on the remote tablet.
 * [vtctldclient SetKeyspaceDurabilityPolicy](./vtctldclient_setkeyspacedurabilitypolicy/)	 - Sets the durability-policy used by the specified keyspace.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -8,7 +8,7 @@ Perform commands related to moving tables from a source keyspace to a target key
 
 ### Synopsis
 
-MoveTables commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
+moveTables commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
 See the --help output for each command for more details.
 
 ### Options
@@ -16,7 +16,7 @@ See the --help output for each command for more details.
 ```
       --format string            The format of the output; supported formats are: text,json (default "text")
   -h, --help                     help for MoveTables
-      --target-keyspace string   Keyspace where the tables are being moved to and where the workflow exists (required)
+      --target-keyspace string   Target keyspace for this workflow exists (required)
   -w, --workflow string          The workflow you want to perform the command on (required)
 ```
 
@@ -30,13 +30,13 @@ See the --help output for each command for more details.
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient MoveTables cancel](./vtctldclient_movetables_cancel/)	 - Cancel a MoveTables VReplication workflow.
-* [vtctldclient MoveTables complete](./vtctldclient_movetables_complete/)	 - Complete a MoveTables VReplication workflow.
-* [vtctldclient MoveTables create](./vtctldclient_movetables_create/)	 - Create and optionally run a MoveTables VReplication workflow.
-* [vtctldclient MoveTables reversetraffic](./vtctldclient_movetables_reversetraffic/)	 - Reverse traffic for a MoveTables VReplication workflow.
-* [vtctldclient MoveTables show](./vtctldclient_movetables_show/)	 - Show the details for a MoveTables VReplication workflow.
-* [vtctldclient MoveTables start](./vtctldclient_movetables_start/)	 - Start the MoveTables workflow.
-* [vtctldclient MoveTables status](./vtctldclient_movetables_status/)	 - Show the current status for a MoveTables VReplication workflow.
-* [vtctldclient MoveTables stop](./vtctldclient_movetables_stop/)	 - Stop a MoveTables workflow.
-* [vtctldclient MoveTables switchtraffic](./vtctldclient_movetables_switchtraffic/)	 - Switch traffic for a MoveTables VReplication workflow.
+* [vtctldclient MoveTables Cancel](./vtctldclient_movetables_cancel/)	 - Cancel a moveTables VReplication workflow.
+* [vtctldclient MoveTables Complete](./vtctldclient_movetables_complete/)	 - Complete a MoveTables VReplication workflow.
+* [vtctldclient MoveTables Create](./vtctldclient_movetables_create/)	 - Create and optionally run a moveTables VReplication workflow.
+* [vtctldclient MoveTables ReverseTraffic](./vtctldclient_movetables_reversetraffic/)	 - Reverse traffic for a moveTables VReplication workflow.
+* [vtctldclient MoveTables Show](./vtctldclient_movetables_show/)	 - Show the details for a moveTables VReplication workflow.
+* [vtctldclient MoveTables Start](./vtctldclient_movetables_start/)	 - Start a moveTables workflow.
+* [vtctldclient MoveTables Status](./vtctldclient_movetables_status/)	 - Show the current status for a moveTables VReplication workflow.
+* [vtctldclient MoveTables Stop](./vtctldclient_movetables_stop/)	 - Stop a moveTables workflow.
+* [vtctldclient MoveTables SwitchTraffic](./vtctldclient_movetables_switchtraffic/)	 - Switch traffic for a moveTables VReplication workflow.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -14,10 +14,10 @@ See the --help output for each command for more details.
 ### Options
 
 ```
-      --format string            The format of the output; supported formats are: text,json (default "text")
+      --format string            The format of the output; supported formats are: text,json. (default "text")
   -h, --help                     help for MoveTables
-      --target-keyspace string   Target keyspace for this workflow exists (required)
-  -w, --workflow string          The workflow you want to perform the command on (required)
+      --target-keyspace string   Target keyspace for this workflow exists (required).
+  -w, --workflow string          The workflow you want to perform the command on (required).
 ```
 
 ### Options inherited from parent commands
@@ -30,13 +30,13 @@ See the --help output for each command for more details.
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient MoveTables Cancel](./vtctldclient_movetables_cancel/)	 - Cancel a moveTables VReplication workflow.
-* [vtctldclient MoveTables Complete](./vtctldclient_movetables_complete/)	 - Complete a MoveTables VReplication workflow.
-* [vtctldclient MoveTables Create](./vtctldclient_movetables_create/)	 - Create and optionally run a moveTables VReplication workflow.
-* [vtctldclient MoveTables ReverseTraffic](./vtctldclient_movetables_reversetraffic/)	 - Reverse traffic for a moveTables VReplication workflow.
-* [vtctldclient MoveTables Show](./vtctldclient_movetables_show/)	 - Show the details for a moveTables VReplication workflow.
-* [vtctldclient MoveTables Start](./vtctldclient_movetables_start/)	 - Start a moveTables workflow.
-* [vtctldclient MoveTables Status](./vtctldclient_movetables_status/)	 - Show the current status for a moveTables VReplication workflow.
-* [vtctldclient MoveTables Stop](./vtctldclient_movetables_stop/)	 - Stop a moveTables workflow.
-* [vtctldclient MoveTables SwitchTraffic](./vtctldclient_movetables_switchtraffic/)	 - Switch traffic for a moveTables VReplication workflow.
+* [vtctldclient MoveTables cancel](./vtctldclient_movetables_cancel/)	 - Cancel a MoveTables VReplication workflow.
+* [vtctldclient MoveTables complete](./vtctldclient_movetables_complete/)	 - Complete a MoveTables VReplication workflow.
+* [vtctldclient MoveTables create](./vtctldclient_movetables_create/)	 - Create and optionally run a moveTables VReplication workflow.
+* [vtctldclient MoveTables reversetraffic](./vtctldclient_movetables_reversetraffic/)	 - Reverse traffic for a MoveTables VReplication workflow.
+* [vtctldclient MoveTables show](./vtctldclient_movetables_show/)	 - Show the details for a MoveTables VReplication workflow.
+* [vtctldclient MoveTables start](./vtctldclient_movetables_start/)	 - Start a MoveTables workflow.
+* [vtctldclient MoveTables status](./vtctldclient_movetables_status/)	 - Show the current status for a MoveTables VReplication workflow.
+* [vtctldclient MoveTables stop](./vtctldclient_movetables_stop/)	 - Stop a MoveTables workflow.
+* [vtctldclient MoveTables switchtraffic](./vtctldclient_movetables_switchtraffic/)	 - Switch traffic for a MoveTables VReplication workflow.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,27 +1,25 @@
 ---
-title: MoveTables cancel
+title: MoveTables Cancel
 series: vtctldclient
 ---
-## vtctldclient MoveTables cancel
+## vtctldclient MoveTables Cancel
 
-Cancel a MoveTables VReplication workflow.
+Cancel a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables cancel
+vtctldclient MoveTables Cancel
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer cancel
+vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer cancel
 ```
 
 ### Options
 
 ```
-  -h, --help                 help for cancel
-      --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace
-      --keep-routing-rules   Keep the routing rules created for the MoveTables workflow
+  -h, --help   help for Cancel
 ```
 
 ### Options inherited from parent commands
@@ -29,7 +27,6 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables Cancel
+title: MoveTables cancel
 series: vtctldclient
 ---
-## vtctldclient MoveTables Cancel
+## vtctldclient MoveTables cancel
 
-Cancel a moveTables VReplication workflow.
+Cancel a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Cancel
+vtctldclient MoveTables cancel
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer cancel
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer cancel
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Cancel
+  -h, --help   help for cancel
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,13 +1,13 @@
 ---
-title: MoveTables Complete
+title: MoveTables complete
 series: vtctldclient
 ---
-## vtctldclient MoveTables Complete
+## vtctldclient MoveTables complete
 
 Complete a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Complete
+vtctldclient MoveTables complete
 ```
 
 ### Examples
@@ -19,7 +19,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for Complete
+  -h, --help   help for complete
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,13 +1,13 @@
 ---
-title: MoveTables create
+title: MoveTables Create
 series: vtctldclient
 ---
-## vtctldclient MoveTables create
+## vtctldclient MoveTables Create
 
-Create and optionally run a MoveTables VReplication workflow.
+Create and optionally run a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables create
+vtctldclient MoveTables Create
 ```
 
 ### Examples
@@ -20,15 +20,16 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 
 ```
       --all-tables                         Copy all tables from the source
+      --atomic-copy                        (EXPERIMENTAL) A single copy phase is run for all tables from the source. Use this, for example, if your source keyspace has tables which use foreign key constraints.
       --auto-start                         Start the MoveTables workflow after creating it (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from
       --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied
       --exclude-tables strings             Source tables to exclude from copying
-  -h, --help                               help for create
+  -h, --help                               help for Create
       --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE (default "IGNORE")
       --source-keyspace string             Keyspace where the tables are being moved from (required)
-      --source-shards strings              Source shards to copy data from when performing a partial MoveTables (experimental)
+      --source-shards strings              Source shards to copy data from when performing a partial moveTables (experimental)
       --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC
       --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes
       --tables strings                     Source tables to copy
@@ -41,7 +42,6 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,13 +1,13 @@
 ---
-title: MoveTables Create
+title: MoveTables create
 series: vtctldclient
 ---
-## vtctldclient MoveTables Create
+## vtctldclient MoveTables create
 
 Create and optionally run a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Create
+vtctldclient MoveTables create
 ```
 
 ### Examples
@@ -19,22 +19,22 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options
 
 ```
-      --all-tables                         Copy all tables from the source
+      --all-tables                         Copy all tables from the source.
       --atomic-copy                        (EXPERIMENTAL) A single copy phase is run for all tables from the source. Use this, for example, if your source keyspace has tables which use foreign key constraints.
-      --auto-start                         Start the MoveTables workflow after creating it (default true)
-  -c, --cells strings                      Cells and/or CellAliases to copy table data from
-      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied
-      --exclude-tables strings             Source tables to exclude from copying
-  -h, --help                               help for Create
+      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+      --exclude-tables strings             Source tables to exclude from copying.
+  -h, --help                               help for create
       --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
-      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE (default "IGNORE")
-      --source-keyspace string             Keyspace where the tables are being moved from (required)
-      --source-shards strings              Source shards to copy data from when performing a partial moveTables (experimental)
-      --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes
-      --tables strings                     Source tables to copy
-      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY)
-      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag (default true)
+      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
+      --source-keyspace string             Keyspace where the tables are being moved from (required).
+      --source-shards strings              Source shards to copy data from when performing a partial moveTables (experimental).
+      --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC.
+      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --tables strings                     Source tables to copy.
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,30 +1,30 @@
 ---
-title: MoveTables ReverseTraffic
+title: MoveTables reversetraffic
 series: vtctldclient
 ---
-## vtctldclient MoveTables ReverseTraffic
+## vtctldclient MoveTables reversetraffic
 
-Reverse traffic for a moveTables VReplication workflow.
+Reverse traffic for a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables ReverseTraffic
+vtctldclient MoveTables reversetraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer reversetraffic
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer reversetraffic
 ```
 
 ### Options
 
 ```
-  -c, --cells strings                          Cells and/or CellAliases to switch traffic in
-      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
-      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for ReverseTraffic
-      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
-      --tablet-types strings                   Tablet types to switch traffic for
+  -c, --cells strings                          Cells and/or CellAliases to switch traffic in.
+      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred.
+      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
+  -h, --help                                   help for reversetraffic
+      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables show
+title: MoveTables Show
 series: vtctldclient
 ---
-## vtctldclient MoveTables show
+## vtctldclient MoveTables Show
 
-Show the details for a MoveTables VReplication workflow.
+Show the details for a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables show
+vtctldclient MoveTables Show
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer show
+vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer show
 ```
 
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help   help for Show
 ```
 
 ### Options inherited from parent commands
@@ -27,7 +27,6 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables Show
+title: MoveTables show
 series: vtctldclient
 ---
-## vtctldclient MoveTables Show
+## vtctldclient MoveTables show
 
-Show the details for a moveTables VReplication workflow.
+Show the details for a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Show
+vtctldclient MoveTables show
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer show
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer show
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Show
+  -h, --help   help for show
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables Start
+title: MoveTables start
 series: vtctldclient
 ---
-## vtctldclient MoveTables Start
+## vtctldclient MoveTables start
 
-Start a moveTables workflow.
+Start a MoveTables workflow.
 
 ```
-vtctldclient MoveTables Start
+vtctldclient MoveTables start
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer start
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer start
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Start
+  -h, --help   help for start
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables start
+title: MoveTables Start
 series: vtctldclient
 ---
-## vtctldclient MoveTables start
+## vtctldclient MoveTables Start
 
-Start the MoveTables workflow.
+Start a moveTables workflow.
 
 ```
-vtctldclient MoveTables start
+vtctldclient MoveTables Start
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer start
+vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer start
 ```
 
 ### Options
 
 ```
-  -h, --help   help for start
+  -h, --help   help for Start
 ```
 
 ### Options inherited from parent commands
@@ -27,7 +27,6 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables Status
+title: MoveTables status
 series: vtctldclient
 ---
-## vtctldclient MoveTables Status
+## vtctldclient MoveTables status
 
-Show the current status for a moveTables VReplication workflow.
+Show the current status for a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Status
+vtctldclient MoveTables status
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer status
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer status
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Status
+  -h, --help   help for status
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables status
+title: MoveTables Status
 series: vtctldclient
 ---
-## vtctldclient MoveTables status
+## vtctldclient MoveTables Status
 
-Show the current status for a MoveTables VReplication workflow.
+Show the current status for a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables status
+vtctldclient MoveTables Status
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer status
+vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer status
 ```
 
 ### Options
 
 ```
-  -h, --help   help for status
+  -h, --help   help for Status
 ```
 
 ### Options inherited from parent commands
@@ -27,7 +27,6 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,25 +1,25 @@
 ---
-title: MoveTables Stop
+title: MoveTables stop
 series: vtctldclient
 ---
-## vtctldclient MoveTables Stop
+## vtctldclient MoveTables stop
 
-Stop a moveTables workflow.
+Stop a MoveTables workflow.
 
 ```
-vtctldclient MoveTables Stop
+vtctldclient MoveTables stop
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer stop
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer stop
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Stop
+  -h, --help   help for stop
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,31 +1,31 @@
 ---
-title: MoveTables SwitchTraffic
+title: MoveTables switchtraffic
 series: vtctldclient
 ---
-## vtctldclient MoveTables SwitchTraffic
+## vtctldclient MoveTables switchtraffic
 
-Switch traffic for a moveTables VReplication workflow.
+Switch traffic for a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables SwitchTraffic
+vtctldclient MoveTables switchtraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
 ```
 
 ### Options
 
 ```
-  -c, --cells strings                          Cells and/or CellAliases to switch traffic in
-      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
-      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for SwitchTraffic
+  -c, --cells strings                          Cells and/or CellAliases to switch traffic in.
+      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred.
+      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
+  -h, --help                                   help for switchtraffic
       --initialize-target-sequences            When moving tables from an unsharded keyspace to a sharded keyspace, initialize any sequences that are being used on the target when switching writes.
-      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
-      --tablet-types strings                   Tablet types to switch traffic for
+      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,19 +1,19 @@
 ---
-title: MoveTables switchtraffic
+title: MoveTables SwitchTraffic
 series: vtctldclient
 ---
-## vtctldclient MoveTables switchtraffic
+## vtctldclient MoveTables SwitchTraffic
 
-Switch traffic for a MoveTables VReplication workflow.
+Switch traffic for a moveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables switchtraffic
+vtctldclient MoveTables SwitchTraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
+vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
 ```
 
 ### Options
@@ -22,7 +22,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
   -c, --cells strings                          Cells and/or CellAliases to switch traffic in
       --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
       --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for switchtraffic
+  -h, --help                                   help for SwitchTraffic
       --initialize-target-sequences            When moving tables from an unsharded keyspace to a sharded keyspace, initialize any sequences that are being used on the target when switching writes.
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
       --tablet-types strings                   Tablet types to switch traffic for
@@ -34,7 +34,6 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
-      --target-keyspace string    Keyspace where the tables are being moved to and where the workflow exists (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -22,10 +22,10 @@ Operates on online DDL (schema migrations).
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient OnlineDDL cancel](./vtctldclient_onlineddl_cancel/)	 - Cancel one or all pending migrations, terminating any actively running ones.
+* [vtctldclient OnlineDDL cancel](./vtctldclient_onlineddl_cancel/)	 - cancel one or all migrations, terminating any running ones as needed.
 * [vtctldclient OnlineDDL cleanup](./vtctldclient_onlineddl_cleanup/)	 - Mark a given schema migration ready for artifact cleanup.
-* [vtctldclient OnlineDDL complete](./vtctldclient_onlineddl_complete/)	 - Complete one or all migrations executed with `--postpone-completion`.
-* [vtctldclient OnlineDDL launch](./vtctldclient_onlineddl_launch/)	 - Launch one or all migrations executed with `--postpone-launch`.
+* [vtctldclient OnlineDDL complete](./vtctldclient_onlineddl_complete/)	 - complete one or all migrations executed with --postpone-completion
+* [vtctldclient OnlineDDL launch](./vtctldclient_onlineddl_launch/)	 - launch one or all migrations executed with --postpone-launch
 * [vtctldclient OnlineDDL retry](./vtctldclient_onlineddl_retry/)	 - Mark a given schema migration for retry.
 * [vtctldclient OnlineDDL show](./vtctldclient_onlineddl_show/)	 - Display information about online DDL operations.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -4,7 +4,7 @@ series: vtctldclient
 ---
 ## vtctldclient OnlineDDL cancel
 
-Cancel one or all pending migrations, terminating any actively running ones.
+cancel one or all migrations, terminating any running ones as needed.
 
 ```
 vtctldclient OnlineDDL cancel <keyspace> <uuid|all>
@@ -14,7 +14,6 @@ vtctldclient OnlineDDL cancel <keyspace> <uuid|all>
 
 ```
 OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
-OnlineDDL cancel test_keyspace all
 ```
 
 ### Options

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -4,7 +4,7 @@ series: vtctldclient
 ---
 ## vtctldclient OnlineDDL complete
 
-Complete one or all migrations executed with `--postpone-completion`.
+complete one or all migrations executed with --postpone-completion
 
 ```
 vtctldclient OnlineDDL complete <keyspace> <uuid|all>
@@ -14,7 +14,6 @@ vtctldclient OnlineDDL complete <keyspace> <uuid|all>
 
 ```
 OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
-OnlineDDL complete test_keyspace all
 ```
 
 ### Options

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -4,7 +4,7 @@ series: vtctldclient
 ---
 ## vtctldclient OnlineDDL launch
 
-Launch one or all migrations executed with `--postpone-launch`.
+launch one or all migrations executed with --postpone-launch
 
 ```
 vtctldclient OnlineDDL launch <keyspace> <uuid|all>
@@ -14,7 +14,6 @@ vtctldclient OnlineDDL launch <keyspace> <uuid|all>
 
 ```
 OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
-OnlineDDL launch test_keyspace all
 ```
 
 ### Options

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -14,10 +14,10 @@ See the --help output for each command for more details.
 ### Options
 
 ```
-      --format string            The format of the output; supported formats are: text,json (default "text")
+      --format string            The format of the output; supported formats are: text,json. (default "text")
   -h, --help                     help for Reshard
-      --target-keyspace string   Target keyspace for this workflow exists (required)
-  -w, --workflow string          The workflow you want to perform the command on (required)
+      --target-keyspace string   Target keyspace for this workflow exists (required).
+  -w, --workflow string          The workflow you want to perform the command on (required).
 ```
 
 ### Options inherited from parent commands
@@ -30,13 +30,13 @@ See the --help output for each command for more details.
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient Reshard Cancel](./vtctldclient_reshard_cancel/)	 - Cancel a reshard VReplication workflow.
-* [vtctldclient Reshard Complete](./vtctldclient_reshard_complete/)	 - Complete a MoveTables VReplication workflow.
-* [vtctldclient Reshard Create](./vtctldclient_reshard_create/)	 - Create and optionally run a reshard VReplication workflow.
-* [vtctldclient Reshard ReverseTraffic](./vtctldclient_reshard_reversetraffic/)	 - Reverse traffic for a reshard VReplication workflow.
-* [vtctldclient Reshard Show](./vtctldclient_reshard_show/)	 - Show the details for a reshard VReplication workflow.
-* [vtctldclient Reshard Start](./vtctldclient_reshard_start/)	 - Start a reshard workflow.
-* [vtctldclient Reshard Status](./vtctldclient_reshard_status/)	 - Show the current status for a reshard VReplication workflow.
-* [vtctldclient Reshard Stop](./vtctldclient_reshard_stop/)	 - Stop a reshard workflow.
-* [vtctldclient Reshard SwitchTraffic](./vtctldclient_reshard_switchtraffic/)	 - Switch traffic for a reshard VReplication workflow.
+* [vtctldclient Reshard cancel](./vtctldclient_reshard_cancel/)	 - Cancel a Reshard VReplication workflow.
+* [vtctldclient Reshard complete](./vtctldclient_reshard_complete/)	 - Complete a MoveTables VReplication workflow.
+* [vtctldclient Reshard create](./vtctldclient_reshard_create/)	 - Create and optionally run a reshard VReplication workflow.
+* [vtctldclient Reshard reversetraffic](./vtctldclient_reshard_reversetraffic/)	 - Reverse traffic for a Reshard VReplication workflow.
+* [vtctldclient Reshard show](./vtctldclient_reshard_show/)	 - Show the details for a Reshard VReplication workflow.
+* [vtctldclient Reshard start](./vtctldclient_reshard_start/)	 - Start a Reshard workflow.
+* [vtctldclient Reshard status](./vtctldclient_reshard_status/)	 - Show the current status for a Reshard VReplication workflow.
+* [vtctldclient Reshard stop](./vtctldclient_reshard_stop/)	 - Stop a Reshard workflow.
+* [vtctldclient Reshard switchtraffic](./vtctldclient_reshard_switchtraffic/)	 - Switch traffic for a Reshard VReplication workflow.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,0 +1,42 @@
+---
+title: Reshard
+series: vtctldclient
+---
+## vtctldclient Reshard
+
+Perform commands related to resharding a keyspace.
+
+### Synopsis
+
+Reshard commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
+See the --help output for each command for more details.
+
+### Options
+
+```
+      --format string            The format of the output; supported formats are: text,json (default "text")
+  -h, --help                     help for Reshard
+      --target-keyspace string   Target keyspace for this workflow exists (required)
+  -w, --workflow string          The workflow you want to perform the command on (required)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Reshard Cancel](./vtctldclient_reshard_cancel/)	 - Cancel a reshard VReplication workflow.
+* [vtctldclient Reshard Complete](./vtctldclient_reshard_complete/)	 - Complete a MoveTables VReplication workflow.
+* [vtctldclient Reshard Create](./vtctldclient_reshard_create/)	 - Create and optionally run a reshard VReplication workflow.
+* [vtctldclient Reshard ReverseTraffic](./vtctldclient_reshard_reversetraffic/)	 - Reverse traffic for a reshard VReplication workflow.
+* [vtctldclient Reshard Show](./vtctldclient_reshard_show/)	 - Show the details for a reshard VReplication workflow.
+* [vtctldclient Reshard Start](./vtctldclient_reshard_start/)	 - Start a reshard workflow.
+* [vtctldclient Reshard Status](./vtctldclient_reshard_status/)	 - Show the current status for a reshard VReplication workflow.
+* [vtctldclient Reshard Stop](./vtctldclient_reshard_stop/)	 - Stop a reshard workflow.
+* [vtctldclient Reshard SwitchTraffic](./vtctldclient_reshard_switchtraffic/)	 - Switch traffic for a reshard VReplication workflow.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Cancel.md
@@ -1,0 +1,35 @@
+---
+title: Reshard Cancel
+series: vtctldclient
+---
+## vtctldclient Reshard Cancel
+
+Cancel a reshard VReplication workflow.
+
+```
+vtctldclient Reshard Cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for Cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Cancel.md
@@ -1,25 +1,25 @@
 ---
-title: Reshard Cancel
+title: Reshard cancel
 series: vtctldclient
 ---
-## vtctldclient Reshard Cancel
+## vtctldclient Reshard cancel
 
-Cancel a reshard VReplication workflow.
+Cancel a Reshard VReplication workflow.
 
 ```
-vtctldclient Reshard Cancel
+vtctldclient Reshard cancel
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer cancel
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer cancel
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Cancel
+  -h, --help   help for cancel
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Complete.md
@@ -1,13 +1,13 @@
 ---
-title: MoveTables Complete
+title: Reshard Complete
 series: vtctldclient
 ---
-## vtctldclient MoveTables Complete
+## vtctldclient Reshard Complete
 
 Complete a MoveTables VReplication workflow.
 
 ```
-vtctldclient MoveTables Complete
+vtctldclient Reshard Complete
 ```
 
 ### Examples
@@ -31,5 +31,5 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 
 ### SEE ALSO
 
-* [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Complete.md
@@ -1,13 +1,13 @@
 ---
-title: Reshard Complete
+title: Reshard complete
 series: vtctldclient
 ---
-## vtctldclient Reshard Complete
+## vtctldclient Reshard complete
 
 Complete a MoveTables VReplication workflow.
 
 ```
-vtctldclient Reshard Complete
+vtctldclient Reshard complete
 ```
 
 ### Examples
@@ -19,7 +19,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for Complete
+  -h, --help   help for complete
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Create.md
@@ -1,0 +1,45 @@
+---
+title: Reshard Create
+series: vtctldclient
+---
+## vtctldclient Reshard Create
+
+Create and optionally run a reshard VReplication workflow.
+
+```
+vtctldclient Reshard Create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 reshard --workflow customer2customer --target-keyspace customer create --source_shards="0" --target_shards="-80,80-" --cells zone1 --cells zone2 --tablet-types replica
+```
+
+### Options
+
+```
+      --auto-start                         Start the MoveTables workflow after creating it (default true)
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied
+  -h, --help                               help for Create
+      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE (default "IGNORE")
+      --skip-schema-copy                   Skip copying the schema from the source shards to the target shards.
+      --source-shards strings              Comma-separated list of source shards.
+      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY)
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag (default true)
+      --target-shards strings              Comma-separated list of target shards.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Create.md
@@ -1,13 +1,13 @@
 ---
-title: Reshard Create
+title: Reshard create
 series: vtctldclient
 ---
-## vtctldclient Reshard Create
+## vtctldclient Reshard create
 
 Create and optionally run a reshard VReplication workflow.
 
 ```
-vtctldclient Reshard Create
+vtctldclient Reshard create
 ```
 
 ### Examples
@@ -19,17 +19,17 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
 ### Options
 
 ```
-      --auto-start                         Start the MoveTables workflow after creating it (default true)
-  -c, --cells strings                      Cells and/or CellAliases to copy table data from
-      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied
-  -h, --help                               help for Create
-      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE (default "IGNORE")
+      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+  -h, --help                               help for create
+      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --skip-schema-copy                   Skip copying the schema from the source shards to the target shards.
-      --source-shards strings              Comma-separated list of source shards.
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes
-      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY)
-      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag (default true)
-      --target-shards strings              Comma-separated list of target shards.
+      --source-shards strings              Source shards.
+      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+      --target-shards strings              Target shards.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_ReverseTraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_ReverseTraffic.md
@@ -1,30 +1,30 @@
 ---
-title: Reshard ReverseTraffic
+title: Reshard reversetraffic
 series: vtctldclient
 ---
-## vtctldclient Reshard ReverseTraffic
+## vtctldclient Reshard reversetraffic
 
-Reverse traffic for a reshard VReplication workflow.
+Reverse traffic for a Reshard VReplication workflow.
 
 ```
-vtctldclient Reshard ReverseTraffic
+vtctldclient Reshard reversetraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer reversetraffic
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer reversetraffic
 ```
 
 ### Options
 
 ```
-  -c, --cells strings                          Cells and/or CellAliases to switch traffic in
-      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
-      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for ReverseTraffic
-      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
-      --tablet-types strings                   Tablet types to switch traffic for
+  -c, --cells strings                          Cells and/or CellAliases to switch traffic in.
+      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred.
+      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
+  -h, --help                                   help for reversetraffic
+      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_ReverseTraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_ReverseTraffic.md
@@ -1,19 +1,19 @@
 ---
-title: MoveTables ReverseTraffic
+title: Reshard ReverseTraffic
 series: vtctldclient
 ---
-## vtctldclient MoveTables ReverseTraffic
+## vtctldclient Reshard ReverseTraffic
 
-Reverse traffic for a moveTables VReplication workflow.
+Reverse traffic for a reshard VReplication workflow.
 
 ```
-vtctldclient MoveTables ReverseTraffic
+vtctldclient Reshard ReverseTraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer reversetraffic
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer reversetraffic
 ```
 
 ### Options
@@ -37,5 +37,5 @@ vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-k
 
 ### SEE ALSO
 
-* [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Show.md
@@ -1,0 +1,35 @@
+---
+title: Reshard Show
+series: vtctldclient
+---
+## vtctldclient Reshard Show
+
+Show the details for a reshard VReplication workflow.
+
+```
+vtctldclient Reshard Show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help   help for Show
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Show.md
@@ -1,25 +1,25 @@
 ---
-title: Reshard Show
+title: Reshard show
 series: vtctldclient
 ---
-## vtctldclient Reshard Show
+## vtctldclient Reshard show
 
-Show the details for a reshard VReplication workflow.
+Show the details for a Reshard VReplication workflow.
 
 ```
-vtctldclient Reshard Show
+vtctldclient Reshard show
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer show
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer show
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Show
+  -h, --help   help for show
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Start.md
@@ -1,25 +1,25 @@
 ---
-title: Reshard Start
+title: Reshard start
 series: vtctldclient
 ---
-## vtctldclient Reshard Start
+## vtctldclient Reshard start
 
-Start a reshard workflow.
+Start a Reshard workflow.
 
 ```
-vtctldclient Reshard Start
+vtctldclient Reshard start
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer start
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer start
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Start
+  -h, --help   help for start
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Start.md
@@ -1,0 +1,35 @@
+---
+title: Reshard Start
+series: vtctldclient
+---
+## vtctldclient Reshard Start
+
+Start a reshard workflow.
+
+```
+vtctldclient Reshard Start
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer start
+```
+
+### Options
+
+```
+  -h, --help   help for Start
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Status.md
@@ -1,0 +1,35 @@
+---
+title: Reshard Status
+series: vtctldclient
+---
+## vtctldclient Reshard Status
+
+Show the current status for a reshard VReplication workflow.
+
+```
+vtctldclient Reshard Status
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer status
+```
+
+### Options
+
+```
+  -h, --help   help for Status
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Status.md
@@ -1,25 +1,25 @@
 ---
-title: Reshard Status
+title: Reshard status
 series: vtctldclient
 ---
-## vtctldclient Reshard Status
+## vtctldclient Reshard status
 
-Show the current status for a reshard VReplication workflow.
+Show the current status for a Reshard VReplication workflow.
 
 ```
-vtctldclient Reshard Status
+vtctldclient Reshard status
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer status
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer status
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Status
+  -h, --help   help for status
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Stop.md
@@ -1,19 +1,19 @@
 ---
-title: MoveTables Stop
+title: Reshard Stop
 series: vtctldclient
 ---
-## vtctldclient MoveTables Stop
+## vtctldclient Reshard Stop
 
-Stop a moveTables workflow.
+Stop a reshard workflow.
 
 ```
-vtctldclient MoveTables Stop
+vtctldclient Reshard Stop
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer stop
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer stop
 ```
 
 ### Options
@@ -31,5 +31,5 @@ vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-k
 
 ### SEE ALSO
 
-* [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_Stop.md
@@ -1,25 +1,25 @@
 ---
-title: Reshard Stop
+title: Reshard stop
 series: vtctldclient
 ---
-## vtctldclient Reshard Stop
+## vtctldclient Reshard stop
 
-Stop a reshard workflow.
+Stop a Reshard workflow.
 
 ```
-vtctldclient Reshard Stop
+vtctldclient Reshard stop
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer stop
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer stop
 ```
 
 ### Options
 
 ```
-  -h, --help   help for Stop
+  -h, --help   help for stop
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_SwitchTraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_SwitchTraffic.md
@@ -1,30 +1,30 @@
 ---
-title: Reshard SwitchTraffic
+title: Reshard switchtraffic
 series: vtctldclient
 ---
-## vtctldclient Reshard SwitchTraffic
+## vtctldclient Reshard switchtraffic
 
-Switch traffic for a reshard VReplication workflow.
+Switch traffic for a Reshard VReplication workflow.
 
 ```
-vtctldclient Reshard SwitchTraffic
+vtctldclient Reshard switchtraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
 ```
 
 ### Options
 
 ```
-  -c, --cells strings                          Cells and/or CellAliases to switch traffic in
-      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
-      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for SwitchTraffic
-      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
-      --tablet-types strings                   Tablet types to switch traffic for
+  -c, --cells strings                          Cells and/or CellAliases to switch traffic in.
+      --dry-run                                Print the actions that would be taken and report any known errors that would have occurred.
+      --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
+  -h, --help                                   help for switchtraffic
+      --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_SwitchTraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_SwitchTraffic.md
@@ -1,19 +1,19 @@
 ---
-title: MoveTables ReverseTraffic
+title: Reshard SwitchTraffic
 series: vtctldclient
 ---
-## vtctldclient MoveTables ReverseTraffic
+## vtctldclient Reshard SwitchTraffic
 
-Reverse traffic for a moveTables VReplication workflow.
+Switch traffic for a reshard VReplication workflow.
 
 ```
-vtctldclient MoveTables ReverseTraffic
+vtctldclient Reshard SwitchTraffic
 ```
 
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-keyspace customer reversetraffic
+vtctldclient --server localhost:15999 reshard --workflow cust2cust --target-keyspace customer switchtraffic --tablet-types "replica,rdonly"
 ```
 
 ### Options
@@ -22,7 +22,7 @@ vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-k
   -c, --cells strings                          Cells and/or CellAliases to switch traffic in
       --dry-run                                Print the actions that would be taken and report any known errors that would have occurred
       --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover (default true)
-  -h, --help                                   help for ReverseTraffic
+  -h, --help                                   help for SwitchTraffic
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this (default 30s)
       --tablet-types strings                   Tablet types to switch traffic for
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
@@ -37,5 +37,5 @@ vtctldclient --server localhost:15999 moveTables --workflow cust2cust --target-k
 
 ### SEE ALSO
 
-* [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
+* [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -19,7 +19,7 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
 
 ```
   -h, --help              help for Workflow
-  -k, --keyspace string   Keyspace context for the workflow (required)
+  -k, --keyspace string   Keyspace context for the workflow (required).
 ```
 
 ### Options inherited from parent commands
@@ -32,10 +32,10 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient Workflow Delete](./vtctldclient_workflow_delete/)	 - Delete a VReplication workflow.
-* [vtctldclient Workflow List](./vtctldclient_workflow_list/)	 - List the VReplication workflows in the given keyspace.
-* [vtctldclient Workflow Start](./vtctldclient_workflow_start/)	 - Start a VReplication workflow.
-* [vtctldclient Workflow Update](./vtctldclient_workflow_update/)	 - Update the configuration parameters for a VReplication workflow.
+* [vtctldclient Workflow delete](./vtctldclient_workflow_delete/)	 - Delete a VReplication workflow.
+* [vtctldclient Workflow list](./vtctldclient_workflow_list/)	 - List the VReplication workflows in the given keyspace.
 * [vtctldclient Workflow show](./vtctldclient_workflow_show/)	 - Show the details for a VReplication workflow.
+* [vtctldclient Workflow start](./vtctldclient_workflow_start/)	 - Start a VReplication workflow.
 * [vtctldclient Workflow stop](./vtctldclient_workflow_stop/)	 - Stop a VReplication workflow.
+* [vtctldclient Workflow update](./vtctldclient_workflow_update/)	 - Update the configuration parameters for a VReplication workflow.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -32,10 +32,10 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
-* [vtctldclient Workflow delete](./vtctldclient_workflow_delete/)	 - Delete a VReplication workflow.
-* [vtctldclient Workflow list](./vtctldclient_workflow_list/)	 - List the VReplication workflows in the given keyspace.
+* [vtctldclient Workflow Delete](./vtctldclient_workflow_delete/)	 - Delete a VReplication workflow.
+* [vtctldclient Workflow List](./vtctldclient_workflow_list/)	 - List the VReplication workflows in the given keyspace.
+* [vtctldclient Workflow Start](./vtctldclient_workflow_start/)	 - Start a VReplication workflow.
+* [vtctldclient Workflow Update](./vtctldclient_workflow_update/)	 - Update the configuration parameters for a VReplication workflow.
 * [vtctldclient Workflow show](./vtctldclient_workflow_show/)	 - Show the details for a VReplication workflow.
-* [vtctldclient Workflow start](./vtctldclient_workflow_start/)	 - Start a VReplication workflow.
 * [vtctldclient Workflow stop](./vtctldclient_workflow_stop/)	 - Stop a VReplication workflow.
-* [vtctldclient Workflow update](./vtctldclient_workflow_update/)	 - Update the configuration parameters for a VReplication workflow.
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow delete
+title: Workflow Delete
 series: vtctldclient
 ---
-## vtctldclient Workflow delete
+## vtctldclient Workflow Delete
 
 Delete a VReplication workflow.
 
 ```
-vtctldclient Workflow delete
+vtctldclient Workflow Delete
 ```
 
 ### Examples
@@ -19,7 +19,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
 ### Options
 
 ```
-  -h, --help                 help for delete
+  -h, --help                 help for Delete
       --keep-data            Keep the partially copied table data from the workflow in the target keyspace
       --keep-routing-rules   Keep the routing rules created for the workflow
   -w, --workflow string      The workflow you want to delete (required)

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow Delete
+title: Workflow delete
 series: vtctldclient
 ---
-## vtctldclient Workflow Delete
+## vtctldclient Workflow delete
 
 Delete a VReplication workflow.
 
 ```
-vtctldclient Workflow Delete
+vtctldclient Workflow delete
 ```
 
 ### Examples
@@ -19,17 +19,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
 ### Options
 
 ```
-  -h, --help                 help for Delete
-      --keep-data            Keep the partially copied table data from the workflow in the target keyspace
-      --keep-routing-rules   Keep the routing rules created for the workflow
-  -w, --workflow string      The workflow you want to delete (required)
+  -h, --help                 help for delete
+      --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
+      --keep-routing-rules   Keep the routing rules created for the workflow.
+  -w, --workflow string      The workflow you want to delete (required).
 ```
 
 ### Options inherited from parent commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow list
+title: Workflow List
 series: vtctldclient
 ---
-## vtctldclient Workflow list
+## vtctldclient Workflow List
 
 List the VReplication workflows in the given keyspace.
 
 ```
-vtctldclient Workflow list
+vtctldclient Workflow List
 ```
 
 ### Examples
@@ -19,7 +19,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options
 
 ```
-  -h, --help   help for list
+  -h, --help   help for List
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow List
+title: Workflow list
 series: vtctldclient
 ---
-## vtctldclient Workflow List
+## vtctldclient Workflow list
 
 List the VReplication workflows in the given keyspace.
 
 ```
-vtctldclient Workflow List
+vtctldclient Workflow list
 ```
 
 ### Examples
@@ -19,14 +19,14 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options
 
 ```
-  -h, --help   help for List
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -20,14 +20,14 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
 
 ```
   -h, --help              help for show
-  -w, --workflow string   The workflow you want the details for (required)
+  -w, --workflow string   The workflow you want the details for (required).
 ```
 
 ### Options inherited from parent commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow Start
+title: Workflow start
 series: vtctldclient
 ---
-## vtctldclient Workflow Start
+## vtctldclient Workflow start
 
 Start a VReplication workflow.
 
 ```
-vtctldclient Workflow Start
+vtctldclient Workflow start
 ```
 
 ### Examples
@@ -19,14 +19,14 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ### Options
 
 ```
-  -h, --help   help for Start
+  -h, --help   help for start
 ```
 
 ### Options inherited from parent commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow start
+title: Workflow Start
 series: vtctldclient
 ---
-## vtctldclient Workflow start
+## vtctldclient Workflow Start
 
 Start a VReplication workflow.
 
 ```
-vtctldclient Workflow start
+vtctldclient Workflow Start
 ```
 
 ### Examples
@@ -19,8 +19,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ### Options
 
 ```
-  -h, --help              help for start
-  -w, --workflow string   The workflow you want to start (required)
+  -h, --help   help for Start
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -19,8 +19,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 ### Options
 
 ```
-  -h, --help              help for stop
-  -w, --workflow string   The workflow you want to stop (required)
+  -h, --help   help for stop
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -26,7 +26,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow Update
+title: Workflow update
 series: vtctldclient
 ---
-## vtctldclient Workflow Update
+## vtctldclient Workflow update
 
 Update the configuration parameters for a VReplication workflow.
 
 ```
-vtctldclient Workflow Update
+vtctldclient Workflow update
 ```
 
 ### Examples
@@ -19,19 +19,19 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
 ### Options
 
 ```
-  -c, --cells strings           New Cell(s) or CellAlias(es) (comma-separated) to replicate from
-  -h, --help                    help for Update
-      --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE
-  -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY)
-      --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag (default true)
-  -w, --workflow string         The workflow you want to update (required)
+  -c, --cells strings           New Cell(s) or CellAlias(es) (comma-separated) to replicate from.
+  -h, --help                    help for update
+      --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE.
+  -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+  -w, --workflow string         The workflow you want to update (required).
 ```
 
 ### Options inherited from parent commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required)
+  -k, --keyspace string           Keyspace context for the workflow (required).
       --server string             server to use for connection (required)
 ```
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,13 +1,13 @@
 ---
-title: Workflow update
+title: Workflow Update
 series: vtctldclient
 ---
-## vtctldclient Workflow update
+## vtctldclient Workflow Update
 
 Update the configuration parameters for a VReplication workflow.
 
 ```
-vtctldclient Workflow update
+vtctldclient Workflow Update
 ```
 
 ### Examples
@@ -20,7 +20,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
 
 ```
   -c, --cells strings           New Cell(s) or CellAlias(es) (comma-separated) to replicate from
-  -h, --help                    help for update
+  -h, --help                    help for Update
       --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE
   -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY)
       --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag (default true)


### PR DESCRIPTION
Regenerate docs based on the changes in https://github.com/vitessio/vitess/pull/13792. 

There are also additional changes related to OnlineDDL, which presumably have been missed, since all OnlineDDL vtctldclient PRs have been ported over.

