### PR TITLE
Improve code block formatting in Getting Started guide - Local Install

### DIFF
--- a/content/en/docs/20.0/get-started/local.md
+++ b/content/en/docs/20.0/get-started/local.md
@@ -39,12 +39,13 @@ sudo systemctl disable etcd
 
 ## Install Node
 
-```
+```sh
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 ```
 
 Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically attempts to add them:
-```
+
+```bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
@@ -52,7 +53,7 @@ export NVM_DIR="$HOME/.nvm"
 
 Finally, install [node](https://nodejs.org/):
 
-```
+```sh
 nvm install 18
 nvm use 18
 ```
@@ -64,6 +65,7 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 AppArmor/SELinux will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:
 
 __AppArmor__:
+
 ```sh
 # Debian and Ubuntu
 sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
@@ -74,6 +76,7 @@ sudo aa-status | grep mysqld
 ```
 
 __SELinux__:
+
 ```sh
 # CentOS
 sudo setenforce 0

--- a/content/en/docs/21.0/get-started/local.md
+++ b/content/en/docs/21.0/get-started/local.md
@@ -84,15 +84,15 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 19:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example:
 
 **Notes:**
 
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=20.0.1
-file=vitess-${version}-003c441.tar.gz
+version=20.0.0-rc2
+file=vitess-${version}-4af99b5.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}

--- a/content/en/docs/21.0/get-started/local.md
+++ b/content/en/docs/21.0/get-started/local.md
@@ -39,12 +39,13 @@ sudo systemctl disable etcd
 
 ## Install Node
 
-```
+```sh
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 ```
 
 Ensure the following is in your bashrc/zshrc or similar. `nvm` automatically attempts to add them:
-```
+
+```bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
@@ -52,7 +53,7 @@ export NVM_DIR="$HOME/.nvm"
 
 Finally, install [node](https://nodejs.org/):
 
-```
+```sh
 nvm install 18
 nvm use 18
 ```
@@ -64,6 +65,7 @@ See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmi
 AppArmor/SELinux will not allow Vitess to launch MySQL in any data directory by default. You will need to disable it:
 
 __AppArmor__:
+
 ```sh
 # Debian and Ubuntu
 sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/
@@ -74,6 +76,7 @@ sudo aa-status | grep mysqld
 ```
 
 __SELinux__:
+
 ```sh
 # CentOS
 sudo setenforce 0
@@ -81,15 +84,15 @@ sudo setenforce 0
 
 ## Install Vitess
 
-Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example:
+Download the [latest binary release](https://github.com/vitessio/vitess/releases) for Vitess on Linux. For example with Vitess 19:
 
 **Notes:**
 
 * Ubuntu is the only fully supported OS, for another OS please [build Vitess by yourself](/docs/contributing) or use the Docker images.
 
 ```sh
-version=20.0.0-rc2
-file=vitess-${version}-4af99b5.tar.gz
+version=20.0.1
+file=vitess-${version}-003c441.tar.gz
 wget https://github.com/vitessio/vitess/releases/download/v${version}/${file}
 tar -xzf ${file}
 cd ${file/.tar.gz/}


### PR DESCRIPTION
I have noticed the inconsistency of the code block formatting which confused me as a new user while going through the [local installation](https://vitess.io/docs/20.0/get-started/local/) guide.  

![Screenshot from 2024-08-01 09-45-20](https://github.com/user-attachments/assets/131ab676-8bdf-487f-a447-7e2c3f5c725e)



Related Issue: #1738