### PR TITLE
fix missing backslash in `vttestserver` docs

### DIFF
--- a/content/en/docs/16.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/16.0/get-started/vttestserver-docker-image.md
@@ -89,7 +89,7 @@ docker run --name=vttestserver \
   --health-interval=5s \
   --health-timeout=2s \
   --health-retries=5 \
-  -v vttestserver_data:/vt/vtdataroot/vitess \
+  -v vttestserver_data:/vt/vtdataroot \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \

--- a/content/en/docs/16.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/16.0/get-started/vttestserver-docker-image.md
@@ -90,7 +90,7 @@ docker run --name=vttestserver \
   --health-timeout=2s \
   --health-retries=5 \
   -v vttestserver_data:/vt/vtdataroot/vitess \
-  vitess/vttestserver:mysql80
+  vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
   --data_dir=/vt/vtdataroot/vitess \

--- a/content/en/docs/16.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/16.0/get-started/vttestserver-docker-image.md
@@ -93,7 +93,7 @@ docker run --name=vttestserver \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
-  --data_dir=/vt/vtdataroot/vitess \
+  --data_dir=/vt/vtdataroot/ \
   --persistent_mode \
   --port=33574 \
   --mysql_bind_host=0.0.0.0 \

--- a/content/en/docs/17.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/17.0/get-started/vttestserver-docker-image.md
@@ -89,7 +89,7 @@ docker run --name=vttestserver \
   --health-interval=5s \
   --health-timeout=2s \
   --health-retries=5 \
-  -v vttestserver_data:/vt/vtdataroot/vitess \
+  -v vttestserver_data:/vt/vtdataroot \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \

--- a/content/en/docs/17.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/17.0/get-started/vttestserver-docker-image.md
@@ -90,7 +90,7 @@ docker run --name=vttestserver \
   --health-timeout=2s \
   --health-retries=5 \
   -v vttestserver_data:/vt/vtdataroot/vitess \
-  vitess/vttestserver:mysql80
+  vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
   --data_dir=/vt/vtdataroot/vitess \

--- a/content/en/docs/17.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/17.0/get-started/vttestserver-docker-image.md
@@ -93,7 +93,7 @@ docker run --name=vttestserver \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
-  --data_dir=/vt/vtdataroot/vitess \
+  --data_dir=/vt/vtdataroot/ \
   --persistent_mode \
   --port=33574 \
   --mysql_bind_host=0.0.0.0 \

--- a/content/en/docs/18.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/18.0/get-started/vttestserver-docker-image.md
@@ -89,7 +89,7 @@ docker run --name=vttestserver \
   --health-interval=5s \
   --health-timeout=2s \
   --health-retries=5 \
-  -v vttestserver_data:/vt/vtdataroot/vitess \
+  -v vttestserver_data:/vt/vtdataroot \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \

--- a/content/en/docs/18.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/18.0/get-started/vttestserver-docker-image.md
@@ -90,7 +90,7 @@ docker run --name=vttestserver \
   --health-timeout=2s \
   --health-retries=5 \
   -v vttestserver_data:/vt/vtdataroot/vitess \
-  vitess/vttestserver:mysql80
+  vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
   --data_dir=/vt/vtdataroot/vitess \

--- a/content/en/docs/18.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/18.0/get-started/vttestserver-docker-image.md
@@ -93,7 +93,7 @@ docker run --name=vttestserver \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
-  --data_dir=/vt/vtdataroot/vitess \
+  --data_dir=/vt/vtdataroot/ \
   --persistent_mode \
   --port=33574 \
   --mysql_bind_host=0.0.0.0 \

--- a/content/en/docs/19.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/19.0/get-started/vttestserver-docker-image.md
@@ -102,7 +102,7 @@ docker run --name=vttestserver \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
-  --data_dir=/vt/vtdataroot/vitess \
+  --data_dir=/vt/vtdataroot/ \
   --persistent_mode \
   --port=33574 \
   --mysql_bind_host=0.0.0.0 \

--- a/content/en/docs/19.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/19.0/get-started/vttestserver-docker-image.md
@@ -99,7 +99,7 @@ docker run --name=vttestserver \
   --health-timeout=2s \
   --health-retries=5 \
   -v vttestserver_data:/vt/vtdataroot/vitess \
-  vitess/vttestserver:mysql80
+  vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
   --data_dir=/vt/vtdataroot/vitess \

--- a/content/en/docs/19.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/19.0/get-started/vttestserver-docker-image.md
@@ -98,7 +98,7 @@ docker run --name=vttestserver \
   --health-interval=5s \
   --health-timeout=2s \
   --health-retries=5 \
-  -v vttestserver_data:/vt/vtdataroot/vitess \
+  -v vttestserver_data:/vt/vtdataroot \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \

--- a/content/en/docs/20.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/20.0/get-started/vttestserver-docker-image.md
@@ -98,7 +98,7 @@ docker run --name=vttestserver \
   --health-timeout=2s \
   --health-retries=5 \
   -v vttestserver_data:/vt/vtdataroot/vitess \
-  vitess/vttestserver:mysql80
+  vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
   --data_dir=/vt/vtdataroot/vitess \

--- a/content/en/docs/20.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/20.0/get-started/vttestserver-docker-image.md
@@ -101,7 +101,7 @@ docker run --name=vttestserver \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \
-  --data_dir=/vt/vtdataroot/vitess \
+  --data_dir=/vt/vtdataroot/ \
   --persistent_mode \
   --port=33574 \
   --mysql_bind_host=0.0.0.0 \

--- a/content/en/docs/20.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/20.0/get-started/vttestserver-docker-image.md
@@ -97,7 +97,7 @@ docker run --name=vttestserver \
   --health-interval=5s \
   --health-timeout=2s \
   --health-retries=5 \
-  -v vttestserver_data:/vt/vtdataroot/vitess \
+  -v vttestserver_data:/vt/vtdataroot \
   vitess/vttestserver:mysql80 \
   /vt/bin/vttestserver \
   --alsologtostderr \


### PR DESCRIPTION
Fixes https://github.com/vitessio/vitess/issues/15231 

There is a missing backslash in the example to run vttestserver on Docker, which leads to the following error:

```
invalid argument "" for "--port" flag: strconv.ParseInt: parsing "": invalid syntax
```

Additionally, the path for the data volume is changed from `/vt/vtdataroot/vitess` to `/vt/vtdataroot`. The `./vitess` directory does not exist and is irrelevant, we should attach the volume to the root of `vtdataroot` instead.

The `--data_dir` flag has also changed to point to the root of `vtdataroot` too.