### PR TITLE
Docs: Backup/BackupShard --incremental-from-pos accepts backup name

### DIFF
--- a/content/en/docs/16.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/16.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: a7f80a82e5d99cf00c253c3902367bec5fa40e5d
+commit: 6c9f87de69a1fdbf6a68ff8375b32a1c2abba291
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -14,7 +14,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options
 
 ```
-  -c, --cells strings       Limit the VSchema graph rebuildingg to the specified cells. Ignored if --skip-rebuild is specified.
+  -c, --cells strings       Limit the VSchema graph rebuilding to the specified cells. Ignored if --skip-rebuild is specified.
   -d, --dry-run             Load the specified routing rules as a validation step, but do not actually apply the rules to the topo.
   -h, --help                help for ApplyRoutingRules
   -r, --rules string        Routing rules, specified as a string.

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/_index.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: workflow
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient workflow
 

--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_update.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: workflow update
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient workflow update
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -14,7 +14,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options
 
 ```
-  -c, --cells strings       Limit the VSchema graph rebuildingg to the specified cells. Ignored if --skip-rebuild is specified.
+  -c, --cells strings       Limit the VSchema graph rebuilding to the specified cells. Ignored if --skip-rebuild is specified.
   -d, --dry-run             Load the specified routing rules as a validation step, but do not actually apply the rules to the topo.
   -h, --help                help for ApplyRoutingRules
   -r, --rules string        Routing rules, specified as a string.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff create
 
@@ -25,8 +25,8 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --debug-query                               Adds a mysql query to the report that can be used for further debugging.
       --filtered-replication-wait-time duration   Specifies the maximum time to wait, in seconds, for replication to catch up when syncing tablet streams. (default 30s)
   -h, --help                                      help for create
-      --limit uint32                              Max rows to stop comparing after. (default 4294967295)
-      --max-extra-rows-to-compare uint32          If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
+      --limit int                                 Max rows to stop comparing after. (default 9223372036854775807)
+      --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --only-pks                                  When reporting missing rows, only show primary keys in the report.
       --source-cells strings                      The source cell(s) to compare from; default is any available cell.
       --tables strings                            Only run vdiff for these tables in the workflow.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/19.0/reference/programs/vtctl/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctl/_index.md
