### PR TITLE
Upgrade K8S version to `v1.28.5` in vtop example

### DIFF
--- a/content/en/docs/19.0/get-started/operator.md
+++ b/content/en/docs/19.0/get-started/operator.md
@@ -15,7 +15,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
     ```bash
-    minikube start --kubernetes-version=v1.25.8 --cpus=4 --memory=11000 --disk-size=32g
+    minikube start --kubernetes-version=v1.28.5 --cpus=4 --memory=11000 --disk-size=32g
     ```
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and ensure it is in your `PATH`.


### PR DESCRIPTION
This change matches the compatibility table of vtop: https://github.com/planetscale/vitess-operator#compatibility