### PR TITLE
Docs: Backup/BackupShard --incremental-from-pos accepts backup name

### DIFF
--- a/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/17.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 9a3d0f4a69a840cfa2cb86654abd4afa0be6e0aa
+commit: 9a3628037518bc108c636220319f3c7385b2a559
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -14,7 +14,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options
 
 ```
-  -c, --cells strings       Limit the VSchema graph rebuildingg to the specified cells. Ignored if --skip-rebuild is specified.
+  -c, --cells strings       Limit the VSchema graph rebuilding to the specified cells. Ignored if --skip-rebuild is specified.
   -d, --dry-run             Load the specified routing rules as a validation step, but do not actually apply the rules to the topo.
   -h, --help                help for ApplyRoutingRules
   -r, --rules string        Routing rules, specified as a string.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient ApplyRoutingRules
 
@@ -14,7 +14,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
 ### Options
 
 ```
-  -c, --cells strings       Limit the VSchema graph rebuildingg to the specified cells. Ignored if --skip-rebuild is specified.
+  -c, --cells strings       Limit the VSchema graph rebuilding to the specified cells. Ignored if --skip-rebuild is specified.
   -d, --dry-run             Load the specified routing rules as a validation step, but do not actually apply the rules to the topo.
   -h, --help                help for ApplyRoutingRules
   -r, --rules string        Routing rules, specified as a string.

--- a/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/18.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 9a6f5262f7707ff80ce85c111d2ff686d85d29cc
+commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
 ---
 ## vtctldclient VDiff create
 
@@ -25,8 +25,8 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --debug-query                               Adds a mysql query to the report that can be used for further debugging.
       --filtered-replication-wait-time duration   Specifies the maximum time to wait, in seconds, for replication to catch up when syncing tablet streams. (default 30s)
   -h, --help                                      help for create
-      --limit uint32                              Max rows to stop comparing after. (default 4294967295)
-      --max-extra-rows-to-compare uint32          If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
+      --limit int                                 Max rows to stop comparing after. (default 9223372036854775807)
+      --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --only-pks                                  When reporting missing rows, only show primary keys in the report.
       --source-cells strings                      The source cell(s) to compare from; default is any available cell.
       --tables strings                            Only run vdiff for these tables in the workflow.

--- a/content/en/docs/19.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl
 
@@ -80,6 +80,7 @@ This helps ensure that `mysqld` is automatically restarted after failures.
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl init
 
@@ -98,6 +98,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl init_config
 
@@ -96,6 +96,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl position
 
@@ -81,6 +81,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl reinit_config
 
@@ -96,6 +96,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl shutdown
 
@@ -94,6 +94,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl start
 
@@ -93,6 +93,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctl teardown
 
@@ -97,6 +97,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## mysqlctld
 
@@ -123,6 +123,7 @@ mysqlctld \
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/19.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## topo2topo
 
@@ -47,6 +47,7 @@ topo2topo [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)

--- a/content/en/docs/19.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtaclcheck
 
