### PR TITLE
Docs: preliminary notice about upcoming changes to lifecycle table names

### DIFF
--- a/content/en/docs/19.0/user-guides/schema-changes/table-lifecycle.md
+++ b/content/en/docs/19.0/user-guides/schema-changes/table-lifecycle.md
@@ -81,14 +81,14 @@ Vitess does not track the state of the table lifecycle. The process is stateless
 - The table `_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20210921170000` is eligible to be dropped on `2021-09-21 17:00:00`
 
 {{< info >}}
-Starting Vitess `v20``, the table naming format will change. Tables will be named like so:
+Starting in Vitess `v20`, the table naming format will change. Tables will be named like so:
 
 - `_vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
 - `_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
 - `_vt_evc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
 - `_vt_drp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
 
-Version `v19` supports the new naming format, but does not generate any tables in this format. Version `v20` will generate tables in the new format, and will support the old format. Support for old format will be dropped in `v21` or later.
+`v19` supports the new naming format, but does not generate any tables in this format. `v20` will generate tables in the new format, and will support the old format. Support for old format will be dropped in `v21` or later.
 {{< /info >}}
 
 ## Automated lifecycle

--- a/content/en/docs/19.0/user-guides/schema-changes/table-lifecycle.md
+++ b/content/en/docs/19.0/user-guides/schema-changes/table-lifecycle.md
@@ -80,6 +80,17 @@ Vitess does not track the state of the table lifecycle. The process is stateless
 - The table `_vt_EVAC_6ace8bcef73211ea87e9f875a4d24e90_20210918093000` is held until `2021-09-18 09:30:00`
 - The table `_vt_DROP_6ace8bcef73211ea87e9f875a4d24e90_20210921170000` is eligible to be dropped on `2021-09-21 17:00:00`
 
+{{< info >}}
+Starting Vitess `v20``, the table naming format will change. Tables will be named like so:
+
+- `_vt_hld_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
+- `_vt_prg_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
+- `_vt_evc_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
+- `_vt_drp_6ace8bcef73211ea87e9f875a4d24e90_20200915120410_`
+
+Version `v19` supports the new naming format, but does not generate any tables in this format. Version `v20` will generate tables in the new format, and will support the old format. Support for old format will be dropped in `v21` or later.
+{{< /info >}}
+
 ## Automated lifecycle
 
 Vitess internally uses the above table lifecycle for [online, managed schema migrations](../../../user-guides/schema-changes/managed-online-schema-changes/). All online strategies: `vitess`, `gh-ost`, and `pt-online-schema-change`, create artifact tables or end with leftover tables: Vitess automatically collects those tables. The artifact or leftover tables are immediate moved to `hold` state. Depending on `vttablet`'s `--table_gc_lifecycle` flag, they may spend time in this state, getting purged, or immediately transitioned to the next state.


### PR DESCRIPTION
This is a `v19` preliminary documentation of the new internal table names format, specifically in Table Lifecycle. See story in https://github.com/vitessio/vitess/issues/14582 and changes in https://github.com/vitessio/vitess/pull/14613.

Nothing changes in `v19` other than hidden support for new naming.