@@ -32,7 +32,7 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 | [ExecuteFetchAsApp](../vtctl/tablets#executefetchasapp) | `ExecuteFetchAsApp  -- [--max_rows=10000] [--json] [--use_pool] <tablet alias> <sql command>` |
 | [ExecuteFetchAsDba](../vtctl/tablets#executefetchasdba) | `ExecuteFetchAsDba  -- [--max_rows=10000] [--disable_binlogs] [--json] <tablet alias> <sql command>` |
 | [VReplicationExec](../vtctl/tablets#vreplicationexec) | `VReplicationExec  -- [--json] <tablet alias> <sql command>` |
-| [Backup](../vtctl/tablets#backup) | `Backup  -- [--concurrency=4] [--allow_primary=false] [--upgrade-safe=false] [--incremental-from-pos=<pos>] <tablet alias>` |
+| [Backup](../vtctl/tablets#backup) | `Backup  -- [--concurrency=4] [--allow_primary=false] [--upgrade-safe=false] [--incremental-from-pos=<pos>|<backup-name>|auto] <tablet alias>` |
 | [RestoreFromBackup](../vtctl/tablets#restorefrombackup) | `RestoreFromBackup <tablet alias>` |
 | [ReparentTablet](../vtctl/tablets#reparenttablet) | `ReparentTablet <tablet alias>` |
 
@@ -55,7 +55,7 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 | [RemoveShardCell](../vtctl/shards#removeshardcell) | `RemoveShardCell  -- [--force] [--recursive] <keyspace/shard> <cell>` |
 | [DeleteShard](../vtctl/shards#deleteshard) | `DeleteShard  -- [--recursive] [--even_if_serving] <keyspace/shard> ...` |
 | [ListBackups](../vtctl/shards#listbackups) | `ListBackups <keyspace/shard>` |
-| [BackupShard](../vtctl/shards#backupshard) | `BackupShard  -- [--allow_primary=false] [--upgrade-safe=false] <keyspace/shard>` [--incremental_from_pos=<pos>] |
+| [BackupShard](../vtctl/shards#backupshard) | `BackupShard  -- [--allow_primary=false] [--upgrade-safe=false] <keyspace/shard>` [--incremental_from_pos=<pos>|<backup-name>|auto] |
 | [RemoveBackup](../vtctl/shards#removebackup) | `RemoveBackup <keyspace/shard> <backup name>` |
 | (DEPRECATED) [InitShardPrimary](../vtctl/shards#initshardprimary) | `InitShardPrimary  -- [--force] [--wait_replicas_timeout=<duration>] <keyspace/shard> <tablet alias>` |
 | [PlannedReparentShard](../vtctl/shards#plannedreparentshard) | `PlannedReparentShard  -- --keyspace_shard=<keyspace/shard> [--new_primary=<tablet alias>] [--avoid_tablet=<tablet alias>] [--wait_replicas_timeout=<duration>]` |

--- a/content/en/docs/19.0/reference/programs/vtctl/shards.md
+++ b/content/en/docs/19.0/reference/programs/vtctl/shards.md
@@ -325,7 +325,7 @@ Lists all the backups for a shard.
 ### BackupShard
 
 ```
-BackupShard -- [--allow_primary=false] [--upgrade-safe=false] [--incremental-from-pos=<pos>] <keyspace/shard>
+BackupShard -- [--allow_primary=false] [--upgrade-safe=false] [--incremental-from-pos=<pos>|<backup-name>|auto] <keyspace/shard>
 ```
 
 ### RemoveBackup

--- a/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,14 +1,14 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ApplyVSchema
 
 Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
 
 ```
-vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> || --sql=<sql> || --sql-file=<sql file>} [--cells=c1,c2,...] [--skip-rebuild] [--dry-run] <keyspace>
+vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> || --sql=<sql> || --sql-file=<sql file>} [--cells=c1,c2,...] [--skip-rebuild] [--dry-run] [--strict] <keyspace>
 ```
 
 ### Options
@@ -20,6 +20,7 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
       --skip-rebuild                            Skip rebuilding the SrvSchema objects.
       --sql alter table t add vindex hash(id)   A VSchema DDL SQL statement, e.g. alter table t add vindex hash(id).
       --sql-file string                         Path to a file containing a VSchema DDL SQL.
+      --strict                                  If set, treat unknown vindex params as errors.
       --vschema string                          VSchema to apply, in JSON form.
       --vschema-file string                     Path to a file containing the vschema to apply, in JSON form.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Backup
 
@@ -15,7 +15,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
 
 ```
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --concurrency uint              Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for Backup
       --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -8,7 +8,7 @@ commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 Uses the BackupStorage service on the given tablet to create and store a new backup.
 
 ```
-vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|auto] [--upgrade-safe] <tablet_alias>
+vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|<backup-name>|auto] [--upgrade-safe] <tablet_alias>
 ```
 
 ### Options
@@ -17,7 +17,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for Backup
-      --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient BackupShard
 
@@ -21,7 +21,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
 
 ```
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --concurrency uint              Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for BackupShard
       --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -14,7 +14,7 @@ Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard an
 If no replica-type tablet can be found, the backup can be taken on the primary if --allow-primary is specified.
 
 ```
-vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|auto] [--upgrade-safe] <keyspace/shard>
+vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|<backup-name>|auto] [--upgrade-safe] <keyspace/shard>
 ```
 
 ### Options
@@ -23,7 +23,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for BackupShard
-      --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize create
 
@@ -52,7 +52,10 @@ vtctldclient --server localhost:15999 materialize --workflow product_sales --tar
 ```
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
   -h, --help                               help for create
+      --mysql_server_version string        Configure the MySQL version to use for example for the parser. (default "8.0.30-Vitess")
       --source-keyspace string             Keyspace where the tables queried in the 'source_expression' values within table-settings live.
+      --sql-max-length-errors int          truncate queries in error logs to the given length (default unlimited)
+      --sql-max-length-ui int              truncate queries in debug UIs to the given length (default 512) (default 512)
       --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --table-settings JSON                A JSON array defining what tables to materialize using what select statements. See the --help output for more details. (default null)
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 3b58bee089a76fdb1f9d452787e40f10e34f034d
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ReloadSchemaKeyspace
 
@@ -14,9 +14,9 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
 ### Options
 
 ```
-      --concurrency uint32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
-  -h, --help                 help for ReloadSchemaKeyspace
-      --include-primary      Also reload the primary tablets.
+      --concurrency int32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
+  -h, --help                help for ReloadSchemaKeyspace
+      --include-primary     Also reload the primary tablets.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ReloadSchemaShard
 
@@ -14,9 +14,9 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
 ### Options
 
 ```
-      --concurrency uint32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
-  -h, --help                 help for ReloadSchemaShard
-      --include-primary      Also reload the primary tablet.
+      --concurrency int32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
+  -h, --help                help for ReloadSchemaShard
+      --include-primary     Also reload the primary tablet.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff create
 
@@ -26,6 +26,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --filtered-replication-wait-time duration   Specifies the maximum time to wait, in seconds, for replication to catch up when syncing tablet streams. (default 30s)
   -h, --help                                      help for create
       --limit int                                 Max rows to stop comparing after. (default 9223372036854775807)
+      --max-diff-duration duration                How long should an individual table diff run before being stopped and restarted in order to lessen the impact on tablets due to holding open database snapshots for long periods of time (0 is the default and means no time limit).
       --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --max-report-sample-rows int                Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks (default 10)
       --only-pks                                  When reporting missing rows, only show primary keys in the report.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 3091de1ea79b2ea900007b27403a5c2235092d44
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -101,19 +101,27 @@ vtctldclient --server=<vtctld_host>:<vtctld_port> BackupShard [--allow_primary=f
 
 ## Create an incremental backup with vtctl
 
-An incremental backup requires additional information: the point from which to start the backup. An incremental backup is taken by supplying `--incremental-from-pos` to the `Backup` or `BackupShard` command. The argument may either indicate a valid position, or the value `auto`. Examples:
+An incremental backup requires additional information: the point from which to start the backup. An incremental backup is taken by supplying `--incremental-from-pos` to the `Backup` or `BackupShard` command. The argument may either indicate:
+
+- A valid position.
+- A name of a successful backup.
+- Or, the value `auto`.
 
 ```sh
 vtctldclient Backup --incremental-from-pos="MySQL56/0d7aaca6-1666-11ee-aeaf-0a43f95f28a3:1-53" zone1-0000000102
 
 vtctldclient Backup --incremental-from-pos="0d7aaca6-1666-11ee-aeaf-0a43f95f28a3:1-53" zone1-0000000102
 
+vtctldclient Backup --incremental-from-pos="2024-01-10.062022.zone1-0000000101 commerce/0" zone1-0000000102
+
 vtctldclient Backup --incremental-from-pos="auto" zone1-0000000102
 
 vtctldclient BackupShard --incremental-from-pos=auto commerce/0
 ```
 
-When indicating a position, you may choose to use or to omit the `MySQL56/` prefix (which you can find in the backup manifest's Position).
+When `--incremental-from-pos` supplies a position, you may choose to use or to omit the `MySQL56/` prefix (which you can find in the backup manifest's Position).
+
+When `--incremental-from-pos` indicates a backup name, that must be a successfully completed, existing backup. It may be either a full or an incremental backup.
 
 When `--incremental-from-pos="auto"`, Vitess chooses the position of the last successful backup as the starting point for the incremental backup. This is a convenient way to ensure a sequence of contiguous incremental backups.
 


### PR DESCRIPTION
This PR documents the changes in https://github.com/vitessio/vitess/pull/14923, `--incremental-from-pos` accepting a backup name.

There is a lot of noise because of SHA signatures. The relevant changes are mostly in `content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md` and otherwise in `vtctl` and `vtctldclient` docs.