@@ -31,6 +31,7 @@ vtaclcheck [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --static-auth-file string                                     The path of the auth_server_static JSON file to check

--- a/content/en/docs/19.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtbackup
 
@@ -151,7 +151,7 @@ vtbackup [flags]
       --grpc_max_message_size int                                   Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                             Enable gRPC monitoring with Prometheus.
   -h, --help                                                        help for vtbackup
-      --incremental_from_pos string                                 Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
+      --incremental_from_pos string                                 Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
       --init_db_name_override string                                (init parameter) override the name of the db used by vttablet
       --init_db_sql_file string                                     path to .sql file to run after mysql_install_db
       --init_keyspace string                                        (init parameter) keyspace to use for this tablet
@@ -220,7 +220,7 @@ vtbackup [flags]
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtbackup
 
@@ -196,6 +196,7 @@ vtbackup [flags]
       --opentsdb_uri string                                         URI of opentsdb /api/put method
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.
@@ -219,7 +220,7 @@ vtbackup [flags]
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: a85c612dc9a58aa2e4b13010fdba99e246646618
+commit: 20b1e461f3710f368a04eb0b563fd3de3df56908
 ---
 ## vtbackup
 
@@ -151,7 +151,7 @@ vtbackup [flags]
       --grpc_max_message_size int                                   Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                             Enable gRPC monitoring with Prometheus.
   -h, --help                                                        help for vtbackup
-      --incremental_from_pos string                                 Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
+      --incremental_from_pos string                                 Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
       --init_db_name_override string                                (init parameter) override the name of the db used by vttablet
       --init_db_sql_file string                                     path to .sql file to run after mysql_install_db
       --init_keyspace string                                        (init parameter) keyspace to use for this tablet

--- a/content/en/docs/19.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtclient
 series: vtclient
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtclient
 
@@ -55,6 +55,7 @@ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1,
       --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
       --parallel int                                                DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing. (default 1)
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --qps int                                                     queries per second to throttle each thread at.
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtcombo
 
@@ -357,7 +357,7 @@ vtcombo [flags]
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 6b481a7dc8639a070f8aa42773aa9c5a497f79c7
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtcombo
 
@@ -270,6 +270,7 @@ vtcombo [flags]
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
@@ -356,7 +357,7 @@ vtcombo [flags]
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctld
 
@@ -111,12 +111,14 @@ vtctld \
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --opentsdb_uri string                                              URI of opentsdb /api/put method
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
@@ -154,7 +156,7 @@ vtctld \
       --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctld
 
@@ -156,7 +156,7 @@ vtctld \
       --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,14 +1,14 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient ApplyVSchema
 
 Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
 
 ```
-vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> || --sql=<sql> || --sql-file=<sql file>} [--cells=c1,c2,...] [--skip-rebuild] [--dry-run] <keyspace>
+vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> || --sql=<sql> || --sql-file=<sql file>} [--cells=c1,c2,...] [--skip-rebuild] [--dry-run] [--strict] <keyspace>
 ```
 
 ### Options
@@ -20,6 +20,7 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
       --skip-rebuild                            Skip rebuilding the SrvSchema objects.
       --sql alter table t add vindex hash(id)   A VSchema DDL SQL statement, e.g. alter table t add vindex hash(id).
       --sql-file string                         Path to a file containing a VSchema DDL SQL.
+      --strict                                  If set, treat unknown vindex params as errors.
       --vschema string                          VSchema to apply, in JSON form.
       --vschema-file string                     Path to a file containing the vschema to apply, in JSON form.
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: a85c612dc9a58aa2e4b13010fdba99e246646618
+commit: 20b1e461f3710f368a04eb0b563fd3de3df56908
 ---
 ## vtctldclient Backup
 
@@ -17,7 +17,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for Backup
-      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Backup
 
@@ -15,7 +15,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
 
 ```
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --concurrency uint              Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for Backup
       --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,14 +1,14 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Backup
 
 Uses the BackupStorage service on the given tablet to create and store a new backup.
 
 ```
-vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|auto] [--upgrade-safe] <tablet_alias>
+vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|<backup-name>|auto] [--upgrade-safe] <tablet_alias>
 ```
 
 ### Options
@@ -17,7 +17,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for Backup
-      --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient BackupShard
 
@@ -14,7 +14,7 @@ Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard an
 If no replica-type tablet can be found, the backup can be taken on the primary if --allow-primary is specified.
 
 ```
-vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|auto] [--upgrade-safe] <keyspace/shard>
+vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incremental-from-pos=<pos>|<backup-name>|auto] [--upgrade-safe] <keyspace/shard>
 ```
 
 ### Options
@@ -23,7 +23,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for BackupShard
-      --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient BackupShard
 
@@ -21,7 +21,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
 
 ```
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --concurrency uint              Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for BackupShard
       --incremental-from-pos string   Position of previous backup. Default: empty. If given, then this backup becomes an incremental backup from given position. If value is 'auto', backup taken from last successful backup position
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: a85c612dc9a58aa2e4b13010fdba99e246646618
+commit: 20b1e461f3710f368a04eb0b563fd3de3df56908
 ---
 ## vtctldclient BackupShard
 
@@ -23,7 +23,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
       --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
       --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
   -h, --help                          help for BackupShard
-      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', backup taken from last successful backup position.
+      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Materialize create
 
