### PR TITLE
update docs after explicitly allowing bind addressed in servenv 

### DIFF
--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/_index.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/_index.md
@@ -1,6 +1,7 @@
 ---
 title: workflow
 series: vtctldclient
+commit: dced85dd0f33b8bd95d37adb781d6cdc1949af92
 ---
 ## vtctldclient workflow
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_update.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_update.md
@@ -1,6 +1,7 @@
 ---
-title: workflow_update
+title: workflow update
 series: vtctldclient
+commit: dced85dd0f33b8bd95d37adb781d6cdc1949af92
 ---
 ## vtctldclient workflow update
 
@@ -36,5 +37,5 @@ vtctldclient --server=localhost:15999 workflow --keyspace=customer update --work
 
 ### SEE ALSO
 
-* [vtctldclient workflow](./vtctldclient_workflow/)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace
+* [vtctldclient workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace
 

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl init
 
@@ -44,7 +44,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl init_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl position
 
@@ -27,7 +27,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl reinit_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl shutdown
 
@@ -40,7 +40,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl start
 
@@ -39,7 +39,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctl teardown
 
@@ -43,7 +43,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## mysqlctld
 
@@ -39,6 +39,7 @@ mysqlctld \
       --alsologtostderr                                                  log to standard error as well as files
       --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app_pool_size int                                                Size of the connection pool for app connections (default 40)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
@@ -81,6 +82,7 @@ mysqlctld \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtbackup
 
@@ -69,6 +69,7 @@ vtbackup [flags]
       --backup_storage_compress                                     if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                        Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                            if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --builtinbackup-file-read-buffer-size uint                    read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                   write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup_mysqld_timeout duration                       how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)

--- a/content/en/docs/18.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtcombo
 
@@ -34,6 +34,7 @@ vtcombo [flags]
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
       --binlog_password string                                           PITR restore parameter: password of binlog server.
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
@@ -159,6 +160,7 @@ vtcombo [flags]
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake

--- a/content/en/docs/18.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtctld
 
@@ -51,6 +51,7 @@ vtctld \
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
@@ -76,6 +77,7 @@ vtctld \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtgate
 
@@ -45,6 +45,7 @@ vtgate \
       --allow-kill-statement                                             Allows the execution of kill statement
       --allowed_tablet_types strings                                     Specifies the tablet types this vtgate is allowed to route queries to. Should be provided as a comma-separated set of tablet types.
       --alsologtostderr                                                  log to standard error as well as files
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --buffer_drain_concurrency int                                     Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer. (default 1)
       --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.
       --buffer_max_failover_duration duration                            Stop buffering completely if a failover takes longer than this duration. (default 20s)
@@ -88,6 +89,7 @@ vtgate \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtgateclienttest
 
