### PR TITLE
Docs: update to rc2 release tag

### DIFF
--- a/content/en/docs/20.0/get-started/local.md
+++ b/content/en/docs/20.0/get-started/local.md
@@ -88,8 +88,8 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=20.0.0-rc1
-file=vitess-${version}-7e8c974.tar.gz
+version=20.0.0-rc2
+file=vitess-${version}-4af99b5.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/21.0/get-started/local.md
+++ b/content/en/docs/21.0/get-started/local.md
@@ -88,8 +88,8 @@ Download the [latest binary release](https://github.com/vitessio/vitess/releases
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=20.0.0-rc1
-file=vitess-${version}-7e8c974.tar.gz
+version=20.0.0-rc2
+file=vitess-${version}-4af99b5.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/releases/_index.md
+++ b/content/en/docs/releases/_index.md
@@ -18,7 +18,7 @@ Each major release is maintained for 1 year.
 > The latest and current vitess release is v17.0
 
 ### v20.0
-- **Current version:** [v20.0.0-rc1](https://github.com/vitessio/vitess/releases/tag/v20.0.0-rc1) (2024-06-13)
+- **Current version:** [v20.0.0-rc2](https://github.com/vitessio/vitess/releases/tag/v20.0.0-rc2) (2024-06-20)
 
 ### v19.0
 - **Current version:** [v19.0.4](https://github.com/vitessio/vitess/releases/tag/v19.0.4) (2024-05-08)


### PR DESCRIPTION
As part of https://github.com/vitessio/vitess/issues/16188