### PR TITLE
Manual rebuild of vtctldclient reference docs for v18 and v19

### DIFF
--- a/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient
 
@@ -14,9 +14,10 @@ vtctldclient [flags]
 ### Options
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
   -h, --help                      help for vtctldclient
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO
@@ -67,6 +68,10 @@ vtctldclient [flags]
 * [vtctldclient GetVSchema](./vtctldclient_getvschema/)	 - Prints a JSON representation of a keyspace's topo record.
 * [vtctldclient GetWorkflows](./vtctldclient_getworkflows/)	 - Gets all vreplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 * [vtctldclient LegacyVtctlCommand](./vtctldclient_legacyvtctlcommand/)	 - Invoke a legacy vtctlclient command. Flag parsing is best effort.
+* [vtctldclient LookupVindex](./vtctldclient_lookupvindex/)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+* [vtctldclient Materialize](./vtctldclient_materialize/)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+* [vtctldclient Migrate](./vtctldclient_migrate/)	 - Migrate is used to import data from an external cluster into the current cluster.
+* [vtctldclient Mount](./vtctldclient_mount/)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 * [vtctldclient MoveTables](./vtctldclient_movetables/)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 * [vtctldclient OnlineDDL](./vtctldclient_onlineddl/)	 - Operates on online DDL (schema migrations).
 * [vtctldclient PingTablet](./vtctldclient_pingtablet/)	 - Checks that the specified tablet is awake and responding to RPCs. This command can be blocked by other in-flight operations.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient AddCellInfo
 
@@ -29,8 +30,9 @@ vtctldclient AddCellInfo --root <root> [--server-address <addr>] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient AddCellsAlias
 
@@ -28,8 +29,9 @@ vtctldclient AddCellsAlias --cells <cell1,cell2,...> [--cells <cell3> ...] <alia
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -24,8 +25,9 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: b2d7604e4e0728329314500c182c3192cee74510
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ApplySchema
 
