### PR TITLE
fail if there are no sync changes to commit instead of committing empty

### DIFF
--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -30,4 +30,10 @@ git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs) || true
 git checkout -- .
 # Add any net-new files that were missed in the first `git add`.
 git add content/**
-git commit --allow-empty -sm "sync cobradocs to latest release branches"
+
+if [ $(git diff --cached --name-only | wc -l) -eq 0 ]; then
+    echo "No changes to cobradocs detected" >&2
+    exit 1
+fi
+
+git commit -sm "sync cobradocs to latest release branches"


### PR DESCRIPTION
this prevents us from creating unnecessary empty commits and better communicates when there were no changes to sync.

running the script twice in a row results in the following on the _second_ run:

```
+ git add
Nothing specified, nothing added.
hint: Maybe you wanted to say 'git add .'?
hint: Turn this message off by running
hint: "git config advice.addEmptyPathspec false"
+ git checkout -- .
+ git add content/en content/zh
++ git diff --cached --name-only
++ wc -l
+ '[' 0 -eq 0 ']'
+ echo 'No changes to cobradocs detected'
No changes to cobradocs detected
+ exit 1
```