@@ -52,7 +52,10 @@ vtctldclient --server localhost:15999 materialize --workflow product_sales --tar
 ```
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
   -h, --help                               help for create
+      --mysql_server_version string        Configure the MySQL version to use for example for the parser. (default "8.0.30-Vitess")
       --source-keyspace string             Keyspace where the tables queried in the 'source_expression' values within table-settings live.
+      --sql-max-length-errors int          truncate queries in error logs to the given length (default unlimited)
+      --sql-max-length-ui int              truncate queries in debug UIs to the given length (default 512) (default 512)
       --stop-after-copy                    Stop the workflow after it's finished copying the existing rows and before it starts replicating changes.
       --table-settings JSON                A JSON array defining what tables to materialize using what select statements. See the --help output for more details. (default null)
       --tablet-types strings               Source tablet types to replicate table data from (e.g. PRIMARY,REPLICA,RDONLY).

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables cancel
 
@@ -23,7 +23,6 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help                 help for cancel
       --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the MoveTables workflow.
-      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables cancel
 
@@ -23,6 +23,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help                 help for cancel
       --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the MoveTables workflow.
+      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables complete
 
@@ -25,6 +25,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --keep-data            Keep the original source table data that was copied by the MoveTables workflow.
       --keep-routing-rules   Keep the routing rules in place that direct table traffic from the source keyspace to the target keyspace of the MoveTables workflow.
       --rename-tables        Keep the original source table data that was copied by the MoveTables workflow, but rename each table to '_<tablename>_old'.
+      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables complete
 
@@ -25,7 +25,6 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --keep-data            Keep the original source table data that was copied by the MoveTables workflow.
       --keep-routing-rules   Keep the routing rules in place that direct table traffic from the source keyspace to the target keyspace of the MoveTables workflow.
       --rename-tables        Keep the original source table data that was copied by the MoveTables workflow, but rename each table to '_<tablename>_old'.
-      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables reversetraffic
 
@@ -25,7 +25,6 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
   -h, --help                                   help for reversetraffic
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
-      --shards strings                         (Optional) Specifies a comma-separated list of shards to operate on.
       --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables reversetraffic
 
@@ -25,6 +25,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --enable-reverse-replication             Setup replication going back to the original source keyspace to support rolling back the traffic cutover. (default true)
   -h, --help                                   help for reversetraffic
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --shards strings                         (Optional) Specifies a comma-separated list of shards to operate on.
       --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables show
 
@@ -20,9 +20,8 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help             help for show
-      --include-logs     Include recent logs for the workflow. (default true)
-      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
+  -h, --help           help for show
+      --include-logs   Include recent logs for the workflow. (default true)
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables show
 
@@ -20,8 +20,9 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help           help for show
-      --include-logs   Include recent logs for the workflow. (default true)
+  -h, --help             help for show
+      --include-logs     Include recent logs for the workflow. (default true)
+      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables status
 
@@ -20,8 +20,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help             help for status
-      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
+  -h, --help   help for status
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables status
 
@@ -20,7 +20,8 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help   help for status
+  -h, --help             help for status
+      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient MoveTables switchtraffic
 
@@ -26,6 +26,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help                                   help for switchtraffic
       --initialize-target-sequences            When moving tables from an unsharded keyspace to a sharded keyspace, initialize any sequences that are being used on the target when switching writes.
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
+      --shards strings                         (Optional) Specifies a comma-separated list of shards to operate on.
       --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient MoveTables switchtraffic
 
@@ -26,7 +26,6 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help                                   help for switchtraffic
       --initialize-target-sequences            When moving tables from an unsharded keyspace to a sharded keyspace, initialize any sequences that are being used on the target when switching writes.
       --max-replication-lag-allowed duration   Allow traffic to be switched only if VReplication lag is below this. (default 30s)
-      --shards strings                         (Optional) Specifies a comma-separated list of shards to operate on.
       --tablet-types strings                   Tablet types to switch traffic for.
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient ReloadSchemaKeyspace
 
@@ -14,9 +14,9 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
 ### Options
 
 ```
-      --concurrency uint32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
-  -h, --help                 help for ReloadSchemaKeyspace
-      --include-primary      Also reload the primary tablets.
+      --concurrency int32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
+  -h, --help                help for ReloadSchemaKeyspace
+      --include-primary     Also reload the primary tablets.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient ReloadSchemaShard
 