@@ -15,6 +15,7 @@ vtgateclienttest [flags]
 
 ```
       --alsologtostderr                                                  log to standard error as well as files
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
@@ -27,6 +28,7 @@ vtgateclienttest [flags]
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vtorc
 
@@ -35,6 +35,7 @@ vtorc \
       --audit-purge-duration duration                               Duration for which audit logs are held before being purged. Should be in multiples of days (default 168h0m0s)
       --audit-to-backend                                            Whether to store the audit log in the VTOrc database
       --audit-to-syslog                                             Whether to store the audit log in the syslog
+      --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
       --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
       --clusters_to_watch strings                                   Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"

--- a/content/en/docs/18.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/18.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vttablet
 
@@ -74,6 +74,7 @@ vttablet \
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
       --binlog_password string                                           PITR restore parameter: password of binlog server.
       --binlog_player_grpc_ca string                                     the server ca to use to validate servers when connecting
@@ -188,6 +189,7 @@ vttablet \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/18.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## vttestserver
 
@@ -57,6 +57,7 @@ vttestserver [flags]
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## zkctl init
 
@@ -24,7 +24,7 @@ zkctl init [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## zkctl shutdown
 
@@ -24,7 +24,7 @@ zkctl shutdown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## zkctl start
 
@@ -24,7 +24,7 @@ zkctl start [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6ab165ade925b35a00cf447827d874eba13998b6
 ---
 ## zkctl teardown
 
@@ -24,7 +24,7 @@ zkctl teardown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl init
 
@@ -44,7 +44,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl init_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl position
 
@@ -27,7 +27,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl reinit_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl shutdown
 
@@ -40,7 +40,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl start
 
@@ -39,7 +39,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctl teardown
 
@@ -43,7 +43,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## mysqlctld
 
@@ -39,6 +39,7 @@ mysqlctld \
       --alsologtostderr                                                  log to standard error as well as files
       --app_idle_timeout duration                                        Idle timeout for app connections (default 1m0s)
       --app_pool_size int                                                Size of the connection pool for app connections (default 40)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
@@ -81,6 +82,7 @@ mysqlctld \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/19.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtbackup
 
@@ -69,6 +69,7 @@ vtbackup [flags]
       --backup_storage_compress                                     if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                        Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                            if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --builtinbackup-file-read-buffer-size uint                    read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                   write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup_mysqld_timeout duration                       how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)

--- a/content/en/docs/19.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtcombo
 
@@ -34,6 +34,7 @@ vtcombo [flags]
       --backup_storage_block_size int                                    if backup_storage_compress is true, backup_storage_block_size sets the byte size for each block while compressing (default is 250000). (default 250000)
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
       --binlog_password string                                           PITR restore parameter: password of binlog server.
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
@@ -159,6 +160,7 @@ vtcombo [flags]
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_crl string                                                  path to a certificate revocation list in PEM format, client certificates will be further verified against this file during TLS handshake
@@ -435,6 +437,9 @@ vtcombo [flags]
       --vtgate_grpc_server_name string                                   the server name to use to validate server certificate
       --vttablet_skip_buildinfo_tags string                              comma-separated list of buildinfo tags to skip from merging with --init_tags. each tag is either an exact match or a regular expression of the form '/regexp/'. (default "/.*/")
       --wait_for_backup_interval duration                                (init restore parameter) if this is greater than 0, instead of starting up empty when no backups are found, keep checking at this interval for a backup to appear
+      --warming-reads-concurrency int                                    Number of concurrent warming reads allowed (default 500)
+      --warming-reads-percent int                                        Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm
+      --warming-reads-query-timeout duration                             Timeout of warming read queries (default 5s)
       --warn_memory_rows int                                             Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented. (default 30000)
       --warn_payload_size int                                            The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.
       --warn_sharded_only                                                If any features that are only available in unsharded mode are used, query execution warnings will be added to the session

--- a/content/en/docs/19.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctld
 
@@ -51,6 +51,7 @@ vtctld \
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup_mysqld_timeout duration                            how long to wait for mysqld to shutdown at the start of the backup. (default 10m0s)
@@ -76,6 +77,7 @@ vtctld \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient
 
@@ -67,6 +67,7 @@ vtctldclient [flags]
 * [vtctldclient GetVSchema](./vtctldclient_getvschema/)	 - Prints a JSON representation of a keyspace's topo record.
 * [vtctldclient GetWorkflows](./vtctldclient_getworkflows/)	 - Gets all vreplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 * [vtctldclient LegacyVtctlCommand](./vtctldclient_legacyvtctlcommand/)	 - Invoke a legacy vtctlclient command. Flag parsing is best effort.
+* [vtctldclient LookupVindex](./vtctldclient_lookupvindex/)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
 * [vtctldclient MoveTables](./vtctldclient_movetables/)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 * [vtctldclient OnlineDDL](./vtctldclient_onlineddl/)	 - Operates on online DDL (schema migrations).
 * [vtctldclient PingTablet](./vtctldclient_pingtablet/)	 - Checks that the specified tablet is awake and responding to RPCs. This command can be blocked by other in-flight operations.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,0 +1,32 @@
+---
+title: LookupVindex
+series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+---
+## vtctldclient LookupVindex
+
+Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+
+### Options
+
+```
+  -h, --help                    help for LookupVindex
+      --name string             The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --table-keyspace string   The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --server string             server to use for connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient LookupVindex cancel](./vtctldclient_lookupvindex_cancel/)	 - Cancel the VReplication workflow that backfills the Lookup Vindex.
+* [vtctldclient LookupVindex create](./vtctldclient_lookupvindex_create/)	 - Create the Lookup Vindex in the specified keyspace and backfill it with a VReplication workflow.
+* [vtctldclient LookupVindex externalize](./vtctldclient_lookupvindex_externalize/)	 - Externalize the Lookup Vindex. If the Vindex has an owner the VReplication workflow will also be deleted.
+* [vtctldclient LookupVindex show](./vtctldclient_lookupvindex_show/)	 - Show the status of the VReplication workflow that backfills the Lookup Vindex.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,0 +1,38 @@
+---
+title: LookupVindex cancel
+series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+---
+## vtctldclient LookupVindex cancel
+
+Cancel the VReplication workflow that backfills the Lookup Vindex.
+
+```
+vtctldclient LookupVindex cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,0 +1,49 @@
+---
+title: LookupVindex create
+series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+---
+## vtctldclient LookupVindex create
+
+Create the Lookup Vindex in the specified keyspace and backfill it with a VReplication workflow.
+
+```
+vtctldclient LookupVindex create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns sku --table-name corder_lookup_tbl --table-vindex-type unicode_loose_xxhash
+```
+
+### Options
+
+```
+      --cells strings                      Cells to look in for source tablets to replicate from.
+      --continue-after-copy-with-owner     Vindex will continue materialization after the backfill completes when an owner is provided. (default true)
+  -h, --help                               help for create
+      --ignore-nulls                       Do not add corresponding records in the lookup table if any of the owner table's 'from' fields are NULL.
+      --keyspace string                    The keyspace to create the Lookup Vindex in. This is also where the table-owner must exist.
+      --table-name string                  The name of the lookup table. If not specified, then it will be created using the same name as the Lookup Vindex.
+      --table-owner string                 The table holding the data which we should use to backfill the Lookup Vindex. This must exist in the same keyspace as the Lookup Vindex.
+      --table-owner-columns strings        The columns to read from the owner table. These will be used to build the hash which gets stored as the keyspace_id value in the lookup table.
+      --table-vindex-type string           The primary vindex name/type to use for the lookup table, if the table-keyspace is sharded. This must match the name of a vindex defined in the table-keyspace. If no value is provided then the default type will be used based on the table-owner-columns types.
+      --tablet-types strings               Source tablet types to replicate from.
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+      --type string                        The type of Lookup Vindex to create.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,0 +1,39 @@
+---
+title: LookupVindex externalize
+series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+---
+## vtctldclient LookupVindex externalize
+
+Externalize the Lookup Vindex. If the Vindex has an owner the VReplication workflow will also be deleted.
+
+```
+vtctldclient LookupVindex externalize
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer externalize
+```
+
+### Options
+
+```
+  -h, --help              help for externalize
+      --keyspace string   The keyspace containing the Lookup Vindex. If no value is specified then the table-keyspace will be used.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,0 +1,38 @@
+---
+title: LookupVindex show
+series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+---
+## vtctldclient LookupVindex show
+
+Show the status of the VReplication workflow that backfills the Lookup Vindex.
+
+```
+vtctldclient LookupVindex show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,16 +1,11 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient MoveTables
 
 Perform commands related to moving tables from a source keyspace to a target keyspace.
