### PR TITLE
Fix redirect logic and link references for buffering scenarios documentation

### DIFF
--- a/content/en/docs/archive/17.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/archive/17.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -6,7 +6,7 @@ aliases: ['/docs/reference/features/vtgate-buffering',
 ---
 
 For documentation on buffering behaviors please see
-[VTGate Buffering](../../../reference/features/vtgate-buffering/).
+[VTGate Buffering](https://vitess.io/docs/20.0/reference/features/vtgate-buffering/).
 In this guide we are going to go through a few scenarios involving buffering to
 see the practical behaviors. There are several parameters to tune for buffering
 so, we will be using a python utility [gateslap](https://github.com/planetscale/gateslap)

--- a/content/en/docs/archive/17.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/archive/17.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -6,7 +6,7 @@ aliases: ['/docs/reference/features/vtgate-buffering',
 ---
 
 For documentation on buffering behaviors please see
-[VTGate Buffering](https://vitess.io/docs/20.0/reference/features/vtgate-buffering/).
+[VTGate Buffering]( /docs/20.0/reference/features/vtgate-buffering ).
 In this guide we are going to go through a few scenarios involving buffering to
 see the practical behaviors. There are several parameters to tune for buffering
 so, we will be using a python utility [gateslap](https://github.com/planetscale/gateslap)

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -66,6 +66,14 @@
 /docs/11.0/                              /docs/archive/11.0/
 /docs/11.0/*                             /docs/archive/11.0/:splat
 
+# Redirect old version documentation to current version
+/docs/archive/17.0/reference/features/vtgate-buffering     /docs/20.0/reference/features/vtgate-buffering 301
+     
+
+# Redirect old version directories to current version
+/docs/17.0/                              /docs/20.0/ 301
+/docs/17.0/*                             /docs/20.0/:splat 301
+
 # Blog post
 /blog/2024-02-28-announcing-vitess-19/   /blog/2024-03-06-announcing-vitess-19/
 


### PR DESCRIPTION
This PR addresses the issue [#1787](https://github.com/vitessio/website/issues/1787) where links without an explicit version redirect to the incorrect version and page. Specifically, the link for VTGate Buffering is incorrectly redirecting to the v17 archive page instead of the current v20 page. The redirect logic needs to be updated to point to the correct version and page.

**Changes Made**
- Updated Redirect Logic: Adjusted the redirect logic to ensure that links without an explicit version correctly redirect to the current version (20.0) and the appropriate page.

- Fixed Link References: Changed all relative links in the v17 page to ensure they properly redirect to the current version’s page. This avoids linking to outdated content and ensures users land on the correct page.

**Testing**
![vt buffer](https://github.com/user-attachments/assets/9e77a222-5a06-420d-9e0a-fea3b6104972)
![vt buffer 2](https://github.com/user-attachments/assets/0c9c8ba4-f01e-4e40-acac-24d8dc975ab1)