@@ -45,8 +45,9 @@ vtctldclient ApplySchema [--ddl-strategy <strategy>] [--uuid <uuid> ...] [--migr
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ApplyShardRoutingRules
 
@@ -24,8 +25,9 @@ vtctldclient ApplyShardRoutingRules {--rules RULES | --rules-file RULES_FILE} [-
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ApplyVSchema
 
@@ -26,8 +27,9 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,6 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Backup
 
@@ -23,8 +24,9 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,6 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient BackupShard
 
@@ -29,8 +30,9 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,6 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ChangeTabletType
 
@@ -27,8 +28,9 @@ vtctldclient ChangeTabletType [--dry-run] <alias> <tablet-type>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient CreateKeyspace
 
@@ -34,8 +35,9 @@ vtctldclient CreateKeyspace <keyspace> [--force|-f] [--type KEYSPACE_TYPE] [--ba
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,6 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient CreateShard
 
@@ -21,8 +22,9 @@ vtctldclient CreateShard [--force|-f] [--include-parent|-p] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteCellInfo
 
@@ -24,8 +25,9 @@ vtctldclient DeleteCellInfo [--force] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteCellsAlias
 
@@ -23,8 +24,9 @@ vtctldclient DeleteCellsAlias <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteKeyspace
 
@@ -28,8 +29,9 @@ vtctldclient DeleteKeyspace [--recursive|-r] [--force|-f] <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteShards
 
@@ -30,8 +31,9 @@ vtctldclient DeleteShards [--recursive|-r] [--even-if-serving] [--force|-f] <key
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteSrvVSchema
 
@@ -19,8 +20,9 @@ vtctldclient DeleteSrvVSchema <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient DeleteTablets
 
@@ -20,8 +21,9 @@ vtctldclient DeleteTablets <alias> [ <alias> ... ]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,6 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient EmergencyReparentShard
 
@@ -24,8 +25,9 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ExecuteFetchAsApp
 
@@ -22,8 +23,9 @@ vtctldclient ExecuteFetchAsApp [--max-rows <max-rows>] [--json|-j] [--use-pool] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ExecuteFetchAsDBA
 
@@ -23,8 +24,9 @@ vtctldclient ExecuteFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disable-bi
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ExecuteHook
 
@@ -33,8 +34,9 @@ vtctldclient ExecuteHook <alias> <hook_name> [<param1=value1> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient FindAllShardsInKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient FindAllShardsInKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,6 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GenerateShardRanges
 
@@ -19,8 +20,9 @@ vtctldclient GenerateShardRanges <num_shards>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,6 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetBackups
 
@@ -21,8 +22,9 @@ vtctldclient GetBackups [--limit <limit>] [--json] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetCellInfo
 
@@ -19,8 +20,9 @@ vtctldclient GetCellInfo <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetCellInfoNames
 
@@ -19,8 +20,9 @@ vtctldclient GetCellInfoNames
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetCellsAliases
 
@@ -19,8 +20,9 @@ vtctldclient GetCellsAliases
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,6 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetFullStatus
 
@@ -19,8 +20,9 @@ vtctldclient GetFullStatus <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient GetKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,6 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetKeyspaces
 
@@ -19,8 +20,9 @@ vtctldclient GetKeyspaces
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,6 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetPermissions
 
@@ -19,8 +20,9 @@ vtctldclient GetPermissions <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetRoutingRules
 
@@ -19,8 +20,9 @@ vtctldclient GetRoutingRules
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetSchema
 
@@ -25,8 +26,9 @@ vtctldclient GetSchema [--tables TABLES ...] [--exclude-tables EXCLUDE_TABLES ..
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,6 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetShard
 
@@ -19,8 +20,9 @@ vtctldclient GetShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetShardRoutingRules
 
@@ -27,8 +28,9 @@ vtctldclient GetShardRoutingRules
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetSrvKeyspaceNames
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvKeyspaceNames [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetSrvKeyspaces
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvKeyspaces <keyspace> [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetSrvVSchema
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvVSchema cell
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetSrvVSchemas
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvVSchemas [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,6 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetTablet
 
@@ -19,8 +20,9 @@ vtctldclient GetTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,6 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetTabletVersion
 
@@ -19,8 +20,9 @@ vtctldclient GetTabletVersion <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,6 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetTablets
 
@@ -47,8 +48,9 @@ vtctldclient GetTablets [--strict] [{--cell $c1 [--cell $c2 ...] [--tablet-type 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,6 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetTopologyPath
 
@@ -19,8 +20,9 @@ vtctldclient GetTopologyPath <path>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetVSchema
 
@@ -19,8 +20,9 @@ vtctldclient GetVSchema <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,6 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient GetWorkflows
 
@@ -13,15 +14,17 @@ vtctldclient GetWorkflows <keyspace>
 ### Options
 
 ```
-  -h, --help       help for GetWorkflows
-  -a, --show-all   Show all workflows instead of just active workflows.
+  -h, --help           help for GetWorkflows
+      --include-logs   Include recent logs for the workflows. (default true)
+  -a, --show-all       Show all workflows instead of just active workflows.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,6 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient LegacyVtctlCommand
 
@@ -52,8 +53,9 @@ LegacyVtctlCommand -- AddCellInfo --server_address "localhost:5678" --root "/vit
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,0 +1,33 @@
+---
+title: LookupVindex
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient LookupVindex
+
+Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+
+### Options
+
+```
+  -h, --help                    help for LookupVindex
+      --name string             The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --table-keyspace string   The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient LookupVindex cancel](./vtctldclient_lookupvindex_cancel/)	 - Cancel the VReplication workflow that backfills the Lookup Vindex.
+* [vtctldclient LookupVindex create](./vtctldclient_lookupvindex_create/)	 - Create the Lookup Vindex in the specified keyspace and backfill it with a VReplication workflow.
+* [vtctldclient LookupVindex externalize](./vtctldclient_lookupvindex_externalize/)	 - Externalize the Lookup Vindex. If the Vindex has an owner the VReplication workflow will also be deleted.
+* [vtctldclient LookupVindex show](./vtctldclient_lookupvindex_show/)	 - Show the status of the VReplication workflow that backfills the Lookup Vindex.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,0 +1,39 @@
+---
+title: LookupVindex cancel
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient LookupVindex cancel
+
+Cancel the VReplication workflow that backfills the Lookup Vindex.
+
+```
+vtctldclient LookupVindex cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for the connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,0 +1,50 @@
+---
+title: LookupVindex create
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient LookupVindex create
+
+Create the Lookup Vindex in the specified keyspace and backfill it with a VReplication workflow.
+
+```
+vtctldclient LookupVindex create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns sku --table-name corder_lookup_tbl --table-vindex-type unicode_loose_xxhash
+```
+
+### Options
+
+```
+      --cells strings                      Cells to look in for source tablets to replicate from.
+      --continue-after-copy-with-owner     Vindex will continue materialization after the backfill completes when an owner is provided. (default true)
+  -h, --help                               help for create
+      --ignore-nulls                       Do not add corresponding records in the lookup table if any of the owner table's 'from' fields are NULL.
+      --keyspace string                    The keyspace to create the Lookup Vindex in. This is also where the table-owner must exist.
+      --table-name string                  The name of the lookup table. If not specified, then it will be created using the same name as the Lookup Vindex.
+      --table-owner string                 The table holding the data which we should use to backfill the Lookup Vindex. This must exist in the same keyspace as the Lookup Vindex.
+      --table-owner-columns strings        The columns to read from the owner table. These will be used to build the hash which gets stored as the keyspace_id value in the lookup table.
+      --table-vindex-type string           The primary vindex name/type to use for the lookup table, if the table-keyspace is sharded. This must match the name of a vindex defined in the table-keyspace. If no value is provided then the default type will be used based on the table-owner-columns types.
+      --tablet-types strings               Source tablet types to replicate from.
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+      --type string                        The type of Lookup Vindex to create.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for the connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,0 +1,40 @@
+---
+title: LookupVindex externalize
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient LookupVindex externalize
+
+Externalize the Lookup Vindex. If the Vindex has an owner the VReplication workflow will also be deleted.
+
+```
+vtctldclient LookupVindex externalize
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer externalize
+```
+
+### Options
+
+```
+  -h, --help              help for externalize
+      --keyspace string   The keyspace containing the Lookup Vindex. If no value is specified then the table-keyspace will be used.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for the connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,0 +1,39 @@
+---
+title: LookupVindex show
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient LookupVindex show
+
+Show the status of the VReplication workflow that backfills the Lookup Vindex.
+
+```
+vtctldclient LookupVindex show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --table-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
+      --server string             server to use for the connection (required)
+      --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
+```
+
+### SEE ALSO
+
+* [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,0 +1,35 @@
+---
+title: Materialize
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize
+
+Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+
+### Options
+
+```
+      --format string            The format of the output; supported formats are: text,json. (default "text")
+  -h, --help                     help for Materialize
+      --target-keyspace string   Target keyspace for this workflow.
+  -w, --workflow string          The workflow you want to perform the command on.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Materialize cancel](./vtctldclient_materialize_cancel/)	 - Cancel a Materialize VReplication workflow.
+* [vtctldclient Materialize create](./vtctldclient_materialize_create/)	 - Create and run a Materialize VReplication workflow.
+* [vtctldclient Materialize show](./vtctldclient_materialize_show/)	 - Show the details for a Materialize VReplication workflow.
+* [vtctldclient Materialize start](./vtctldclient_materialize_start/)	 - Start a Materialize workflow.
+* [vtctldclient Materialize stop](./vtctldclient_materialize_stop/)	 - Stop a Materialize workflow.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,0 +1,40 @@
+---
+title: Materialize cancel
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize cancel
+
+Cancel a Materialize VReplication workflow.
+
+```
+vtctldclient Materialize cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,0 +1,76 @@
+---
+title: Materialize create
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize create
+
+Create and run a Materialize VReplication workflow.
+
+### Synopsis
+
+Materialize is a lower level VReplication command that allows for generalized materialization
+of tables. The target tables can be copies, aggregations, or views. The target tables are kept
+in sync in near-realtime. The primary flag used to define the materializations (you can have
+multiple per workflow) is table-settings which is a JSON array where each value must contain
+two key/value pairs. The first required key is 'target_table' and it is the name of the table
+in the target-keyspace to store the results in. The second required key is 'source_expression'
+and its value is the select query to run against the source table. An optional key/value pair
+can also be specified for 'create_ddl' which provides the DDL to create the target table if it
+does not exist -- you can alternatively specify a value of 'copy' if the target table schema
+should be copied as-is from the source keyspace. Here's an example value for table-settings:
+[
+  {
+    "target_table": "customer_one_email",
+    "source_expression": "select email from customer where customer_id = 1"
+  },
+  {
+    "target_table": "states",
+    "source_expression": "select * from states",
+    "create_ddl": "copy"
+  },
+  {
+    "target_table": "sales_by_sku",
+    "source_expression": "select sku, count(*) as orders, sum(price) as revenue from corder group by sku",
+    "create_ddl": "create table sales_by_sku (sku varbinary(128) not null primary key, orders bigint, revenue bigint)"
+  }
+]
+
+
+```
+vtctldclient Materialize create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 materialize --workflow product_sales --target-keyspace commerce create --source-keyspace commerce --table-settings '[{"target_table": "sales_by_sku", "create_ddl": "create table sales_by_sku (sku varbinary(128) not null primary key, orders bigint, revenue bigint)", "source_expression": "select sku, count(*) as orders, sum(price) as revenue from corder group by sku"}]' --cells zone1 --cells zone2 --tablet-types replica
+```
+
+### Options
+
+```
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+  -h, --help                               help for create
+      --source-keyspace string             Keyspace where the tables queried in the 'source_expression' values within table-settings live.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --table-settings JSON                A JSON array defining what tables to materialize using what select statements. See the --help output for more details. (default null)
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,0 +1,41 @@
+---
+title: Materialize show
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize show
+
+Show the details for a Materialize VReplication workflow.
+
+```
+vtctldclient Materialize show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,0 +1,40 @@
+---
+title: Materialize start
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize start
+
+Start a Materialize workflow.
+
+```
+vtctldclient Materialize start
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer start
+```
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,0 +1,40 @@
+---
+title: Materialize stop
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Materialize stop
+
+Stop a Materialize workflow.
+
+```
+vtctldclient Materialize stop
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer stop
+```
+
+### Options
+
+```
+  -h, --help   help for stop
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,0 +1,35 @@
+---
+title: Migrate
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate
+
+Migrate is used to import data from an external cluster into the current cluster.
+
+### Options
+
+```
+      --format string            The format of the output; supported formats are: text,json. (default "text")
+  -h, --help                     help for Migrate
+      --target-keyspace string   Target keyspace for this workflow.
+  -w, --workflow string          The workflow you want to perform the command on.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Migrate cancel](./vtctldclient_migrate_cancel/)	 - Cancel a Migrate VReplication workflow.
+* [vtctldclient Migrate complete](./vtctldclient_migrate_complete/)	 - Complete a Migrate VReplication workflow.
+* [vtctldclient Migrate create](./vtctldclient_migrate_create/)	 - Create and optionally run a Migrate VReplication workflow.
+* [vtctldclient Migrate show](./vtctldclient_migrate_show/)	 - Show the details for a Migrate VReplication workflow.
+* [vtctldclient Migrate status](./vtctldclient_migrate_status/)	 - Show the current status for a Migrate VReplication workflow.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,0 +1,40 @@
+---
+title: Migrate cancel
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate cancel
+
+Cancel a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,0 +1,40 @@
+---
+title: Migrate complete
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate complete
+
+Complete a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate complete
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer complete
+```
+
+### Options
+
+```
+  -h, --help   help for complete
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,0 +1,54 @@
+---
+title: Migrate create
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate create
+
+Create and optionally run a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 migrate --workflow import --target-keyspace customer create --source-keyspace commerce --mount-name ext1 --tablet-types replica
+```
+
+### Options
+
+```
+      --all-tables                         Copy all tables from the source.
+      --auto-start                         Start the workflow after creating it. (default true)
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+      --exclude-tables strings             Source tables to exclude from copying.
+  -h, --help                               help for create
+      --mount-name string                  Name external cluster is mounted as.
+      --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
+      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
+      --source-keyspace string             Keyspace where the tables are being moved from.
+      --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --tables strings                     Source tables to copy.
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,0 +1,41 @@
+---
+title: Migrate show
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate show
+
+Show the details for a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,0 +1,40 @@
+---
+title: Migrate status
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Migrate status
+
+Show the current status for a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate status
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer status
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,0 +1,31 @@
+---
+title: Mount
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Mount
+
+Mount is used to link an external Vitess cluster in order to migrate data from it.
+
+### Options
+
+```
+  -h, --help   help for Mount
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Mount list](./vtctldclient_mount_list/)	 - List all mounted external Vitess Clusters.
+* [vtctldclient Mount register](./vtctldclient_mount_register/)	 - Register an external Vitess Cluster.
+* [vtctldclient Mount show](./vtctldclient_mount_show/)	 - Show attributes of a previously mounted external Vitess Cluster.
+* [vtctldclient Mount unregister](./vtctldclient_mount_unregister/)	 - Unregister a previously mounted external Vitess Cluster.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,0 +1,37 @@
+---
+title: Mount list
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Mount list
+
+List all mounted external Vitess Clusters.
+
+```
+vtctldclient Mount list
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,0 +1,40 @@
+---
+title: Mount register
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Mount register
+
+Register an external Vitess Cluster.
+
+```
+vtctldclient Mount register
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount register --topo-type etcd2 --topo-server localhost:12379 --topo-root /vitess/global ext1
+```
+
+### Options
+
+```
+  -h, --help                 help for register
+      --topo-root string     Topo server root path.
+      --topo-server string   Topo server address.
+      --topo-type string     Topo server implementation to use.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,0 +1,37 @@
+---
+title: Mount show
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Mount show
+
+Show attributes of a previously mounted external Vitess Cluster.
+
+```
+vtctldclient Mount show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Mount Show ext1
+```
+
+### Options
+
+```
+  -h, --help   help for show
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,0 +1,37 @@
+---
+title: Mount unregister
+series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
+---
+## vtctldclient Mount unregister
+
+Unregister a previously mounted external Vitess Cluster.
+
+```
+vtctldclient Mount unregister
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount unregister ext1
+```
+
+### Options
+
+```
+  -h, --help   help for unregister
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,16 +1,11 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables
 
 Perform commands related to moving tables from a source keyspace to a target keyspace.
-
-### Synopsis
-
-MoveTables commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
-See the --help output for each command for more details.
 
 ### Options
 
@@ -24,8 +19,9 @@ See the --help output for each command for more details.
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables cancel
 
@@ -20,15 +20,18 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for cancel
+  -h, --help                 help for cancel
+      --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace.
+      --keep-routing-rules   Keep the routing rules created for the MoveTables workflow.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables complete
 
@@ -14,21 +14,26 @@ vtctldclient MoveTables complete
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer complete
+vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --target-keyspace customer complete
 ```
 
 ### Options
 
 ```
-  -h, --help   help for complete
+      --dry-run              Print the actions that would be taken and report any known errors that would have occurred.
+  -h, --help                 help for complete
+      --keep-data            Keep the original source table data that was copied by the MoveTables workflow.
+      --keep-routing-rules   Keep the routing rules in place that direct table traffic from the source keyspace to the target keyspace of the MoveTables workflow.
+      --rename-tables        Keep the original source table data that was copied by the MoveTables workflow, but rename each table to '_<tablename>_old'.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables create
 
@@ -22,7 +22,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --all-tables                         Copy all tables from the source.
       --atomic-copy                        (EXPERIMENTAL) A single copy phase is run for all tables from the source. Use this, for example, if your source keyspace has tables which use foreign key constraints.
-      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+      --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
       --exclude-tables strings             Source tables to exclude from copying.
@@ -30,9 +30,9 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
       --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --source-keyspace string             Keyspace where the tables are being moved from.
-      --source-shards strings              Source shards to copy data from when performing a partial moveTables (experimental).
+      --source-shards strings              Source shards to copy data from when performing a partial MoveTables (experimental).
       --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC.
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --tables strings                     Source tables to copy.
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
@@ -41,9 +41,10 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables reversetraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables show
 
@@ -20,15 +20,17 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables start
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables status
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient MoveTables switchtraffic
 
@@ -33,9 +33,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL
 
@@ -16,8 +16,9 @@ Operates on online DDL (schema migrations).
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL cancel
 
@@ -26,8 +26,9 @@ OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL cleanup
 
@@ -26,8 +26,9 @@ OnlineDDL cleanup test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL complete
 
@@ -26,8 +26,9 @@ OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL launch
 
@@ -26,8 +26,9 @@ OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL retry
 
@@ -26,8 +26,9 @@ vtctl OnlineDDL retry test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL show
 
@@ -37,8 +37,9 @@ OnlineDDL show test_keyspace failed
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL throttle
 
@@ -26,8 +26,9 @@ OnlineDDL throttle all
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient OnlineDDL unthrottle
 
@@ -26,8 +26,9 @@ OnlineDDL unthrottle all
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,6 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient PingTablet
 
@@ -19,8 +20,9 @@ vtctldclient PingTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,6 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -22,8 +23,9 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,6 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RebuildKeyspaceGraph
 
@@ -21,8 +22,9 @@ vtctldclient RebuildKeyspaceGraph [--cells=c1,c2,...] [--allow-partial] ks1 [ks2
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,6 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RebuildVSchemaGraph
 
@@ -20,8 +21,9 @@ vtctldclient RebuildVSchemaGraph [--cells=c1,c2,...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,6 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RefreshState
 
@@ -19,8 +20,9 @@ vtctldclient RefreshState <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,6 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RefreshStateByShard
 
@@ -20,8 +21,9 @@ vtctldclient RefreshStateByShard [--cell <cell1> ...] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ReloadSchema
 
@@ -19,8 +20,9 @@ vtctldclient ReloadSchema <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ReloadSchemaKeyspace
 
@@ -21,8 +22,9 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ReloadSchemaShard
 
@@ -21,8 +22,9 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RemoveBackup
 
@@ -19,8 +20,9 @@ vtctldclient RemoveBackup <keyspace/shard> <backup name>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RemoveKeyspaceCell
 
@@ -21,8 +22,9 @@ vtctldclient RemoveKeyspaceCell [--force|-f] [--recursive|-r] <keyspace> <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RemoveShardCell
 
@@ -21,8 +22,9 @@ vtctldclient RemoveShardCell [--force|-f] [--recursive|-r] <keyspace/shard> <cel
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,6 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ReparentTablet
 
@@ -19,8 +20,9 @@ vtctldclient ReparentTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,16 +1,11 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard
 
 Perform commands related to resharding a keyspace.
-
-### Synopsis
-
-Reshard commands: Create, Show, Status, SwitchTraffic, ReverseTraffic, Stop, Start, Cancel, and Delete.
-See the --help output for each command for more details.
 
 ### Options
 
@@ -24,16 +19,17 @@ See the --help output for each command for more details.
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Reshard cancel](./vtctldclient_reshard_cancel/)	 - Cancel a Reshard VReplication workflow.
-* [vtctldclient Reshard complete](./vtctldclient_reshard_complete/)	 - Complete a MoveTables VReplication workflow.
-* [vtctldclient Reshard create](./vtctldclient_reshard_create/)	 - Create and optionally run a reshard VReplication workflow.
+* [vtctldclient Reshard complete](./vtctldclient_reshard_complete/)	 - Complete a Reshard VReplication workflow.
+* [vtctldclient Reshard create](./vtctldclient_reshard_create/)	 - Create and optionally run a Reshard VReplication workflow.
 * [vtctldclient Reshard reversetraffic](./vtctldclient_reshard_reversetraffic/)	 - Reverse traffic for a Reshard VReplication workflow.
 * [vtctldclient Reshard show](./vtctldclient_reshard_show/)	 - Show the details for a Reshard VReplication workflow.
 * [vtctldclient Reshard start](./vtctldclient_reshard_start/)	 - Start a Reshard workflow.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard cancel
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,11 +1,11 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard complete
 
-Complete a MoveTables VReplication workflow.
+Complete a Reshard VReplication workflow.
 
 ```
 vtctldclient Reshard complete
@@ -14,7 +14,7 @@ vtctldclient Reshard complete
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 movetables --workflow commerce2customer --target-keyspace customer complete
+vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keyspace customer complete
 ```
 
 ### Options
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,11 +1,11 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard create
 
-Create and optionally run a reshard VReplication workflow.
+Create and optionally run a Reshard VReplication workflow.
 
 ```
 vtctldclient Reshard create
@@ -14,20 +14,20 @@ vtctldclient Reshard create
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 reshard --workflow customer2customer --target-keyspace customer create --source_shards="0" --target_shards="-80,80-" --cells zone1 --cells zone2 --tablet-types replica
+vtctldclient --server localhost:15999 reshard --workflow customer2customer --target-keyspace customer create --source-shards="0" --target-shards="-80,80-" --cells zone1 --cells zone2 --tablet-types replica
 ```
 
 ### Options
 
 ```
-      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+      --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
   -h, --help                               help for create
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --skip-schema-copy                   Skip copying the schema from the source shards to the target shards.
       --source-shards strings              Source shards.
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
       --target-shards strings              Target shards.
@@ -36,9 +36,10 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard reversetraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard show
 
@@ -20,15 +20,17 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard start
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard status
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Reshard switchtraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,6 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RestoreFromBackup
 
@@ -23,8 +24,9 @@ vtctldclient RestoreFromBackup [--backup-timestamp|-t <YYYY-mm-DD.HHMMSS>] [--re
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,6 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient RunHealthCheck
 
@@ -19,8 +20,9 @@ vtctldclient RunHealthCheck <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,6 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 
@@ -29,8 +30,9 @@ vtctldclient SetKeyspaceDurabilityPolicy [--durability-policy=policy_name] <keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,6 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SetShardIsPrimaryServing
 
@@ -19,8 +20,9 @@ vtctldclient SetShardIsPrimaryServing <keyspace/shard> <true/false>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,6 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SetShardTabletControl
 
@@ -41,8 +42,9 @@ vtctldclient SetShardTabletControl [--cells=c1,c2...] [--denied-tables=t1,t2,...
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,6 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SetWritable
 
@@ -19,8 +20,9 @@ vtctldclient SetWritable <alias> <true/false>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,6 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ShardReplicationFix
 
@@ -19,8 +20,9 @@ vtctldclient ShardReplicationFix <cell> <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,6 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ShardReplicationPositions
 
@@ -25,8 +26,9 @@ vtctldclient ShardReplicationPositions <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,6 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SleepTablet
 
@@ -35,8 +36,9 @@ vtctldclient SleepTablet <alias> <duration>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,6 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SourceShardAdd
 
@@ -21,8 +22,9 @@ vtctldclient SourceShardAdd [--key-range <keyrange>] [--tables <table1,table2,..
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,6 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient SourceShardDelete
 
@@ -19,8 +20,9 @@ vtctldclient SourceShardDelete <keyspace/shard> <uid>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,6 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient StartReplication
 
@@ -19,8 +20,9 @@ vtctldclient StartReplication <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,6 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient StopReplication
 
@@ -19,8 +20,9 @@ vtctldclient StopReplication <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,6 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient TabletExternallyReparented
 
@@ -26,8 +27,9 @@ vtctldclient TabletExternallyReparented <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient UpdateCellInfo
 
@@ -27,8 +28,9 @@ vtctldclient UpdateCellInfo [--root <root>] [--server-address <addr>] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient UpdateCellsAlias
 
@@ -24,8 +25,9 @@ vtctldclient UpdateCellsAlias [--cells <cell1,cell2,...> [--cells <cell4> ...]] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient UpdateThrottlerConfig
 
@@ -30,8 +31,9 @@ vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,16 +1,11 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff
 
 Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
-
-### Synopsis
-
-VDiff commands: create, resume, show, stop, and delete.
-See the --help output for each command for more details.
 
 ### Options
 
@@ -24,8 +19,9 @@ See the --help output for each command for more details.
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff create
 
@@ -14,7 +14,7 @@ vtctldclient VDiff create
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer
+vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002
 ```
 
@@ -41,9 +41,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff delete
 
@@ -27,9 +27,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff resume
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff show
 
@@ -29,9 +29,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient VDiff stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,6 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Validate
 
@@ -20,8 +21,9 @@ vtctldclient Validate [--ping-tablets]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ValidateKeyspace
 
@@ -20,8 +21,9 @@ vtctldclient ValidateKeyspace [--ping-tablets] <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ValidateSchemaKeyspace
 
@@ -23,8 +24,9 @@ vtctldclient ValidateSchemaKeyspace [--exclude-tables=<exclude_tables>] [--inclu
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ValidateShard
 
@@ -20,8 +21,9 @@ vtctldclient ValidateShard [--ping-tablets] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ValidateVersionKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient ValidateVersionKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient ValidateVersionShard
 
@@ -19,8 +20,9 @@ vtctldclient ValidateVersionShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,15 +1,11 @@
 ---
 title: Workflow
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow
 
 Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
-
-### Synopsis
-
-Workflow commands: List, Show, Start, Stop, Update, and Delete.
-See the --help output for each command for more details.
 
 ```
 vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
@@ -19,14 +15,15 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
 
 ```
   -h, --help              help for Workflow
-  -k, --keyspace string   Keyspace context for the workflow (required).
+  -k, --keyspace string   Keyspace context for the workflow.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow delete
 
@@ -22,15 +23,16 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
   -h, --help                 help for delete
       --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the workflow.
-  -w, --workflow string      The workflow you want to delete (required).
+  -w, --workflow string      The workflow you want to delete.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow list
 
@@ -25,9 +26,10 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow show
 
@@ -20,15 +21,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
 
 ```
   -h, --help              help for show
-  -w, --workflow string   The workflow you want the details for (required).
+      --include-logs      Include recent logs for the workflow. (default true)
+  -w, --workflow string   The workflow you want the details for.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow start
 
@@ -19,15 +20,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ### Options
 
 ```
-  -h, --help   help for start
+  -h, --help              help for start
+  -w, --workflow string   The workflow you want to start.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow stop
 
@@ -19,15 +20,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 ### Options
 
 ```
-  -h, --help   help for stop
+  -h, --help              help for stop
+  -w, --workflow string   The workflow you want to stop.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
+commit: fe3121946231107b737e319b680c9686396b9ce1
 ---
 ## vtctldclient Workflow update
 
@@ -24,15 +25,16 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
       --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE.
   -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
-  -w, --workflow string         The workflow you want to update (required).
+  -w, --workflow string         The workflow you want to update.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient
 
@@ -14,9 +14,10 @@ vtctldclient [flags]
 ### Options
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
   -h, --help                      help for vtctldclient
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO
@@ -68,6 +69,9 @@ vtctldclient [flags]
 * [vtctldclient GetWorkflows](./vtctldclient_getworkflows/)	 - Gets all vreplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 * [vtctldclient LegacyVtctlCommand](./vtctldclient_legacyvtctlcommand/)	 - Invoke a legacy vtctlclient command. Flag parsing is best effort.
 * [vtctldclient LookupVindex](./vtctldclient_lookupvindex/)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
+* [vtctldclient Materialize](./vtctldclient_materialize/)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+* [vtctldclient Migrate](./vtctldclient_migrate/)	 - Migrate is used to import data from an external cluster into the current cluster.
+* [vtctldclient Mount](./vtctldclient_mount/)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 * [vtctldclient MoveTables](./vtctldclient_movetables/)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 * [vtctldclient OnlineDDL](./vtctldclient_onlineddl/)	 - Operates on online DDL (schema migrations).
 * [vtctldclient PingTablet](./vtctldclient_pingtablet/)	 - Checks that the specified tablet is awake and responding to RPCs. This command can be blocked by other in-flight operations.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient AddCellInfo
 
@@ -29,8 +30,9 @@ vtctldclient AddCellInfo --root <root> [--server-address <addr>] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient AddCellsAlias
 
@@ -28,8 +29,9 @@ vtctldclient AddCellsAlias --cells <cell1,cell2,...> [--cells <cell3> ...] <alia
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -24,8 +25,9 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: b2d7604e4e0728329314500c182c3192cee74510
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ApplySchema
 
@@ -45,8 +45,9 @@ vtctldclient ApplySchema [--ddl-strategy <strategy>] [--uuid <uuid> ...] [--migr
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ApplyShardRoutingRules
 
@@ -24,8 +25,9 @@ vtctldclient ApplyShardRoutingRules {--rules RULES | --rules-file RULES_FILE} [-
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ApplyVSchema
 
@@ -26,8 +27,9 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,6 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Backup
 
@@ -23,8 +24,9 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,6 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient BackupShard
 
@@ -29,8 +30,9 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,6 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ChangeTabletType
 
@@ -27,8 +28,9 @@ vtctldclient ChangeTabletType [--dry-run] <alias> <tablet-type>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient CreateKeyspace
 
@@ -34,8 +35,9 @@ vtctldclient CreateKeyspace <keyspace> [--force|-f] [--type KEYSPACE_TYPE] [--ba
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,6 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient CreateShard
 
@@ -21,8 +22,9 @@ vtctldclient CreateShard [--force|-f] [--include-parent|-p] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteCellInfo
 
@@ -24,8 +25,9 @@ vtctldclient DeleteCellInfo [--force] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteCellsAlias
 
@@ -23,8 +24,9 @@ vtctldclient DeleteCellsAlias <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteKeyspace
 
@@ -28,8 +29,9 @@ vtctldclient DeleteKeyspace [--recursive|-r] [--force|-f] <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteShards
 
@@ -30,8 +31,9 @@ vtctldclient DeleteShards [--recursive|-r] [--even-if-serving] [--force|-f] <key
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteSrvVSchema
 
@@ -19,8 +20,9 @@ vtctldclient DeleteSrvVSchema <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,6 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient DeleteTablets
 
@@ -20,8 +21,9 @@ vtctldclient DeleteTablets <alias> [ <alias> ... ]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,6 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient EmergencyReparentShard
 
@@ -24,8 +25,9 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ExecuteFetchAsApp
 
@@ -22,8 +23,9 @@ vtctldclient ExecuteFetchAsApp [--max-rows <max-rows>] [--json|-j] [--use-pool] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ExecuteFetchAsDBA
 
@@ -23,8 +24,9 @@ vtctldclient ExecuteFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disable-bi
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,6 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ExecuteHook
 
@@ -33,8 +34,9 @@ vtctldclient ExecuteHook <alias> <hook_name> [<param1=value1> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient FindAllShardsInKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient FindAllShardsInKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,6 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GenerateShardRanges
 
@@ -19,8 +20,9 @@ vtctldclient GenerateShardRanges <num_shards>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,6 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetBackups
 
@@ -21,8 +22,9 @@ vtctldclient GetBackups [--limit <limit>] [--json] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetCellInfo
 
@@ -19,8 +20,9 @@ vtctldclient GetCellInfo <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetCellInfoNames
 
@@ -19,8 +20,9 @@ vtctldclient GetCellInfoNames
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,6 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetCellsAliases
 
@@ -19,8 +20,9 @@ vtctldclient GetCellsAliases
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,6 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetFullStatus
 
@@ -19,8 +20,9 @@ vtctldclient GetFullStatus <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient GetKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,6 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetKeyspaces
 
@@ -19,8 +20,9 @@ vtctldclient GetKeyspaces
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,6 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetPermissions
 
@@ -19,8 +20,9 @@ vtctldclient GetPermissions <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetRoutingRules
 
@@ -19,8 +20,9 @@ vtctldclient GetRoutingRules
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetSchema
 
@@ -25,8 +26,9 @@ vtctldclient GetSchema [--tables TABLES ...] [--exclude-tables EXCLUDE_TABLES ..
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,6 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetShard
 
@@ -19,8 +20,9 @@ vtctldclient GetShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,6 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetShardRoutingRules
 
@@ -27,8 +28,9 @@ vtctldclient GetShardRoutingRules
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetSrvKeyspaceNames
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvKeyspaceNames [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetSrvKeyspaces
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvKeyspaces <keyspace> [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetSrvVSchema
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvVSchema cell
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,6 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetSrvVSchemas
 
@@ -19,8 +20,9 @@ vtctldclient GetSrvVSchemas [<cell> ...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,6 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetTablet
 
@@ -19,8 +20,9 @@ vtctldclient GetTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,6 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetTabletVersion
 
@@ -19,8 +20,9 @@ vtctldclient GetTabletVersion <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,6 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetTablets
 
@@ -47,8 +48,9 @@ vtctldclient GetTablets [--strict] [{--cell $c1 [--cell $c2 ...] [--tablet-type 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,6 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetTopologyPath
 
@@ -19,8 +20,9 @@ vtctldclient GetTopologyPath <path>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,6 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetVSchema
 
@@ -19,8 +20,9 @@ vtctldclient GetVSchema <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,6 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient GetWorkflows
 
@@ -13,15 +14,17 @@ vtctldclient GetWorkflows <keyspace>
 ### Options
 
 ```
-  -h, --help       help for GetWorkflows
-  -a, --show-all   Show all workflows instead of just active workflows.
+  -h, --help           help for GetWorkflows
+      --include-logs   Include recent logs for the workflows. (default true)
+  -a, --show-all       Show all workflows instead of just active workflows.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,6 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LegacyVtctlCommand
 
@@ -52,8 +53,9 @@ LegacyVtctlCommand -- AddCellInfo --server_address "localhost:5678" --root "/vit
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LookupVindex
 
@@ -18,8 +18,9 @@ Perform commands related to creating, backfilling, and externalizing Lookup Vind
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LookupVindex cancel
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LookupVindex create
 
@@ -37,9 +37,10 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LookupVindex externalize
 
@@ -27,9 +27,10 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient LookupVindex show
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --name string               The name of the Lookup Vindex to create. This will also be the name of the VReplication workflow created to backfill the Lookup Vindex.
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --table-keyspace string     The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,0 +1,35 @@
+---
+title: Materialize
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize
+
+Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+
+### Options
+
+```
+      --format string            The format of the output; supported formats are: text,json. (default "text")
+  -h, --help                     help for Materialize
+      --target-keyspace string   Target keyspace for this workflow.
+  -w, --workflow string          The workflow you want to perform the command on.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Materialize cancel](./vtctldclient_materialize_cancel/)	 - Cancel a Materialize VReplication workflow.
+* [vtctldclient Materialize create](./vtctldclient_materialize_create/)	 - Create and run a Materialize VReplication workflow.
+* [vtctldclient Materialize show](./vtctldclient_materialize_show/)	 - Show the details for a Materialize VReplication workflow.
+* [vtctldclient Materialize start](./vtctldclient_materialize_start/)	 - Start a Materialize workflow.
+* [vtctldclient Materialize stop](./vtctldclient_materialize_stop/)	 - Stop a Materialize workflow.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,0 +1,40 @@
+---
+title: Materialize cancel
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize cancel
+
+Cancel a Materialize VReplication workflow.
+
+```
+vtctldclient Materialize cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,0 +1,76 @@
+---
+title: Materialize create
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize create
+
+Create and run a Materialize VReplication workflow.
+
+### Synopsis
+
+Materialize is a lower level VReplication command that allows for generalized materialization
+of tables. The target tables can be copies, aggregations, or views. The target tables are kept
+in sync in near-realtime. The primary flag used to define the materializations (you can have
+multiple per workflow) is table-settings which is a JSON array where each value must contain
+two key/value pairs. The first required key is 'target_table' and it is the name of the table
+in the target-keyspace to store the results in. The second required key is 'source_expression'
+and its value is the select query to run against the source table. An optional key/value pair
+can also be specified for 'create_ddl' which provides the DDL to create the target table if it
+does not exist -- you can alternatively specify a value of 'copy' if the target table schema
+should be copied as-is from the source keyspace. Here's an example value for table-settings:
+[
+  {
+    "target_table": "customer_one_email",
+    "source_expression": "select email from customer where customer_id = 1"
+  },
+  {
+    "target_table": "states",
+    "source_expression": "select * from states",
+    "create_ddl": "copy"
+  },
+  {
+    "target_table": "sales_by_sku",
+    "source_expression": "select sku, count(*) as orders, sum(price) as revenue from corder group by sku",
+    "create_ddl": "create table sales_by_sku (sku varbinary(128) not null primary key, orders bigint, revenue bigint)"
+  }
+]
+
+
+```
+vtctldclient Materialize create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 materialize --workflow product_sales --target-keyspace commerce create --source-keyspace commerce --table-settings '[{"target_table": "sales_by_sku", "create_ddl": "create table sales_by_sku (sku varbinary(128) not null primary key, orders bigint, revenue bigint)", "source_expression": "select sku, count(*) as orders, sum(price) as revenue from corder group by sku"}]' --cells zone1 --cells zone2 --tablet-types replica
+```
+
+### Options
+
+```
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+  -h, --help                               help for create
+      --source-keyspace string             Keyspace where the tables queried in the 'source_expression' values within table-settings live.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --table-settings JSON                A JSON array defining what tables to materialize using what select statements. See the --help output for more details. (default null)
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,0 +1,41 @@
+---
+title: Materialize show
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize show
+
+Show the details for a Materialize VReplication workflow.
+
+```
+vtctldclient Materialize show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,0 +1,40 @@
+---
+title: Materialize start
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize start
+
+Start a Materialize workflow.
+
+```
+vtctldclient Materialize start
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer start
+```
+
+### Options
+
+```
+  -h, --help   help for start
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,0 +1,40 @@
+---
+title: Materialize stop
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Materialize stop
+
+Stop a Materialize workflow.
+
+```
+vtctldclient Materialize stop
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Materialize --workflow product_sales --target-keyspace customer stop
+```
+
+### Options
+
+```
+  -h, --help   help for stop
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,0 +1,35 @@
+---
+title: Migrate
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate
+
+Migrate is used to import data from an external cluster into the current cluster.
+
+### Options
+
+```
+      --format string            The format of the output; supported formats are: text,json. (default "text")
+  -h, --help                     help for Migrate
+      --target-keyspace string   Target keyspace for this workflow.
+  -w, --workflow string          The workflow you want to perform the command on.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Migrate cancel](./vtctldclient_migrate_cancel/)	 - Cancel a Migrate VReplication workflow.
+* [vtctldclient Migrate complete](./vtctldclient_migrate_complete/)	 - Complete a Migrate VReplication workflow.
+* [vtctldclient Migrate create](./vtctldclient_migrate_create/)	 - Create and optionally run a Migrate VReplication workflow.
+* [vtctldclient Migrate show](./vtctldclient_migrate_show/)	 - Show the details for a Migrate VReplication workflow.
+* [vtctldclient Migrate status](./vtctldclient_migrate_status/)	 - Show the current status for a Migrate VReplication workflow.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,0 +1,40 @@
+---
+title: Migrate cancel
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate cancel
+
+Cancel a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate cancel
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer cancel
+```
+
+### Options
+
+```
+  -h, --help   help for cancel
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,0 +1,40 @@
+---
+title: Migrate complete
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate complete
+
+Complete a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate complete
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer complete
+```
+
+### Options
+
+```
+  -h, --help   help for complete
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,0 +1,54 @@
+---
+title: Migrate create
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate create
+
+Create and optionally run a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate create
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 migrate --workflow import --target-keyspace customer create --source-keyspace commerce --mount-name ext1 --tablet-types replica
+```
+
+### Options
+
+```
+      --all-tables                         Copy all tables from the source.
+      --auto-start                         Start the workflow after creating it. (default true)
+  -c, --cells strings                      Cells and/or CellAliases to copy table data from.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+      --exclude-tables strings             Source tables to exclude from copying.
+  -h, --help                               help for create
+      --mount-name string                  Name external cluster is mounted as.
+      --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
+      --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
+      --source-keyspace string             Keyspace where the tables are being moved from.
+      --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --tables strings                     Source tables to copy.
+      --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
+      --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,0 +1,41 @@
+---
+title: Migrate show
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate show
+
+Show the details for a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer show
+```
+
+### Options
+
+```
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,0 +1,40 @@
+---
+title: Migrate status
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Migrate status
+
+Show the current status for a Migrate VReplication workflow.
+
+```
+vtctldclient Migrate status
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspace customer status
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --format string             The format of the output; supported formats are: text,json. (default "text")
+      --server string             server to use for the connection (required)
+      --target-keyspace string    Target keyspace for this workflow.
+  -w, --workflow string           The workflow you want to perform the command on.
+```
+
+### SEE ALSO
+
+* [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,0 +1,31 @@
+---
+title: Mount
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Mount
+
+Mount is used to link an external Vitess cluster in order to migrate data from it.
+
+### Options
+
+```
+  -h, --help   help for Mount
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+* [vtctldclient Mount list](./vtctldclient_mount_list/)	 - List all mounted external Vitess Clusters.
+* [vtctldclient Mount register](./vtctldclient_mount_register/)	 - Register an external Vitess Cluster.
+* [vtctldclient Mount show](./vtctldclient_mount_show/)	 - Show attributes of a previously mounted external Vitess Cluster.
+* [vtctldclient Mount unregister](./vtctldclient_mount_unregister/)	 - Unregister a previously mounted external Vitess Cluster.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,0 +1,37 @@
+---
+title: Mount list
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Mount list
+
+List all mounted external Vitess Clusters.
+
+```
+vtctldclient Mount list
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount list
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,0 +1,41 @@
+---
+title: Mount register
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Mount register
+
+Register an external Vitess Cluster.
+
+```
+vtctldclient Mount register
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount register --name ext1 --topo-type etcd2 --topo-server localhost:12379 --topo-root /vitess/global
+```
+
+### Options
+
+```
+  -h, --help                 help for register
+      --name string          Name to use for the mount.
+      --topo-root string     Topo server root path.
+      --topo-server string   Topo server address.
+      --topo-type string     Topo server implementation to use.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,0 +1,38 @@
+---
+title: Mount show
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Mount show
+
+Show attributes of a previously mounted external Vitess Cluster.
+
+```
+vtctldclient Mount show
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount show --name ext1
+```
+
+### Options
+
+```
+  -h, --help          help for show
+      --name string   Name of the mount.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,0 +1,38 @@
+---
+title: Mount unregister
+series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
+---
+## vtctldclient Mount unregister
+
+Unregister a previously mounted external Vitess Cluster.
+
+```
+vtctldclient Mount unregister
+```
+
+### Examples
+
+```
+vtctldclient --server localhost:15999 mount unregister --name ext1
+```
+
+### Options
+
+```
+  -h, --help          help for unregister
+      --name string   Name of the mount.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
+```
+
+### SEE ALSO
+
+* [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
+

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables
 
@@ -19,8 +19,9 @@ Perform commands related to moving tables from a source keyspace to a target key
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables cancel
 
@@ -20,15 +20,18 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for cancel
+  -h, --help                 help for cancel
+      --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace.
+      --keep-routing-rules   Keep the routing rules created for the MoveTables workflow.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables complete
 
@@ -20,15 +20,20 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for complete
+      --dry-run              Print the actions that would be taken and report any known errors that would have occurred.
+  -h, --help                 help for complete
+      --keep-data            Keep the original source table data that was copied by the MoveTables workflow.
+      --keep-routing-rules   Keep the routing rules in place that direct table traffic from the source keyspace to the target keyspace of the MoveTables workflow.
+      --rename-tables        Keep the original source table data that was copied by the MoveTables workflow, but rename each table to '_<tablename>_old'.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables create
 
@@ -22,7 +22,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ```
       --all-tables                         Copy all tables from the source.
       --atomic-copy                        (EXPERIMENTAL) A single copy phase is run for all tables from the source. Use this, for example, if your source keyspace has tables which use foreign key constraints.
-      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+      --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
       --exclude-tables strings             Source tables to exclude from copying.
@@ -30,9 +30,9 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
       --no-routing-rules                   (Advanced) Do not create routing rules while creating the workflow. See the reference documentation for limitations if you use this flag.
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --source-keyspace string             Keyspace where the tables are being moved from.
-      --source-shards strings              Source shards to copy data from when performing a partial moveTables (experimental).
+      --source-shards strings              Source shards to copy data from when performing a partial MoveTables (experimental).
       --source-time-zone string            Specifying this causes any DATETIME fields to be converted from the given time zone into UTC.
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --tables strings                     Source tables to copy.
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
@@ -41,9 +41,10 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables reversetraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables show
 
@@ -20,15 +20,17 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables start
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables status
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient MoveTables switchtraffic
 
@@ -33,9 +33,10 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL
 
@@ -16,8 +16,9 @@ Operates on online DDL (schema migrations).
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL cancel
 
@@ -26,8 +26,9 @@ OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL cleanup
 
@@ -26,8 +26,9 @@ OnlineDDL cleanup test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL complete
 
@@ -26,8 +26,9 @@ OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL launch
 
@@ -26,8 +26,9 @@ OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL retry
 
@@ -26,8 +26,9 @@ vtctl OnlineDDL retry test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL show
 
@@ -37,8 +37,9 @@ OnlineDDL show test_keyspace failed
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL throttle
 
@@ -26,8 +26,9 @@ OnlineDDL throttle all
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 476ca265d0583549c05a3ab88f76bc8d24174364
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient OnlineDDL unthrottle
 
@@ -26,8 +26,9 @@ OnlineDDL unthrottle all
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,6 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient PingTablet
 
@@ -19,8 +20,9 @@ vtctldclient PingTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,6 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -22,8 +23,9 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,6 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RebuildKeyspaceGraph
 
@@ -21,8 +22,9 @@ vtctldclient RebuildKeyspaceGraph [--cells=c1,c2,...] [--allow-partial] ks1 [ks2
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,6 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RebuildVSchemaGraph
 
@@ -20,8 +21,9 @@ vtctldclient RebuildVSchemaGraph [--cells=c1,c2,...]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,6 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RefreshState
 
@@ -19,8 +20,9 @@ vtctldclient RefreshState <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,6 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RefreshStateByShard
 
@@ -20,8 +21,9 @@ vtctldclient RefreshStateByShard [--cell <cell1> ...] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ReloadSchema
 
@@ -19,8 +20,9 @@ vtctldclient ReloadSchema <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ReloadSchemaKeyspace
 
@@ -21,8 +22,9 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,6 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ReloadSchemaShard
 
@@ -21,8 +22,9 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RemoveBackup
 
@@ -19,8 +20,9 @@ vtctldclient RemoveBackup <keyspace/shard> <backup name>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RemoveKeyspaceCell
 
@@ -21,8 +22,9 @@ vtctldclient RemoveKeyspaceCell [--force|-f] [--recursive|-r] <keyspace> <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,6 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RemoveShardCell
 
@@ -21,8 +22,9 @@ vtctldclient RemoveShardCell [--force|-f] [--recursive|-r] <keyspace/shard> <cel
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,6 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ReparentTablet
 
@@ -19,8 +20,9 @@ vtctldclient ReparentTablet <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard
 
@@ -19,8 +19,9 @@ Perform commands related to resharding a keyspace.
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard cancel
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard complete
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard create
 
@@ -20,14 +20,14 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
 ### Options
 
 ```
-      --auto-start                         Start the MoveTables workflow after creating it. (default true)
+      --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
   -h, --help                               help for create
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --skip-schema-copy                   Skip copying the schema from the source shards to the target shards.
       --source-shards strings              Source shards.
-      --stop-after-copy                    Stop the MoveTables workflow after it's finished copying the existing rows and before it starts replicating changes.
+      --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
       --target-shards strings              Target shards.
@@ -36,9 +36,10 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard reversetraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard show
 
@@ -20,15 +20,17 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options
 
 ```
-  -h, --help   help for show
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard start
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard status
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Reshard switchtraffic
 
@@ -32,9 +32,10 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,6 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RestoreFromBackup
 
@@ -23,8 +24,9 @@ vtctldclient RestoreFromBackup [--backup-timestamp|-t <YYYY-mm-DD.HHMMSS>] [--re
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,6 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient RunHealthCheck
 
@@ -19,8 +20,9 @@ vtctldclient RunHealthCheck <tablet_alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,6 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 
@@ -29,8 +30,9 @@ vtctldclient SetKeyspaceDurabilityPolicy [--durability-policy=policy_name] <keys
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,6 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SetShardIsPrimaryServing
 
@@ -19,8 +20,9 @@ vtctldclient SetShardIsPrimaryServing <keyspace/shard> <true/false>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,6 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SetShardTabletControl
 
@@ -41,8 +42,9 @@ vtctldclient SetShardTabletControl [--cells=c1,c2...] [--denied-tables=t1,t2,...
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,6 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SetWritable
 
@@ -19,8 +20,9 @@ vtctldclient SetWritable <alias> <true/false>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,6 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ShardReplicationFix
 
@@ -19,8 +20,9 @@ vtctldclient ShardReplicationFix <cell> <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,6 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ShardReplicationPositions
 
@@ -25,8 +26,9 @@ vtctldclient ShardReplicationPositions <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,6 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SleepTablet
 
@@ -35,8 +36,9 @@ vtctldclient SleepTablet <alias> <duration>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,6 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SourceShardAdd
 
@@ -21,8 +22,9 @@ vtctldclient SourceShardAdd [--key-range <keyrange>] [--tables <table1,table2,..
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,6 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient SourceShardDelete
 
@@ -19,8 +20,9 @@ vtctldclient SourceShardDelete <keyspace/shard> <uid>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,6 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient StartReplication
 
@@ -19,8 +20,9 @@ vtctldclient StartReplication <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,6 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient StopReplication
 
@@ -19,8 +20,9 @@ vtctldclient StopReplication <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,6 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient TabletExternallyReparented
 
@@ -26,8 +27,9 @@ vtctldclient TabletExternallyReparented <alias>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient UpdateCellInfo
 
@@ -27,8 +28,9 @@ vtctldclient UpdateCellInfo [--root <root>] [--server-address <addr>] <cell>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient UpdateCellsAlias
 
@@ -24,8 +25,9 @@ vtctldclient UpdateCellsAlias [--cells <cell1,cell2,...> [--cells <cell4> ...]] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,6 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient UpdateThrottlerConfig
 
@@ -30,8 +31,9 @@ vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff
 
@@ -19,8 +19,9 @@ Perform commands related to diffing tables involved in a VReplication workflow b
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 30385807689b40668d60dbb5059ea0987f19da5c
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff create
 
@@ -14,7 +14,7 @@ vtctldclient VDiff create
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer
+vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002
 ```
 
@@ -41,9 +41,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff delete
 
@@ -27,9 +27,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff resume
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff show
 
@@ -29,9 +29,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient VDiff stop
 
@@ -26,9 +26,10 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
       --format string             The format of the output; supported formats are: text,json. (default "text")
-      --server string             server to use for connection (required)
+      --server string             server to use for the connection (required)
       --target-keyspace string    Target keyspace for this workflow.
   -w, --workflow string           The workflow you want to perform the command on.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,6 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Validate
 
@@ -20,8 +21,9 @@ vtctldclient Validate [--ping-tablets]
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ValidateKeyspace
 
@@ -20,8 +21,9 @@ vtctldclient ValidateKeyspace [--ping-tablets] <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ValidateSchemaKeyspace
 
@@ -23,8 +24,9 @@ vtctldclient ValidateSchemaKeyspace [--exclude-tables=<exclude_tables>] [--inclu
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ValidateShard
 
@@ -20,8 +21,9 @@ vtctldclient ValidateShard [--ping-tablets] <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ValidateVersionKeyspace
 
@@ -19,8 +20,9 @@ vtctldclient ValidateVersionKeyspace <keyspace>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,6 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient ValidateVersionShard
 
@@ -19,8 +20,9 @@ vtctldclient ValidateVersionShard <keyspace/shard>
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: e73ce917ed97a6a8586cd3647cb2f498fe908a0e
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow
 
@@ -15,14 +15,15 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
 
 ```
   -h, --help              help for Workflow
-  -k, --keyspace string   Keyspace context for the workflow (required).
+  -k, --keyspace string   Keyspace context for the workflow.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow delete
 
@@ -22,15 +23,16 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
   -h, --help                 help for delete
       --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the workflow.
-  -w, --workflow string      The workflow you want to delete (required).
+  -w, --workflow string      The workflow you want to delete.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow list
 
@@ -25,9 +26,10 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow show
 
@@ -20,15 +21,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
 
 ```
   -h, --help              help for show
-  -w, --workflow string   The workflow you want the details for (required).
+      --include-logs      Include recent logs for the workflow. (default true)
+  -w, --workflow string   The workflow you want the details for.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow start
 
@@ -19,15 +20,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ### Options
 
 ```
-  -h, --help   help for start
+  -h, --help              help for start
+  -w, --workflow string   The workflow you want to start.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow stop
 
@@ -19,15 +20,17 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 ### Options
 
 ```
-  -h, --help   help for stop
+  -h, --help              help for stop
+  -w, --workflow string   The workflow you want to stop.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,6 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
+commit: 0f751fbb7c64ca5280c5d4f58d038e1df5477c67
 ---
 ## vtctldclient Workflow update
 
@@ -24,15 +25,16 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
       --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE.
   -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
-  -w, --workflow string         The workflow you want to update (required).
+  -w, --workflow string         The workflow you want to update.
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --action_timeout duration   timeout for the total command (default 1h0m0s)
-  -k, --keyspace string           Keyspace context for the workflow (required).
-      --server string             server to use for connection (required)
+      --action_timeout duration   timeout to use for the command (default 1h0m0s)
+      --compact                   use compact format for otherwise verbose outputs
+  -k, --keyspace string           Keyspace context for the workflow.
+      --server string             server to use for the connection (required)
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
This was not done automatically when the Materialize, Mount, and Migrate commands were added.