-
-### Synopsis
-
-MoveTables commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
-See the --help output for each command for more details.
 
 ### Options
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient MoveTables complete
 
@@ -14,7 +14,7 @@ vtctldclient MoveTables complete
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer complete
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer complete
 ```
 
 ### Options

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,16 +1,11 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient Reshard
 
 Perform commands related to resharding a keyspace.
-
-### Synopsis
-
-Reshard commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
-See the --help output for each command for more details.
 
 ### Options
 
@@ -32,8 +27,8 @@ See the --help output for each command for more details.
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Reshard cancel](./vtctldclient_reshard_cancel/)	 - Cancel a Reshard VReplication workflow.
-* [vtctldclient Reshard complete](./vtctldclient_reshard_complete/)	 - Complete a MoveTables VReplication workflow.
-* [vtctldclient Reshard create](./vtctldclient_reshard_create/)	 - Create and optionally run a reshard VReplication workflow.
+* [vtctldclient Reshard complete](./vtctldclient_reshard_complete/)	 - Complete a Reshard VReplication workflow.
+* [vtctldclient Reshard create](./vtctldclient_reshard_create/)	 - Create and optionally run a Reshard VReplication workflow.
 * [vtctldclient Reshard reversetraffic](./vtctldclient_reshard_reversetraffic/)	 - Reverse traffic for a Reshard VReplication workflow.
 * [vtctldclient Reshard show](./vtctldclient_reshard_show/)	 - Show the details for a Reshard VReplication workflow.
 * [vtctldclient Reshard start](./vtctldclient_reshard_start/)	 - Start a Reshard workflow.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,11 +1,11 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient Reshard complete
 
-Complete a MoveTables VReplication workflow.
+Complete a Reshard VReplication workflow.
 
 ```
 vtctldclient Reshard complete
