### PR TITLE
Document --keep_data behavior for Complete command

### DIFF
--- a/content/en/docs/18.0/reference/vreplication/movetables.md
+++ b/content/en/docs/18.0/reference/vreplication/movetables.md
@@ -258,6 +258,15 @@ See https://github.com/vitessio/vitess/pull/13895 and https://github.com/vitessi
 and more details.
 </div>
 
+#### --keep-data
+**optional**\
+**default** false
+
+<div class="cmd">
+
+During `Complete` or `Cancel` operations, Keeps the original source table data that was copied by the MoveTables workflow. This is useful for retaining data for verification or other purposes.
+</div>
+
 #### --rename-tables
 **optional**\
 **default** false


### PR DESCRIPTION
This PR addresses the issue of https://github.com/vitessio/website/issues/1615 minor improvements and missing details for the Vitess documentation pages on movetables and reshard, along with how to incorporate information about the --keep-data behavior for the complete command.