### PR TITLE
Update the Approving a Pull Request doc

### DIFF
--- a/content/en/docs/contributing/code-reviews.md
+++ b/content/en/docs/contributing/code-reviews.md
@@ -100,10 +100,7 @@ all the items on the checklist are satisfied.
 
 ## Approving a Pull Request
 
-As a reviewer you can approve a pull request through two ways:
-
-* Approve the pull request via GitHub's code review system
-* Reply with a comment that contains *LGTM*  (Looks Good To Me)
+As a reviewer you can approve a Pull Request via GitHub's code review system.
 
 ## Merging a Pull Request
 


### PR DESCRIPTION
There is only one way of approving Pull Requests on GitHub, this PR fixes the docs which is misleading.