### PR TITLE
Update all client reference docs for all Vitess versions

### DIFF
--- a/content/en/docs/18.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl
 

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl init
 
@@ -44,7 +44,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl init_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl position
 
@@ -27,7 +27,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl reinit_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl shutdown
 
@@ -40,7 +40,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl start
 
@@ -39,7 +39,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctl teardown
 
@@ -43,7 +43,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/18.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/18.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## mysqlctld
 

--- a/content/en/docs/18.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/18.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## topo2topo
 

--- a/content/en/docs/18.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtaclcheck
 

--- a/content/en/docs/18.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtbackup
 
@@ -218,7 +218,7 @@ vtbackup [flags]
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtclient
 series: vtclient
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtclient
 

--- a/content/en/docs/18.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtcombo
 
@@ -354,7 +354,7 @@ vtcombo [flags]
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtctld
 
@@ -154,7 +154,7 @@ vtctld \
       --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtgate
 

--- a/content/en/docs/18.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtgateclienttest
 

--- a/content/en/docs/18.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/18.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vtorc
 
@@ -93,7 +93,7 @@ vtorc \
       --table-refresh-interval int                                  interval in milliseconds to refresh tables in status page with refreshRequired class
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/18.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttablet
 
@@ -365,7 +365,7 @@ vttablet \
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/18.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttestserver
 
@@ -128,7 +128,7 @@ vttestserver [flags]
       --tablet_hostname string                                           The hostname to use for the tablet otherwise it will be derived from OS' hostname (default "localhost")
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,AllPrivs,App}) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/18.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttlstest
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest
 

--- a/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest CreateCA
 

--- a/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCRL
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest CreateCRL
 

--- a/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateIntermediateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest CreateIntermediateCA
 

--- a/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -1,7 +1,7 @@
 ---
 title: CreateSignedCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest CreateSignedCert
 

--- a/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/18.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -1,7 +1,7 @@
 ---
 title: RevokeCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## vttlstest RevokeCert
 

--- a/content/en/docs/18.0/reference/programs/zk/_index.md
+++ b/content/en/docs/18.0/reference/programs/zk/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zk
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_addAuth.md
@@ -1,7 +1,7 @@
 ---
 title: addAuth
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk addAuth
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_cat.md
@@ -1,7 +1,7 @@
 ---
 title: cat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk cat
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_chmod.md
@@ -1,7 +1,7 @@
 ---
 title: chmod
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk chmod
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_cp.md
@@ -1,7 +1,7 @@
 ---
 title: cp
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk cp
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_edit.md
@@ -1,7 +1,7 @@
 ---
 title: edit
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk edit
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_ls.md
@@ -1,7 +1,7 @@
 ---
 title: ls
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk ls
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_rm.md
@@ -1,7 +1,7 @@
 ---
 title: rm
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk rm
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_stat.md
@@ -1,7 +1,7 @@
 ---
 title: stat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk stat
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_touch.md
@@ -1,7 +1,7 @@
 ---
 title: touch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk touch
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_unzip.md
@@ -1,7 +1,7 @@
 ---
 title: unzip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk unzip
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_wait.md
@@ -1,7 +1,7 @@
 ---
 title: wait
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk wait
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_watch.md
@@ -1,7 +1,7 @@
 ---
 title: watch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk watch
 

--- a/content/en/docs/18.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/18.0/reference/programs/zk/zk_zip.md
@@ -1,7 +1,7 @@
 ---
 title: zip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zk zip
 

--- a/content/en/docs/18.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctl
 series: zkctl
-commit: aa72dc8d9189843c0a49f32b54f6fc978f6dbcde
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctl
 

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctl init
 
