### PR TITLE
Allow empty commits

### DIFF
--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -25,9 +25,9 @@ VITESS_DIR="${tmp}" make generated-docs
 # which are replaced here using find and sed.
 find ./content/en/docs/ -type f -exec sh -c 'LC_CTYPE=C LANG=en_US.UTF-8 sed -i "" "s@\['"$tmp"'\]@\[<WORKDIR>\]@g" "$0"' {} \;
 
-git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs)
+git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs) || true
 # Reset any modified files that contained _only_ a SHA update.
 git checkout -- .
 # Add any net-new files that were missed in the first `git add`.
 git add content/**
-git commit -sm "sync cobradocs to latest release branches"
+git commit --allow-empty -sm "sync cobradocs to latest release branches"


### PR DESCRIPTION
This is to support the preview functionality of the bot.

The root "cause" here is: on the _first_ PR opened against a release branch after cutting a release tag from that series, the release tag and the head of the release branch are the same, so there is no change generated by `make generated-docs`. This would then cause both the `git add` and `git commit` to error.

See https://github.com/ajm188/vitess/pull/12#issuecomment-1751871022