### PR TITLE
Documentation fixes

### DIFF
--- a/content/en/docs/17.0/get-started/local.md
+++ b/content/en/docs/17.0/get-started/local.md
@@ -16,7 +16,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 
 ```sh
 # Ubuntu based
-sudo apt install -y mysql-server etcd curl
+sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
 sudo apt install -y default-mysql-server default-mysql-client etcd curl

--- a/content/en/docs/18.0/get-started/local-mac.md
+++ b/content/en/docs/18.0/get-started/local-mac.md
@@ -116,7 +116,6 @@ $ source ../common/env.sh
 You should see an output similar to the following:
 
 ```bash
-$ ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1

--- a/content/en/docs/18.0/get-started/local.md
+++ b/content/en/docs/18.0/get-started/local.md
@@ -16,7 +16,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 
 ```sh
 # Ubuntu based
-sudo apt install -y mysql-server etcd curl
+sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
 sudo apt install -y default-mysql-server default-mysql-client etcd curl

--- a/content/en/docs/19.0/get-started/local-mac.md
+++ b/content/en/docs/19.0/get-started/local-mac.md
@@ -116,7 +116,6 @@ $ source ../common/env.sh
 You should see an output similar to the following:
 
 ```bash
-$ ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1

--- a/content/en/docs/19.0/get-started/local.md
+++ b/content/en/docs/19.0/get-started/local.md
@@ -16,7 +16,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 
 ```sh
 # Ubuntu based
-sudo apt install -y mysql-server etcd curl
+sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
 sudo apt install -y default-mysql-server default-mysql-client etcd curl

--- a/content/en/docs/20.0/get-started/local-mac.md
+++ b/content/en/docs/20.0/get-started/local-mac.md
@@ -115,7 +115,6 @@ $ source ../common/env.sh
 You should see an output similar to the following:
 
 ```bash
-$ ./101_initial_cluster.sh
 $ ./101_initial_cluster.sh 
 add /vitess/global
 add /vitess/zone1

--- a/content/en/docs/20.0/get-started/local.md
+++ b/content/en/docs/20.0/get-started/local.md
@@ -16,7 +16,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 
 ```sh
 # Ubuntu based
-sudo apt install -y mysql-server etcd curl
+sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
 sudo apt install -y default-mysql-server default-mysql-client etcd curl


### PR DESCRIPTION
I've been going through vitess docs / building / walkthroughs and noticed a few small issues in the docs:

- In the mac docs, do not need to explicitly execute `source ../common/env.sh` before `./101_initial_cluster.sh`. `./101_initial_cluster.sh` does that within the script!

- On `Ubuntu 24.04 LTS`, `sudo apt install etcd` does not work. I tried several things to get it to work, and ultimately settled on installing both `etcd-server` and `etcd-client`. Perhaps I'm missing something, so please let me know if I'm off here.