### PR TITLE
Replace recommendations/samples using md5 and hash with xxhash

### DIFF
--- a/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -515,7 +515,7 @@ mysql> vexplain select * from corder where sku = "Product_1";
 			"Values": [
 				":sku"
 			],
-			"Vindex": "binary_md5"
+			"Vindex": "xxhash"
 		},
 		{
 			"OperatorType": "Route",

--- a/content/en/docs/21.0/user-guides/configuration-advanced/resharding.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/resharding.md
@@ -156,8 +156,8 @@ the primary [vindex type](../../../reference/features/vindexes/#predefined-vinde
 way of distributing rows into various shards. For other data types we would typically use a different vindex
 type:
 
-* For `VARCHAR` columns, use `unicode_loose_md5` or `unicode_loose_xxhash`.
-* For `VARBINARY`, use `binary_md5` or `xxhash`.
+* For `VARCHAR` columns, use `unicode_loose_xxhash`.
+* For `VARBINARY`, use `xxhash`.
 * Vitess uses a plugin system to define vindexes. If none of the
 [predefined vindexes](../../../reference/features/vindexes/#predefined-vindexes) suit your needs, you can
 develop your own custom vindex.

--- a/content/en/docs/21.0/user-guides/sql/vtexplain.md
+++ b/content/en/docs/21.0/user-guides/sql/vtexplain.md
@@ -78,11 +78,11 @@ The following example VSchema defines a single keyspace `mainkeyspace` and three
   "mainkeyspace": {
     "sharded": true,
     "vindexes": {
-      "hash": {
-        "type": "hash"
+      "xxhash": {
+        "type": "xxhash"
       },
-      "md5": {
-        "type": "unicode_loose_md5",
+      "unicode_loose_xxhash": {
+        "type": "unicode_loose_xxhash",
         "params": {},
         "owner": ""
       },
@@ -101,7 +101,7 @@ The following example VSchema defines a single keyspace `mainkeyspace` and three
         "column_vindexes": [
           {
             "column": "user_id",
-            "name": "hash"
+            "name": "xxhash"
           },
           {
             "column": "name",
@@ -115,7 +115,7 @@ The following example VSchema defines a single keyspace `mainkeyspace` and three
         "column_vindexes": [
           {
             "column": "name",
-            "name": "md5"
+            "name": "unicode_loose_xxhash"
           }
         ],
         "auto_increment": null

--- a/content/en/docs/21.0/user-guides/vschema-guide/sharded.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/sharded.md
@@ -11,9 +11,9 @@ A sharded keyspace allows you to split a large database into smaller parts by di
 
 Vitess provides many predefined vindex types. The most popular ones are:
 
-* `hash`: for numbers
-* `unicode_loose_md5`: for text columns
-* `binary_md5`: for binary columns
+* `xxhash`: for numbers
+* `unicode_loose_xxhash`: for text columns
+* `xxhash`: for binary columns
 
 In our example, we are going to designate `customer` as a sharded keyspace, and create a `customer` table in it. The schema for the table is as follows:
 
@@ -59,7 +59,7 @@ alter vschema on customer.customer add vindex hash(customer_id) using hash;
 The DDL creates the `hash` vindex under the `vindexes` section, the `customer` table under the `tables` section, and associates the `customer_id` column to `hash`. For sharded keyspaces, the only way to create a table is using the above construct. This is because a primary vindex is mandatory for sharded tables.
 
 {{< info >}}
-Every sharded table must have a Primary Vindex. A Primary Vindex must be instantiated from a vindex type that is Unique. `hash`, `unicode_loose_md5` and `binary_md5` are unique vindex types.
+Every sharded table must have a Primary Vindex. A Primary Vindex must be instantiated from a vindex type that is Unique. `xxhash`, `unicode_loose_xxhash` and `binary_md5` are unique vindex types.
 {{< /info >}}
 
 The demo brings up the `customer` table as two shards: `-80` and `80-`. For a `hash` vindex, input values of 1, 2 and 3 fall in the `-80` range, and 4 falls in the `80-` range. Restarting the demo with the updated configs should allow you to perform the following:


### PR DESCRIPTION
It leaves general references in place as they are still valid vindex types. It also leaves references to the examples unchanged as the examples have not been updated to use xxhash based vindexes yet.

This is a follow-up to: https://github.com/vitessio/vitess/pull/16113/files

Changes pages previews:
- https://deploy-preview-1772--vitess.netlify.app/docs/21.0/user-guides/configuration-advanced/createlookupvindex/
- https://deploy-preview-1772--vitess.netlify.app/docs/21.0/user-guides/configuration-advanced/resharding/
- https://deploy-preview-1772--vitess.netlify.app/docs/21.0/user-guides/sql/vtexplain/
- https://deploy-preview-1772--vitess.netlify.app/docs/21.0/user-guides/vschema-guide/sharded/