### PR TITLE
updating video container is-video

### DIFF
--- a/assets/sass/style.sass
+++ b/assets/sass/style.sass
@@ -142,7 +142,12 @@ figure
     flex: 1
 
 .is-video
-  width: 100%
+  max-width: 100%
+  overflow: hidden
+  iframe,
+  video 
+    width: 100%
+    height: 100%
 
 .column
   &.is-thin


### PR DESCRIPTION
contributes to https://github.com/vitessio/website/issues/1763

updates video container `is-video` so it doesn't overflow when the window is resized.