### PR TITLE
update explain format=vitess doc to use vexplain plan

### DIFF
--- a/content/en/docs/19.0/concepts/execution-plans.md
+++ b/content/en/docs/19.0/concepts/execution-plans.md
@@ -26,7 +26,7 @@ Note that not all queries which are sent to multiple (or all) shards in a sharde
 
 Cached execution plans can be observed at the VTGate level by browsing the `/queryz` end point.
 
-Starting with Vitess 6, individual statement plans can also be observed with `EXPLAIN FORMAT=vitess <query>`.
+Starting with Vitess 16, individual statement plans can also be observed with [`VExplain`](../../user-guides/sql/explain-format-vtexplain).
 
 **Related Vitess Documentation**
 

--- a/content/en/docs/19.0/user-guides/vschema-guide/subsharding-vindex.md
+++ b/content/en/docs/19.0/user-guides/vschema-guide/subsharding-vindex.md
@@ -197,12 +197,25 @@ Now, if we have a sharded Vitess cluster, let us observe the routing when all
 columns are provided:
 
 ```
-mysql> explain format=vitess select * from t1 where c1=1 and c2=1 and c3=1;
-+----------+-------------+----------+-------------+------------+-----------------------------------------------------+
-| operator | variant     | keyspace | destination | tabletType | query                                               |
-+----------+-------------+----------+-------------+------------+-----------------------------------------------------+
-| Route    | EqualUnique | sharded  |             | UNKNOWN    | select * from t1 where c1 = 1 and c2 = 1 and c3 = 1 |
-+----------+-------------+----------+-------------+------------+-----------------------------------------------------+
+mysql> vexplain plan select * from t1 where c1=1 and c2=1 and c3=1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "EqualUnique",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1 where c1 = 1 and c2 = 1 and c3 = 1",
+	"Table": "t1",
+	"Values": [
+		"1",
+		"1",
+		"1"
+	],
+	"Vindex": "t1_multicol"
+}
 1 row in set (0.00 sec)
 ```
 
@@ -210,20 +223,43 @@ This is as expected.  Let's see the plans when a subset of columns,
 in order of their appearance in the vindex is provided:
 
 ```
-mysql> explain format=vitess select * from t1 where c1=1 and c2=1;
-+----------+---------+----------+-------------+------------+------------------------------------------+
-| operator | variant | keyspace | destination | tabletType | query                                    |
-+----------+---------+----------+-------------+------------+------------------------------------------+
-| Route    | Equal   | sharded  |             | UNKNOWN    | select * from t1 where c1 = 1 and c2 = 1 |
-+----------+---------+----------+-------------+------------+------------------------------------------+
+mysql> vexplain plan select * from t1 where c1=1 and c2=1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "SubShard",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1 where c1 = 1 and c2 = 1",
+	"Table": "t1",
+	"Values": [
+		"1",
+		"1"
+	],
+	"Vindex": "t1_multicol"
+}
 1 row in set (0.00 sec)
 
-mysql> explain format=vitess select * from t1 where c1=1;
-+----------+---------+----------+-------------+------------+-------------------------------+
-| operator | variant | keyspace | destination | tabletType | query                         |
-+----------+---------+----------+-------------+------------+-------------------------------+
-| Route    | Equal   | sharded  |             | UNKNOWN    | select * from t1 where c1 = 1 |
-+----------+---------+----------+-------------+------------+-------------------------------+
+mysql> vexplain plan select * from t1 where c1=1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "SubShard",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1 where c1 = 1",
+	"Table": "t1",
+	"Values": [
+		"1"
+	],
+	"Vindex": "t1_multicol"
+}
 1 row in set (0.00 sec)
 ```
 
@@ -235,32 +271,53 @@ of shards in the keyspace.
 Next, let's show that providing no columns scatters (as expected):
 
 ```
-mysql> explain format=vitess select * from t1;
-+----------+---------+----------+-------------+------------+------------------+
-| operator | variant | keyspace | destination | tabletType | query            |
-+----------+---------+----------+-------------+------------+------------------+
-| Route    | Scatter | sharded  |             | UNKNOWN    | select * from t1 |
-+----------+---------+----------+-------------+------------+------------------+
-1 row in set (0.00 sec)
+mysql> vexplain plan select * from t1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "Scatter",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1",
+	"Table": "t1"
+}
+1 row in set (0.01 sec)
 ```
 
 Similarly, providing a column (or subset of columns) from the subsharding
 vindex that does not include the first column will lead to a scatter:
 
 ```
-mysql> explain format=vitess select * from t1 where c3=1;
-+----------+---------+----------+-------------+------------+-------------------------------+
-| operator | variant | keyspace | destination | tabletType | query                         |
-+----------+---------+----------+-------------+------------+-------------------------------+
-| Route    | Scatter | sharded  |             | UNKNOWN    | select * from t1 where c3 = 1 |
-+----------+---------+----------+-------------+------------+-------------------------------+
+mysql> vexplain plan select * from t1 where c3=1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "Scatter",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1 where c3 = 1",
+	"Table": "t1"
+}
 1 row in set (0.00 sec)
 
-mysql> explain format=vitess select * from t1 where c2=1 and c3=1;
-+----------+---------+----------+-------------+------------+------------------------------------------+
-| operator | variant | keyspace | destination | tabletType | query                                    |
-+----------+---------+----------+-------------+------------+------------------------------------------+
-| Route    | Scatter | sharded  |             | UNKNOWN    | select * from t1 where c2 = 1 and c3 = 1 |
-+----------+---------+----------+-------------+------------+------------------------------------------+
+mysql> vexplain plan select * from t1 where c2=1 and c3=1 \G
+*************************** 1. row ***************************
+JSON: {
+	"OperatorType": "Route",
+	"Variant": "Scatter",
+	"Keyspace": {
+		"Name": "customer",
+		"Sharded": true
+	},
+	"FieldQuery": "select c1, c2, c3, c4 from t1 where 1 != 1",
+	"Query": "select c1, c2, c3, c4 from t1 where c2 = 1 and c3 = 1",
+	"Table": "t1"
+}
 1 row in set (0.00 sec)
 ```


### PR DESCRIPTION
Update `explain format=vitess` docs to use `vexplain plan` statement.