### PR TITLE
Add edit button in upper right of docs

### DIFF
--- a/assets/sass/docs.sass
+++ b/assets/sass/docs.sass
@@ -190,4 +190,6 @@ li.expanded > a > .navlist-caret
 
 a code
   color: $code-link-color
-  
+
+.edit-this-page-small a
+  font-size: 0.75rem

--- a/layouts/partials/docs/edit-this-page.html
+++ b/layouts/partials/docs/edit-this-page.html
@@ -1,0 +1,10 @@
+{{ $path         := .File.Path }}
+{{ $language     := .Language }}
+{{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
+
+<a class="button" href="{{ $editUrl }}" rel="noopener noreferrer" target="_blank">
+  <span class="icon">
+    <i class="fab fa-github"></i>
+  </span>
+  <span>Edit this page</span>
+</a>

--- a/layouts/partials/docs/footer.html
+++ b/layouts/partials/docs/footer.html
@@ -1,16 +1,6 @@
-{{ $path         := .File.Path }}
-{{ $language     := .Language }}
-{{ $editUrl      := printf "https://github.com/vitessio/website/tree/prod/content/%s/%s" $language $path }}
-
 <footer class="footer">
   <div class="container has-text-centered">
-    <a class="button" href="{{ $editUrl }}" rel="noopener noreferrer" target="_blank">
-      <span class="icon">
-        <i class="fab fa-github"></i>
-      </span>
-      <span>Edit this page</span>
-    </a>
-
+    {{ partial "docs/edit-this-page.html" . }}
     <p class="is-size-7 mt-2">Last updated {{ .Lastmod.Format "January 2, 2006" }}</p>
   </div>
 </footer>

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -1,6 +1,11 @@
 {{ $docsSections := where site.Sections "Section" "docs" }}
 
 <header class="docs-header">
+  {{/* Hide on mobile / compact view because it crowds the UI and there's always a footer link anyway */}}
+  <div class="is-pulled-right is-hidden-touch edit-this-page-small">
+    {{ partial "docs/edit-this-page.html" . }}
+  </div>
+
   {{/* Hide breadcrumbs on mobile since bulma.io doesn't handle overflows nicely for long crumbs */}}
   <nav class="breadcrumb is-hidden-touch" aria-label="breadcrumbs">
     <ul>


### PR DESCRIPTION
It's easy to miss that there's an easy-to-access edit workflow link at the bottom of the page, so this change adds the same link at the top right corner of the documentation for more visibility.