### PR TITLE
Update kubernetes version docs

### DIFF
--- a/content/en/docs/18.0/reference/vreplication/movetables.md
+++ b/content/en/docs/18.0/reference/vreplication/movetables.md
@@ -258,6 +258,15 @@ See https://github.com/vitessio/vitess/pull/13895 and https://github.com/vitessi
 and more details.
 </div>
 
+#### --keep-data
+**optional**\
+**default** false
+
+<div class="cmd">
+
+During `Complete` or `Cancel` operations, Keeps the original source table data that was copied by the MoveTables workflow. This is useful for retaining data for verification or other purposes.
+</div>
+
 #### --rename-tables
 **optional**\
 **default** false

--- a/content/en/docs/archive/11.0/get-started/operator.md
+++ b/content/en/docs/archive/11.0/get-started/operator.md
@@ -13,13 +13,14 @@ Before we get started, let’s get a few things out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine. We recommend using Kubernetes 1.14, as this is a common denominator across public clouds:
     ```bash
-    minikube start --kubernetes-version=v1.14.10 --cpus=8 --memory=11000 --disk-size=50g
+    minikube start --cpus=8 --memory=11000 --disk-size=50g
     ```
 
     If you do not have a machine with 11GB of memory to spare, you could also consider using GKE instead. An equivalent setup can be deployed from the Cloud Shell with:
     ```bash
     gcloud container clusters create vitess --cluster-version 1.14 --zone us-east1-b --num-nodes 5
     ```
+> **Note:** For the best experience, it is recommended to use the latest stable version of Kubernetes. Please refer to the [Vitess Operator Compatibility Matrix](https://github.com/planetscale/vitess-operator#compatibility) to ensure compatibility with your Kubernetes version.
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and ensure it is in your `PATH`. For example, on Linux:
 


### PR DESCRIPTION
This is a a [PR](https://github.com/vitessio/website/issues/1022) that addresses the issue of using an outdated Kubernetes version in the Vitess documentation.
Remove or Update Commands in Documentation:

1. [x] Remove --kubernetes-version=v1.19.16 from the minikube start command in the following files:
 - content/en/docs/14.0/get-started/operator.md
 - content/en/docs/13.0/get-started/operator.md
 - content/en/docs/12.0/get-started/operator.md
 - content/en/docs/11.0/get-started/operator.md
Instead, add a note pointing users to the compatibility matrix in the documentation, or mention that they should use the latest stable version of Kubernetes.
2. Update examples/operator/README.md:
Remove the --kubernetes-version=v1.19.5 flag.
Add a reference to the compatibility matrix in the official documentation.
3. Update the Vitess Operator Compatibility Table:
Ensure that the compatibility matrix in the documentation is up to date with the supported Kubernetes versions.