### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/c27ea8e4-51d5-41b5-abfd-0597410506a3/deploy-status)](https://app.netlify.com/sites/vitess/deploys)
 
+
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://vitess.slack.com/ssb/redirect)
+[![X](https://img.shields.io/badge/X-000000?style=for-the-badge&logo=x&logoColor=white)](https://x.com/vitessio)
+[![Stack Overflow](https://img.shields.io/badge/Stack_Overflow-FE7A16?style=for-the-badge&logo=stack-overflow&logoColor=white)](https://stackoverflow.com/search?q=vitess)
+
+
 This repo houses the assets used to build the website at https://vitess.io.
 
 ## Running the site locally


### PR DESCRIPTION
Add Social Media Icons with Links to README #1745

I have added static badges for the existing socials of vitessio. Since, the sizes of the static badges were not coherent with the netlify badge I have placed them in the next line. Please let me know if I should add live badges instead.

@mattlord please review.