@@ -14,9 +14,9 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
 ### Options
 
 ```
-      --concurrency uint32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
-  -h, --help                 help for ReloadSchemaShard
-      --include-primary      Also reload the primary tablet.
+      --concurrency int32   Number of tablets to reload in parallel. Set to zero for unbounded concurrency. (default 10)
+  -h, --help                help for ReloadSchemaShard
+      --include-primary     Also reload the primary tablet.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient VDiff create
 
@@ -26,6 +26,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --filtered-replication-wait-time duration   Specifies the maximum time to wait, in seconds, for replication to catch up when syncing tablet streams. (default 30s)
   -h, --help                                      help for create
       --limit int                                 Max rows to stop comparing after. (default 9223372036854775807)
+      --max-diff-duration duration                How long should an individual table diff run before being stopped and restarted in order to lessen the impact on tablets due to holding open database snapshots for long periods of time (0 is the default and means no time limit).
       --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --max-report-sample-rows int                Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks (default 10)
       --only-pks                                  When reporting missing rows, only show primary keys in the report.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow delete
 
@@ -23,6 +23,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
   -h, --help                 help for delete
       --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the workflow.
+      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string      The workflow you want to delete.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow delete
 
@@ -23,7 +23,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
   -h, --help                 help for delete
       --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
       --keep-routing-rules   Keep the routing rules created for the workflow.
-      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string      The workflow you want to delete.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow list
 
@@ -20,7 +20,8 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options
 
 ```
-  -h, --help   help for list
+  -h, --help             help for list
+      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow list
 
@@ -20,8 +20,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
 ### Options
 
 ```
-  -h, --help             help for list
-      --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
+  -h, --help   help for list
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow show
 
@@ -22,6 +22,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
 ```
   -h, --help              help for show
       --include-logs      Include recent logs for the workflow. (default true)
+      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want the details for.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow show
 
@@ -22,7 +22,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
 ```
   -h, --help              help for show
       --include-logs      Include recent logs for the workflow. (default true)
-      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want the details for.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow start
 
@@ -21,6 +21,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 
 ```
   -h, --help              help for start
+      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want to start.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow start
 
@@ -21,7 +21,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 
 ```
   -h, --help              help for start
-      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want to start.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow stop
 
@@ -21,7 +21,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 
 ```
   -h, --help              help for stop
-      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want to stop.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow stop
 
@@ -21,6 +21,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
 
 ```
   -h, --help              help for stop
+      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
   -w, --workflow string   The workflow you want to stop.
 ```
 

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtctldclient Workflow update
 
@@ -23,6 +23,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
   -c, --cells strings           New Cell(s) or CellAlias(es) (comma-separated) to replicate from.
   -h, --help                    help for update
       --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE.
+      --shards strings          (Optional) Specifies a comma-separated list of shards to operate on.
   -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
   -w, --workflow string         The workflow you want to update.

--- a/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/19.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtctldclient Workflow update
 
@@ -23,7 +23,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
   -c, --cells strings           New Cell(s) or CellAlias(es) (comma-separated) to replicate from.
   -h, --help                    help for update
       --on-ddl string           New instruction on what to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE.
-      --shards strings          (Optional) Specifies a comma-separated list of shards to operate on.
   -t, --tablet-types strings    New source tablet types to replicate from (e.g. PRIMARY,REPLICA,RDONLY).
       --tablet-types-in-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
   -w, --workflow string         The workflow you want to update.

--- a/content/en/docs/19.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtgate
 
@@ -181,6 +181,7 @@ vtgate \
       --planner-version string                                           Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --query-timeout int                                                Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)

--- a/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtgateclienttest
 
@@ -66,6 +66,7 @@ vtgateclienttest [flags]
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice

--- a/content/en/docs/19.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vtorc
 
@@ -74,6 +74,7 @@ vtorc \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --prevent-cross-cell-failover                                 Prevent VTOrc from promoting a primary in a different cell than the current primary in case of a failover
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --reasonable-replication-lag duration                         Maximum replication lag on replicas which is deemed to be acceptable (default 10s)
@@ -93,7 +94,7 @@ vtorc \
       --table-refresh-interval int                                  interval in milliseconds to refresh tables in status page with refreshRequired class
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vtorc
 
@@ -94,7 +94,7 @@ vtorc \
       --table-refresh-interval int                                  interval in milliseconds to refresh tables in status page with refreshRequired class
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 6b481a7dc8639a070f8aa42773aa9c5a497f79c7
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vttablet
 