@@ -14,7 +14,7 @@ vtctldclient Reshard complete
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer complete
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer complete
 ```
 
 ### Options

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,11 +1,11 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient Reshard create
 
-Create and optionally run a reshard VReplication workflow.
+Create and optionally run a Reshard VReplication workflow.
 
 ```
 vtctldclient Reshard create
@@ -14,7 +14,7 @@ vtctldclient Reshard create
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow customer2customer --target-keyspace customer create --source_shards="0" --target_shards="-80,80-" --cells zone1 --cells zone2 --tablet-types replica
+vtctldclient --server localhost:15999 reshard --workflow customer2customer --target-keyspace customer create --source-shards="0" --target-shards="-80,80-" --cells zone1 --cells zone2 --tablet-types replica
 ```
 
 ### Options

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,16 +1,11 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient VDiff
 
 Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
-
-### Synopsis
-
-VDiff commands: create, resume, show, stop, and delete.
-See the --help output for each command for more details.
 
 ### Options
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,15 +1,11 @@
 ---
 title: Workflow
 series: vtctldclient
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtctldclient Workflow
 
 Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
-
-### Synopsis
-
-Workflow commands: List, Show, Start, Stop, Update, and Delete.
-See the --help output for each command for more details.
 
 ```
 vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]

--- a/content/en/docs/19.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtgate
 
@@ -45,6 +45,7 @@ vtgate \
       --allow-kill-statement                                             Allows the execution of kill statement
       --allowed_tablet_types strings                                     Specifies the tablet types this vtgate is allowed to route queries to. Should be provided as a comma-separated set of tablet types.
       --alsologtostderr                                                  log to standard error as well as files
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --buffer_drain_concurrency int                                     Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer. (default 1)
       --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.
       --buffer_max_failover_duration duration                            Stop buffering completely if a failover takes longer than this duration. (default 20s)
@@ -88,6 +89,7 @@ vtgate \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
@@ -247,6 +249,9 @@ vtgate \
       --vmodule moduleSpec                                               comma-separated list of pattern=N settings for file-filtered logging
       --vschema_ddl_authorized_users string                              List of users authorized to execute vschema ddl operations, or '%' to allow all users.
       --vtgate-config-terse-errors                                       prevent bind vars from escaping in returned errors
