### PR TITLE
persistent cobrasync

### DIFF
--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -11,11 +11,10 @@ git clone --depth=1 git@github.com:vitessio/vitess "${tmp}/vitess" && \
     cd -
 
 VITESS_DIR="$(pwd)/${tmp}/vitess" make generated-docs
-rm -rf "${tmp}/vitess"
 
 git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs)
 # Reset any modified files that contained _only_ a SHA update.
 git checkout -- .
 # Add any net-new files that were missed in the first `git add`.
-git add .
+git add content/**
 git commit -sm "sync cobradocs to latest release branches"

--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -2,13 +2,21 @@
 
 set -exuo pipefail
 
-tmp="$(mktemp -d vitessio.website)"
-trap "rm -rf ${tmp}" EXIT
+persist_tmpdir=${COBRADOCS_SYNC_PERSIST:-}
+tmp="vitessio.website"
 
-git clone --depth=1 git@github.com:vitessio/vitess "${tmp}/vitess" && \
-    cd "${tmp}/vitess" && \
-    git fetch --tags && \
-    cd -
+if [[ -z "${persist_tmpdir}" ]]; then
+    trap "rm -rf ${tmp}" EXIT
+fi
+
+if [ ! -d "${tmp}" ]; then
+    tmp="$(mktemp -d vitessio.website)"
+
+    git clone --depth=1 git@github.com:vitessio/vitess "${tmp}/vitess" && \
+        cd "${tmp}/vitess" && \
+        git fetch --tags && \
+        cd -
+fi
 
 VITESS_DIR="$(pwd)/${tmp}/vitess" make generated-docs
 


### PR DESCRIPTION
this modifies the `sync_cobradocs.sh` script so we can run it multiple times on a vitess clone. this is primarily for us to be able to generate incremental changes in a CI workflow without having to do the work of `git clone`-ing vitess twice (or more)

tested by running first with the variable set and then unset