@@ -272,6 +272,7 @@ vttablet \
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --pt-osc-path string                                               override default pt-online-schema-change binary full path
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
@@ -367,7 +368,7 @@ vttablet \
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vttablet
 
@@ -368,7 +368,7 @@ vttablet \
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
+commit: a85c612dc9a58aa2e4b13010fdba99e246646618
 ---
 ## vttestserver
 
@@ -129,7 +129,7 @@ vttestserver [flags]
       --tablet_hostname string                                           The hostname to use for the tablet otherwise it will be derived from OS' hostname (default "localhost")
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 3b906cf6a3cedd9d216eaee4e162025d408beee9
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## vttestserver
 
@@ -109,6 +109,7 @@ vttestserver [flags]
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         Port to use for vtcombo. If this is 0, a random port will be chosen.
       --pprof strings                                                    enable profiling
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo string                                                Define the fake cluster topology as a compact text format encoded vttest proto. See vttest.proto for more information.
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value
@@ -128,7 +129,7 @@ vttestserver [flags]
       --tablet_hostname string                                           The hostname to use for the tablet otherwise it will be derived from OS' hostname (default "localhost")
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/19.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctl
 series: zkctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## zkctl
 
@@ -26,6 +26,7 @@ Initializes and controls zookeeper with Vitess-specific configuration.
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## zkctl init
 
@@ -35,6 +35,7 @@ zkctl init [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## zkctl shutdown
 
@@ -35,6 +35,7 @@ zkctl shutdown [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## zkctl start
 
@@ -35,6 +35,7 @@ zkctl start [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: c823b86a19bfeb9a6a411a75caf492464caf697e
+commit: 2642bea6b1d3476889564c49ed64829f2a3d0a90
 ---
 ## zkctl teardown
 
@@ -35,6 +35,7 @@ zkctl teardown [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -101,19 +101,27 @@ vtctldclient --server=<vtctld_host>:<vtctld_port> BackupShard [--allow_primary=f
 
 ## Create an incremental backup with vtctl
 
-An incremental backup requires additional information: the point from which to start the backup. An incremental backup is taken by supplying `--incremental-from-pos` to the `Backup` or `BackupShard` command. The argument may either indicate a valid position, or the value `auto`. Examples:
+An incremental backup requires additional information: the point from which to start the backup. An incremental backup is taken by supplying `--incremental-from-pos` to the `Backup` or `BackupShard` command. The argument may either indicate:
+
+- A valid position.
+- A name of a successful backup.
+- Or, the value `auto`.
 
 ```sh
 vtctldclient Backup --incremental-from-pos="MySQL56/0d7aaca6-1666-11ee-aeaf-0a43f95f28a3:1-53" zone1-0000000102
 
 vtctldclient Backup --incremental-from-pos="0d7aaca6-1666-11ee-aeaf-0a43f95f28a3:1-53" zone1-0000000102
 
+vtctldclient Backup --incremental-from-pos="2024-01-10.062022.zone1-0000000101 commerce/0" zone1-0000000102
+
 vtctldclient Backup --incremental-from-pos="auto" zone1-0000000102
 
 vtctldclient BackupShard --incremental-from-pos=auto commerce/0
 ```
 
-When indicating a position, you may choose to use or to omit the `MySQL56/` prefix (which you can find in the backup manifest's Position).
+When `--incremental-from-pos` supplies a position, you may choose to use or to omit the `MySQL56/` prefix (which you can find in the backup manifest's Position).
+
+When `--incremental-from-pos` indicates a backup name, that must be a successfully completed, existing backup. It may be either a full or an incremental backup.
 
 When `--incremental-from-pos="auto"`, Vitess chooses the position of the last successful backup as the starting point for the incremental backup. This is a convenient way to ensure a sequence of contiguous incremental backups.
 


### PR DESCRIPTION
This PR documents the changes in https://github.com/vitessio/vitess/pull/14923, `--incremental-from-pos` accepting a backup name.

There is a lot of noise because of SHA signatures. The relevant changes are mostly in `content/en/docs/19.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md` and otherwise in `vtctl` and `vtctldclient` docs.

Replaces https://github.com/vitessio/website/pull/1662 which was a mess.