@@ -24,7 +24,7 @@ zkctl init [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctl shutdown
 
@@ -24,7 +24,7 @@ zkctl shutdown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctl start
 
@@ -24,7 +24,7 @@ zkctl start [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/18.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: d3012c188ea0cfc6837917fc6642ea23be9bb1ff
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctl teardown
 
@@ -24,7 +24,7 @@ zkctl teardown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/18.0/reference/programs/zkctld/_index.md
+++ b/content/en/docs/18.0/reference/programs/zkctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctld
 series: zkctld
-commit: b2d7604e4e0728329314500c182c3192cee74510
+commit: b5b3114ab9371f882762dd66ae0efc5af3a3dbc0
 ---
 ## zkctld
 

--- a/content/en/docs/19.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl
 
@@ -80,7 +80,7 @@ This helps ensure that `mysqld` is automatically restarted after failures.
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl init
 
@@ -44,7 +44,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -98,7 +98,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl init_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -96,7 +96,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl position
 
@@ -27,7 +27,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -81,7 +81,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl reinit_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -96,7 +96,7 @@ mysqlctl \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl shutdown
 
@@ -40,7 +40,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -94,7 +94,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl start
 
@@ -39,7 +39,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -93,7 +93,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctl teardown
 
@@ -43,7 +43,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file
@@ -97,7 +97,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                     if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                          how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## mysqlctld
 
@@ -101,8 +101,6 @@ mysqlctld \
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for mysqlctld
       --init_db_sql_file string                                          Path to .sql file to run after mysqld initialization
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
@@ -125,7 +123,7 @@ mysqlctld \
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/19.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## topo2topo
 
@@ -47,7 +47,7 @@ topo2topo [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)

--- a/content/en/docs/19.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtaclcheck
 
@@ -31,7 +31,7 @@ vtaclcheck [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --static-auth-file string                                     The path of the auth_server_static JSON file to check

--- a/content/en/docs/19.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtbackup
 
@@ -197,7 +197,7 @@ vtbackup [flags]
       --opentsdb_uri string                                         URI of opentsdb /api/put method
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.

--- a/content/en/docs/19.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtclient
 series: vtclient
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtclient
 
@@ -55,7 +55,7 @@ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1,
       --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
       --parallel int                                                DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing. (default 1)
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --qps int                                                     queries per second to throttle each thread at.
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)

--- a/content/en/docs/19.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtcombo
 
@@ -178,8 +178,6 @@ vtcombo [flags]
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_use_effective_callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
       --health_check_interval duration                                   Interval between health checks (default 20s)
       --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
@@ -273,7 +271,7 @@ vtcombo [flags]
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
@@ -298,21 +296,18 @@ vtcombo [flags]
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
-      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
-      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
       --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
-      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.

--- a/content/en/docs/19.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtctld
 
@@ -100,8 +100,6 @@ vtctld \
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for vtctld
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
@@ -121,7 +119,7 @@ vtctld \
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)

--- a/content/en/docs/19.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtgate
 
@@ -111,8 +111,6 @@ vtgate \
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_use_effective_callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
       --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
@@ -183,7 +181,7 @@ vtgate \
       --planner-version string                                           Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --query-timeout int                                                Sets the default query timeout (in ms). Can be overridden by session variable (query_timeout) or comment directive (QUERY_TIMEOUT_MS)

--- a/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtgateclienttest
 
@@ -50,8 +50,6 @@ vtgateclienttest [flags]
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for vtgateclienttest
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
@@ -68,7 +66,7 @@ vtgateclienttest [flags]
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice

--- a/content/en/docs/19.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/19.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vtorc
 
@@ -74,7 +74,7 @@ vtorc \
       --pid_file string                                             If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --port int                                                    port for the server
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --prevent-cross-cell-failover                                 Prevent VTOrc from promoting a primary in a different cell than the current primary in case of a failover
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --reasonable-replication-lag duration                         Maximum replication lag on replicas which is deemed to be acceptable (default 10s)

--- a/content/en/docs/19.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttablet
 
@@ -211,8 +211,6 @@ vttablet \
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --health_check_interval duration                                   Interval between health checks (default 20s)
       --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.
       --heartbeat_interval duration                                      How frequently to read and write replication heartbeat. (default 1s)
@@ -274,7 +272,7 @@ vttablet \
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --pt-osc-path string                                               override default pt-online-schema-change binary full path
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
@@ -294,21 +292,18 @@ vttablet \
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
-      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
-      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
       --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
-      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.

--- a/content/en/docs/19.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttestserver
 
@@ -80,8 +80,6 @@ vttestserver [flags]
       --grpc_server_initial_window_size int                              gRPC server initial window size
       --grpc_server_keepalive_enforcement_policy_min_time duration       gRPC server minimum keepalive time (default 10s)
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
-      --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
-      --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for vttestserver
       --initialize_with_random_data                                      If this flag is each table-shard will be initialized with random data. See also the 'rng_seed' and 'min_shard_size' and 'max_shard_size' flags.
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
@@ -112,7 +110,7 @@ vttestserver [flags]
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         Port to use for vtcombo. If this is 0, a random port will be chosen.
       --pprof strings                                                    enable profiling
-      --pprof-http                                                       enable pprof http endpoints
+      --pprof-http                                                       enable pprof http endpoints (default true)
       --proto_topo string                                                Define the fake cluster topology as a compact text format encoded vttest proto. See vttest.proto for more information.
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value

--- a/content/en/docs/19.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttlstest
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest
 

--- a/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest CreateCA
 

--- a/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCRL
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest CreateCRL
 

--- a/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateIntermediateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest CreateIntermediateCA
 

--- a/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -1,7 +1,7 @@
 ---
 title: CreateSignedCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest CreateSignedCert
 

--- a/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/19.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -1,7 +1,7 @@
 ---
 title: RevokeCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## vttlstest RevokeCert
 

--- a/content/en/docs/19.0/reference/programs/zk/_index.md
+++ b/content/en/docs/19.0/reference/programs/zk/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zk
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_addAuth.md
@@ -1,7 +1,7 @@
 ---
 title: addAuth
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk addAuth
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_cat.md
@@ -1,7 +1,7 @@
 ---
 title: cat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk cat
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_chmod.md
@@ -1,7 +1,7 @@
 ---
 title: chmod
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk chmod
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_cp.md
@@ -1,7 +1,7 @@
 ---
 title: cp
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk cp
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_edit.md
@@ -1,7 +1,7 @@
 ---
 title: edit
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk edit
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_ls.md
@@ -1,7 +1,7 @@
 ---
 title: ls
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk ls
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_rm.md
@@ -1,7 +1,7 @@
 ---
 title: rm
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk rm
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_stat.md
@@ -1,7 +1,7 @@
 ---
 title: stat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk stat
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_touch.md
@@ -1,7 +1,7 @@
 ---
 title: touch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk touch
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_unzip.md
@@ -1,7 +1,7 @@
 ---
 title: unzip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk unzip
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_wait.md
@@ -1,7 +1,7 @@
 ---
 title: wait
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk wait
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_watch.md
@@ -1,7 +1,7 @@
 ---
 title: watch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk watch
 

--- a/content/en/docs/19.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/19.0/reference/programs/zk/zk_zip.md
@@ -1,7 +1,7 @@
 ---
 title: zip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zk zip
 

--- a/content/en/docs/19.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctl
 series: zkctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctl
 
@@ -26,7 +26,7 @@ Initializes and controls zookeeper with Vitess-specific configuration.
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctl init
 
@@ -24,7 +24,7 @@ zkctl init [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
@@ -35,7 +35,7 @@ zkctl init [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctl shutdown
 
@@ -24,7 +24,7 @@ zkctl shutdown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
@@ -35,7 +35,7 @@ zkctl shutdown [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctl start
 
@@ -24,7 +24,7 @@ zkctl start [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
@@ -35,7 +35,7 @@ zkctl start [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/19.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: 2929deecbcdad21ca991cff62db8205e78cc4452
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctl teardown
 
@@ -24,7 +24,7 @@ zkctl teardown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
@@ -35,7 +35,7 @@ zkctl teardown [flags]
       --log_rotate_max_size uint                                    size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                 log to standard error instead of files
       --pprof strings                                               enable profiling
-      --pprof-http                                                  enable pprof http endpoints
+      --pprof-http                                                  enable pprof http endpoints (default true)
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --v Level                                                     log level for V logs

--- a/content/en/docs/19.0/reference/programs/zkctld/_index.md
+++ b/content/en/docs/19.0/reference/programs/zkctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctld
 series: zkctld
-commit: b2d7604e4e0728329314500c182c3192cee74510
+commit: cb5464edf5d7075feae744f3580f8bc626d185aa
 ---
 ## zkctld
 

--- a/content/en/docs/20.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl
 

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl init
 
@@ -44,7 +44,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl init_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl position
 
@@ -27,7 +27,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl reinit_config
 
@@ -42,7 +42,7 @@ mysqlctl \
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl shutdown
 
@@ -40,7 +40,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl start
 
@@ -39,7 +39,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctl teardown
 
@@ -43,7 +43,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --db-credentials-file string                                  db credentials file; send SIGHUP to reload this file

--- a/content/en/docs/20.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/20.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## mysqlctld
 
@@ -120,7 +120,7 @@ mysqlctld \
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
-      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
+      --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 5m10s)
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server

--- a/content/en/docs/20.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/20.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## topo2topo
 

--- a/content/en/docs/20.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtaclcheck
 

--- a/content/en/docs/20.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtbackup
 
@@ -221,7 +221,7 @@ vtbackup [flags]
       --stderrthreshold severityFlag                                logs at or above this threshold go to stderr (default 1)
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/20.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtclient
 series: vtclient
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtclient
 

--- a/content/en/docs/20.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtcombo
 
@@ -123,7 +123,6 @@ vtcombo [flags]
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
       --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
-      --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
@@ -299,21 +298,18 @@ vtcombo [flags]
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
-      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
-      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
       --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
-      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.
@@ -338,7 +334,7 @@ vtcombo [flags]
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
-      --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown.
+      --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)
@@ -361,7 +357,7 @@ vtcombo [flags]
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect
@@ -369,6 +365,7 @@ vtcombo [flags]
       --tablet_manager_protocol string                                   Protocol to use to make tabletmanager RPCs to vttablets. (default "grpc")
       --tablet_refresh_interval duration                                 Tablet refresh interval. (default 1m0s)
       --tablet_refresh_known_tablets                                     Whether to reload the tablet's address/port map from topo in case they change. (default true)
+      --tablet_types_to_wait strings                                     Wait till connected for specified tablet types during Gateway initialization. Should be provided as a comma-separated set of tablet types.
       --tablet_url_template string                                       Format string describing debug tablet url formatting. See getTabletDebugURL() for how to customize this. (default "http://{{.GetTabletHostPort}}")
       --throttle_tablet_types string                                     Comma separated VTTablet types to be considered by the throttler. default: 'replica'. example: 'replica,rdonly'. 'replica' always implicitly included (default "replica")
       --topo_consul_lock_delay duration                                  LockDelay for consul session. (default 15s)
@@ -414,6 +411,7 @@ vtcombo [flags]
       --tx_throttler_config string                                       The configuration of the transaction throttler as a text-formatted throttlerdata.Configuration protocol buffer message. (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
       --tx_throttler_healthcheck_cells strings                           A comma-separated list of cells. Only tabletservers running in these cells will be monitored for replication lag by the transaction throttler.
       --unhealthy_threshold duration                                     replication lag after which a replica is considered unhealthy (default 2h0m0s)
+      --unmanaged                                                        Indicates an unmanaged tablet, i.e. using an external mysql-compatible database
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging

--- a/content/en/docs/20.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtctld
 
@@ -160,7 +160,7 @@ vtctld \
       --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/20.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtgate
 

--- a/content/en/docs/20.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtgateclienttest
 

--- a/content/en/docs/20.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/20.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vtorc
 
@@ -20,7 +20,6 @@ vtorc \
 	--topo_global_root /vitess/global \
 	--log_dir $VTDATAROOT/tmp \
 	--port 15000 \
-	--recovery-period-block-duration "10m" \
 	--instance-poll-time "1s" \
 	--topo-information-refresh-duration "30s" \
 	--alsologtostderr
@@ -78,7 +77,6 @@ vtorc \
       --prevent-cross-cell-failover                                 Prevent VTOrc from promoting a primary in a different cell than the current primary in case of a failover
       --purge_logs_interval duration                                how often try to remove old logs (default 1h0m0s)
       --reasonable-replication-lag duration                         Maximum replication lag on replicas which is deemed to be acceptable (default 10s)
-      --recovery-period-block-duration duration                     Duration for which a new recovery is blocked on an instance after running a recovery (default 30s)
       --recovery-poll-duration duration                             Timer duration on which VTOrc polls its database to run a recovery (default 1s)
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --security_policy string                                      the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
@@ -94,7 +92,7 @@ vtorc \
       --table-refresh-interval int                                  interval in milliseconds to refresh tables in status page with refreshRequired class
       --tablet_manager_grpc_ca string                               the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                             the cert to use to connect
-      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                         concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                       number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                              the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                              the key to use to connect

--- a/content/en/docs/20.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/20.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttablet
 
@@ -293,21 +293,18 @@ vttablet \
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
-      --queryserver-config-query-pool-waiter-cap int                     query server query pool waiter limit, this is the maximum number of queries that can be queued waiting to get a connection (default 5000)
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
-      --queryserver-config-stream-pool-waiter-cap int                    query server stream pool waiter limit, this is the maximum number of streaming queries that can be queued waiting to get a connection
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
       --queryserver-config-terse-errors                                  prevent bind vars from escaping in client error messages
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
-      --queryserver-config-txpool-waiter-cap int                         query server transaction pool waiter limit, this is the maximum number of transactions that can be queued waiting to get a connection (default 5000)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.
@@ -339,7 +336,7 @@ vttablet \
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
-      --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown.
+      --shutdown_grace_period duration                                   how long to wait for queries and transactions to complete during graceful shutdown. (default 3s)
       --sql-max-length-errors int                                        truncate queries in error logs to the given length (default unlimited)
       --sql-max-length-ui int                                            truncate queries in debug UIs to the given length (default 512) (default 512)
       --srv_topo_cache_refresh duration                                  how frequently to refresh the topology for cached entries (default 1s)
@@ -369,7 +366,7 @@ vttablet \
       --tablet_hostname string                                           if not empty, this hostname will be assumed instead of trying to resolve it
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/20.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/20.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttestserver
 
@@ -42,7 +42,6 @@ vttestserver [flags]
       --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --default_schema_dir string                                        Default directory for initial schema files. If no schema is found in schema_dir, default to this location.
-      --disable_active_reparents                                         if set, do not allow active reparents. Use this to protect a cluster using external reparents.
       --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
       --enable_online_ddl                                                Allow users to submit, review and control Online DDL (default true)
       --enable_system_settings                                           This will enable the system settings to be changed per session at the database connection level (default true)
@@ -83,6 +82,7 @@ vttestserver [flags]
       --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
       --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
   -h, --help                                                             help for vttestserver
+      --initialize-with-vt-dba-tcp                                       If this flag is enabled, MySQL will be initialized with an additional user named vt_dba_tcp, who will have access via TCP/IP connection.
       --initialize_with_random_data                                      If this flag is each table-shard will be initialized with random data. See also the 'rng_seed' and 'min_shard_size' and 'max_shard_size' flags.
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
@@ -132,7 +132,7 @@ vttestserver [flags]
       --tablet_hostname string                                           The hostname to use for the tablet otherwise it will be derived from OS' hostname (default "localhost")
       --tablet_manager_grpc_ca string                                    the server ca to use to validate servers when connecting
       --tablet_manager_grpc_cert string                                  the cert to use to connect
-      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App} and CheckThrottler) (default 8)
+      --tablet_manager_grpc_concurrency int                              concurrency to use to talk to a vttablet server for performance-sensitive RPCs (like ExecuteFetchAs{Dba,App}, CheckThrottler and FullStatus) (default 8)
       --tablet_manager_grpc_connpool_size int                            number of tablets to keep tmclient connections open to (default 100)
       --tablet_manager_grpc_crl string                                   the server crl to use to validate server certificates when connecting
       --tablet_manager_grpc_key string                                   the key to use to connect

--- a/content/en/docs/20.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttlstest
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest
 

--- a/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest CreateCA
 

--- a/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCRL
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest CreateCRL
 

--- a/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateIntermediateCA
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest CreateIntermediateCA
 

--- a/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -1,7 +1,7 @@
 ---
 title: CreateSignedCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest CreateSignedCert
 

--- a/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/20.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -1,7 +1,7 @@
 ---
 title: RevokeCert
 series: vttlstest
-commit: b089f78945653f6acd17c66f896820e36df49437
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## vttlstest RevokeCert
 

--- a/content/en/docs/20.0/reference/programs/zk/_index.md
+++ b/content/en/docs/20.0/reference/programs/zk/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zk
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_addAuth.md
@@ -1,7 +1,7 @@
 ---
 title: addAuth
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk addAuth
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_cat.md
@@ -1,7 +1,7 @@
 ---
 title: cat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk cat
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_chmod.md
@@ -1,7 +1,7 @@
 ---
 title: chmod
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk chmod
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_cp.md
@@ -1,7 +1,7 @@
 ---
 title: cp
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk cp
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_edit.md
@@ -1,7 +1,7 @@
 ---
 title: edit
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk edit
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_ls.md
@@ -1,7 +1,7 @@
 ---
 title: ls
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk ls
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_rm.md
@@ -1,7 +1,7 @@
 ---
 title: rm
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk rm
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_stat.md
@@ -1,7 +1,7 @@
 ---
 title: stat
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk stat
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_touch.md
@@ -1,7 +1,7 @@
 ---
 title: touch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk touch
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_unzip.md
@@ -1,7 +1,7 @@
 ---
 title: unzip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk unzip
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_wait.md
@@ -1,7 +1,7 @@
 ---
 title: wait
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk wait
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_watch.md
@@ -1,7 +1,7 @@
 ---
 title: watch
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk watch
 

--- a/content/en/docs/20.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/20.0/reference/programs/zk/zk_zip.md
@@ -1,7 +1,7 @@
 ---
 title: zip
 series: zk
-commit: 0e61ba498e0344d37d6e1cae933ae14aa2804fcd
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zk zip
 

--- a/content/en/docs/20.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/20.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctl
 series: zkctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctl
 

--- a/content/en/docs/20.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/20.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctl init
 
@@ -24,7 +24,7 @@ zkctl init [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/20.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/20.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctl shutdown
 
@@ -24,7 +24,7 @@ zkctl shutdown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/20.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/20.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctl start
 
@@ -24,7 +24,7 @@ zkctl start [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/20.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/20.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: b539ce927ee86b723a94a627cdec1403dd4020f0
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctl teardown
 
@@ -24,7 +24,7 @@ zkctl teardown [flags]
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
-      --config-path strings                                         Paths to search for config files in. (default [/tmp/pull_request_handler/vitess])
+      --config-path strings                                         Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)

--- a/content/en/docs/20.0/reference/programs/zkctld/_index.md
+++ b/content/en/docs/20.0/reference/programs/zkctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctld
 series: zkctld
-commit: b2d7604e4e0728329314500c182c3192cee74510
+commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
 ## zkctld
 

--- a/tools/sync_cobradocs.sh
+++ b/tools/sync_cobradocs.sh
@@ -20,6 +20,10 @@ fi
 
 VITESS_DIR="${tmp}" make generated-docs
 
+# The documentation generation in Vitess produces a non-anonymous path
+# which are replaced here using find and sed.
+find ./content/en/docs/ -type f -exec sh -c 'LC_CTYPE=C LANG=en_US.UTF-8 sed -i "" "s@\['"$tmp"'\]@\[<WORKDIR>\]@g" "$0"' {} \;
+
 git add $(git diff -I"^commit:.*$" --numstat | awk '{print $3}' | xargs) || true
 # Reset any modified files that contained _only_ a SHA update.
 git checkout -- .


### PR DESCRIPTION
These changes were generated from:
```
make generated-docs
find ./content/en/docs/ -type f -exec sh -c 'LC_CTYPE=C LANG=en_US.UTF-8 sed -i "" "s@\[/Users/matt/git/vitess\]@\[<WORKDIR>\]@g" "$0"' {} \; git clean -f \*-e
git commit -a -s
```

This is a follow-up to:
- https://github.com/vitessio/website/pull/1720
- https://github.com/vitessio/website/pull/1721