+      --warming-reads-concurrency int                                    Number of concurrent warming reads allowed (default 500)
+      --warming-reads-percent int                                        Percentage of reads on the primary to forward to replicas. Useful for keeping buffer pools warm
+      --warming-reads-query-timeout duration                             Timeout of warming read queries (default 5s)
       --warn_memory_rows int                                             Warning threshold for in-memory results. A row count higher than this amount will cause the VtGateWarnings.ResultsExceeded counter to be incremented. (default 30000)
       --warn_payload_size int                                            The warning threshold for query payloads in bytes. A payload greater than this threshold will cause the VtGateWarnings.WarnPayloadSizeExceeded counter to be incremented.
       --warn_sharded_only                                                If any features that are only available in unsharded mode are used, query execution warnings will be added to the session

--- a/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtgateclienttest
 
@@ -15,6 +15,7 @@ vtgateclienttest [flags]
 
 ```
       --alsologtostderr                                                  log to standard error as well as files
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                                    catch and ignore SIGPIPE on stdout and stderr if specified
       --config-file string                                               Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling        Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
@@ -27,6 +28,7 @@ vtgateclienttest [flags]
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/19.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vtorc
 
@@ -35,6 +35,7 @@ vtorc \
       --audit-purge-duration duration                               Duration for which audit logs are held before being purged. Should be in multiples of days (default 168h0m0s)
       --audit-to-backend                                            Whether to store the audit log in the VTOrc database
       --audit-to-syslog                                             Whether to store the audit log in the syslog
+      --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
       --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
       --clusters_to_watch strings                                   Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"

--- a/content/en/docs/19.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vttablet
 
@@ -74,6 +74,7 @@ vttablet \
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
+      --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
       --binlog_password string                                           PITR restore parameter: password of binlog server.
       --binlog_player_grpc_ca string                                     the server ca to use to validate servers when connecting
@@ -188,6 +189,7 @@ vttablet \
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/19.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## vttestserver
 
@@ -57,6 +57,7 @@ vttestserver [flags]
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_auth_static_password_file string                            JSON File to read the users/passwords from.
+      --grpc_bind_address string                                         Bind address for gRPC calls. If empty, listen on all addresses.
       --grpc_ca string                                                   server CA to use for gRPC connections, requires TLS, and enforces client certificate check
       --grpc_cert string                                                 server certificate to use for gRPC connections, requires grpc_key, enables TLS
       --grpc_compression string                                          Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## zkctl init
 
@@ -24,7 +24,7 @@ zkctl init [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## zkctl shutdown
 
@@ -24,7 +24,7 @@ zkctl shutdown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## zkctl start
 
@@ -24,7 +24,7 @@ zkctl start [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
 ---
 ## zkctl teardown
 
@@ -24,7 +24,7 @@ zkctl teardown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/Users/andrew/dev/vtwebsite/vitessio.website/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -5,9 +5,9 @@ set -exuo pipefail
 persist_tmpdir=${COBRADOCS_SYNC_PERSIST:-}
 tmp=${VITESS_DIR:-"$(pwd)/vitessio.website"}
 
-if [[ -z "${persist_tmpdir}" ]]; then
-    trap "rm -rf ${tmp}" EXIT
-fi
+#if [[ -z "${persist_tmpdir}" ]]; then
+#    trap "rm -rf ${tmp}" EXIT
+#fi
 
 if [ ! -d "${tmp}" ]; then
     tmp="$(mktemp -d $tmp)"
@@ -19,6 +19,11 @@ if [ ! -d "${tmp}" ]; then
 fi
 
 VITESS_DIR="${tmp}" make generated-docs
+
+# This command be removed once v18.0.0 (GA), v17.0.4, v16.0.6 and v15.0.6 are outs.
+# In the meantime, the documentation generation in Vitess produces non-anonymous path
+# which are replaced here using find and sed.
+find ./content/en/docs/ -type f -exec sh -c 'LC_CTYPE=C LANG=en_US.UTF-8 sed -i "" "s@\['"$tmp"'\]@\[<WORKDIR>\]@g" "$0"' {} \;
 
 git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs)
 # Reset any modified files that contained _only_ a SHA update.


### PR DESCRIPTION
https://github.com/vitessio/vitess/pull/13188

Note: this PR also include a small fix to `./tools/sync_cobradocs.sh` to `sed` the modified files in order to make all path anonymous.