### PR TITLE
Capitalization Update in Header

### DIFF
--- a/content/en/docs/21.0/concepts/query-rewriting.md
+++ b/content/en/docs/21.0/concepts/query-rewriting.md
@@ -69,7 +69,7 @@ Vitess handles system variables in one of five different ways:
 In addition to this, Vitess makes sure that @@version includes both the emulated MySQL version and the Vitess version, such as: `5.7.9-vitess-14.0.0`. This value can be changed by using the vtgate flag `--mysql_server_version`.
 
 
-### Special functions
+### Special Functions
 
 There are a few special functions that Vitess handles without delegating to MySQL.
 

--- a/content/en/docs/21.0/get-started/local-mac.md
+++ b/content/en/docs/21.0/get-started/local-mac.md
@@ -236,7 +236,7 @@ vtorc killed (pid 226397)
 user@computer:~/Github/vitess/examples/local$ rm -rf ./vtdataroot
 ```
 
-## Connect to your cluster
+## Connect to Your Cluster
 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 

--- a/content/en/docs/21.0/get-started/local.md
+++ b/content/en/docs/21.0/get-started/local.md
@@ -253,7 +253,7 @@ source ../common/env.sh
 
 Setting up aliases changes `mysql` to always connect to Vitess for your current session. To revert this, type `unalias mysql && unalias vtctldclient` or close your session.
 
-## Connect to your cluster
+## Connect to Your Cluster
 
 You should now be able to connect to the VTGate server that was started in `101_initial_cluster.sh`:
 

--- a/content/en/docs/21.0/get-started/operator.md
+++ b/content/en/docs/21.0/get-started/operator.md
@@ -43,7 +43,7 @@ Install the operator:
 kubectl apply -f operator.yaml
 ```
 
-## Bring up an initial cluster
+## Bring up an Initial Cluster
 
 In this directory, you will see a group of yaml files. The first digit of each file name indicates the phase of example. The next two digits indicate the order in which to execute them. For example, `101_initial_cluster.yaml` is the first file of the first phase. We shall execute that now:
 
@@ -51,7 +51,7 @@ In this directory, you will see a group of yaml files. The first digit of each f
 kubectl apply -f 101_initial_cluster.yaml
 ```
 
-### Verify cluster
+### Verify Cluster
 
 You can check the state of your cluster with `kubectl get pods`. After a few minutes, it should show that all pods are in the status of running:
 
@@ -97,7 +97,7 @@ vtctldclient ApplySchema --sql-file="create_commerce_schema.sql" commerce
 vtctldclient ApplyVSchema --vschema-file="vschema_commerce_initial.json" commerce
 ```
 
-### Connect to your cluster
+### Connect to Your Cluster
 
 You should now be able to connect to the VTGate Server in your cluster with the MySQL client:
 

--- a/content/en/docs/21.0/get-started/vttestserver-docker-image.md
+++ b/content/en/docs/21.0/get-started/vttestserver-docker-image.md
@@ -7,7 +7,7 @@ aliases: ['/docs/tutorials/vttestserver/']
 
 This guide covers using the vttestserver docker image for testing purposes. This is also the docker image that we use for testing in [Vitess Framework Testing](https://github.com/planetscale/vitess-framework-testing).
 
-## Get the docker image
+## Get the Docker Image
 
 The first step is to get the docker image. There are two ways of doing this :
 
@@ -24,7 +24,7 @@ Clone the GitHub repository via:
 cd vitess
 ```
 
-#### Build the docker image
+#### Build the Docker Image
 
 In your shell, execute:
 
@@ -43,11 +43,11 @@ docker pull vitess/vttestserver:mysql57
 docker pull vitess/vttestserver:mysql80
 ```
 
-## Run the docker image
+## Run the Docker Image
 
 At this point, you should have a docker image named `vitess/vttestserver:mysql57` or `vitess/vttestserver:mysql80`.
 
-### Environment variables
+### Environment Variables
 
 The docker image expects some of the environment variables to be set to function properly. The following table lists all the environment variables available along with their usages.
 
@@ -69,18 +69,18 @@ The docker image expects some of the environment variables to be set to function
 
 Environment variables in docker can be specified using the `-e` aka `--env` flag.
 
-### Sending queries to vttestserver container from outside
+### Sending Queries to vttestserver Container from Outside
 
 The vtgate listens for MySQL connections on 3 + the `PORT` environment variable specified. i.e. if you specify `PORT` to be 33574, then vtgate will be listening to connections on 33577, on the `MYSQL_BIND_HOST` which defaults to localhost. But this port will be on the docker container side. To connect to vtgate externally from a MySQL client, you will need to publish that port as well and specify the `MYSQL_BIND_HOST` to `0.0.0.0`. This can be done via the `-p` aka `--publish` flag to docker. For eg: adding `-p 33577:33577` to the `docker
 run` command will publish the container's 33577 port to your local 33577 port, which can now be used to connect to the vtgate.
 
-### Viewing the vtcombo `/debug/status` dashboard and running vtctld commands
+### Viewing the vtcombo `/debug/status` Dashboard and Running vtctld Commands
 
 The vtcombo `/debug/status` page is viewable at the port specified by the `PORT` environment variable on the docker side. To view it in a browser outside, you will need to publish that port as well and specify the `VTCOMBO_BIND_HOST` to `0.0.0.0`. This can be done via the `-p` aka `--publish` flag to docker.
 
 Similarily, vtctld listens for grpc requests at the port 1 + `PORT`. So, in order to run vtctld commands using vtctldclient binary, this port must also be published.
  
-### Persisting container data
+### Persisting Container Data
 
 If you wish to keep the state of the test container across reboots, such as when running the vttestserver container as a database container in local application development environments, you may optionally pass the `--persistent_mode` flag, along with a `--data_dir` directory which is bound to a docker volume. Due to a bug, the `--port` argument must also be present for correct operation.
 

--- a/content/en/docs/21.0/overview/history.md
+++ b/content/en/docs/21.0/overview/history.md
@@ -13,7 +13,7 @@ Vitess was created in 2010 to solve the MySQL scalability challenges that the te
 
 Vitess let YouTube remove that logic from the application source code, introducing a proxy between the application and the database to route and manage database interactions. Since then, YouTube has scaled its user base by a factor of more than 50, greatly increasing its capacity to serve pages, process newly uploaded videos, and more. Even more importantly, Vitess is a platform that continues to scale.
 
-## Vitess becomes a CNCF project
+## Vitess Becomes a CNCF Project
 
 The [CNCF](https://www.cncf.io) serves as the vendor-neutral home for many of the fastest-growing open source projects. In [February 2018](https://www.cncf.io/blog/2018/02/05/cncf-host-vitess/) the Technical Oversight Committee (TOC) voted to accept Vitess as a CNCF incubation project. Vitess became the eighth CNCF project to graduate in [November 2019](https://www.cncf.io/announcement/2019/11/05/cloud-native-computing-foundation-announces-vitess-graduation/), joining Kubernetes, Prometheus, Envoy, CoreDNS, containerd, Fluentd, and Jaeger.
 

--- a/content/en/docs/21.0/overview/scalability-philosophy.md
+++ b/content/en/docs/21.0/overview/scalability-philosophy.md
@@ -6,7 +6,7 @@ aliases: ['/docs/launching/scalability-philosophy/']
 
 Scalability problems can be solved using many approaches. This document describes Vitess' approach to address these problems.
 
-## Small instances
+## Small Instances
 
 When deciding to shard or break databases up into smaller parts, it's tempting to break them just enough that they fit in one machine. In the industry, it’s common to run only one MySQL instance per host.
 
@@ -14,7 +14,7 @@ Vitess recommends that instances be broken up into manageable chunks (250GB per 
 
 There are fewer lock contentions to worry about, replication is a lot happier, production impact of outages is smaller, backups and restores run faster, and a lot more secondary advantages can be realized. For example, you can shuffle instances around to get better machine or rack diversity leading to even smaller production impact on outages, and improved resource usage.
 
-## Durability through replication
+## Durability Through Replication
 
 Traditional data storage software treated data as durable as soon as it was flushed to disk. However, this approach is impractical in today’s world of commodity hardware. Such an approach also does not address disaster scenarios.
 
@@ -24,7 +24,7 @@ Many of the workflows in Vitess have been built with this approach in mind. For 
 
 Relying on replication also allows you to loosen some of the disk-based durability settings. For example, you can turn off `sync_binlog`, which greatly reduces the number of IOPS to the disk thereby increasing effective throughput.
 
-## Consistency model
+## Consistency Model
 
 Before sharding or moving tables to different keyspaces, the application needs to be verified (or changed) such that it can tolerate the following changes:
 
@@ -51,7 +51,7 @@ As for atomicity, the following levels are supported:
 * `MULTI`: multi-db transactions with best effort commit.
 * `TWOPC`: multi-db transactions with 2PC commit.
 
-### No active-active replication
+### No active-active Replication
 
 Vitess doesn’t support active-active replication setup (previously called multi-master). It has alternate ways of addressing most of the use cases that are typically solved by such a configuration.
 

--- a/content/en/docs/21.0/overview/supported-databases.md
+++ b/content/en/docs/21.0/overview/supported-databases.md
@@ -24,6 +24,6 @@ Vitess supports importing from a wide range of databases that include:
 - [Percona Server for MySQL](https://www.percona.com/software/mysql-database/percona-server) version 5.7 to 8.0
 - [MariaDB](https://mariadb.com) versions 10.10+
 
-## See also
+## See Also
 
 + [MySQL Compatibility](../../reference/compatibility/mysql-compatibility/)

--- a/content/en/docs/21.0/overview/whatisvitess.md
+++ b/content/en/docs/21.0/overview/whatisvitess.md
@@ -40,7 +40,7 @@ Vitess served all YouTube database traffic for over five years. Many enterprises
     - Vertical and Horizontal sharding support
     - Multiple sharding schemes, with the ability to plug-in custom ones
 
-## Comparisons to other storage options
+## Comparisons to Other Storage Options
 
 The following sections compare Vitess to two common alternatives, a vanilla MySQL implementation and a NoSQL implementation.
 

--- a/content/en/docs/21.0/reference/backup-and-restore/metrics.md
+++ b/content/en/docs/21.0/reference/backup-and-restore/metrics.md
@@ -6,7 +6,7 @@ weight: 10
 
 Backup and restore operations export several metrics using the expvars interface. These are available at the `/debug/vars` endpoint of Vtbackup's and VTTablet's http status pages. [More details can be found here](../../features/monitoring/#3-push-based-metrics-system).
 
-## Backup metrics
+## Backup Metrics
 
 Metrics related to backup operations are available in both Vtbackup and VTTablet.
 
@@ -20,7 +20,7 @@ Depending on the Backup Engine and Backup Storage in-use, a backup may be a comp
 
 These operations are counted and timed, and the number of bytes consumed or produced by each stage of the pipeline are counted as well.
 
-## Restore metrics
+## Restore Metrics
 
 Metrics related to restore operations are available in both Vtbackup and VTTablet.
 
@@ -38,7 +38,7 @@ These operations are counted and timed, and the number of bytes consumed or prod
 
 _RestoredBackupTime_ captures the timestamp associated with the backup from which the current process was restored. _RestorePosition_ captures the GTID position associated with that backup.
 
-## Vtbackup metrics
+## Vtbackup Metrics
 
 Vtbackup exports some metrics which are not available elsewhere.
 

--- a/content/en/docs/21.0/reference/compatibility/mysql-compatibility.md
+++ b/content/en/docs/21.0/reference/compatibility/mysql-compatibility.md
@@ -126,7 +126,7 @@ Currently, Vitess does not have support for recursive CTEs.
 ### Window Functions
 Vitess does not yet support Window Functions.
 
-### Killing running queries
+### Killing Running Queries
 
 In v18, Vitess introduced the ability to terminate running queries using the [`KILL` command](https://dev.mysql.com/doc/refman/8.0/en/kill.html) through VTGate.
 To execute a "kill connection" or "kill query" statement, the client needs to establish a new connection.

--- a/content/en/docs/21.0/reference/features/connection-pools.md
+++ b/content/en/docs/21.0/reference/features/connection-pools.md
@@ -66,7 +66,7 @@ As a result, connection pools should be sized mindful of the capacity of the und
  * Used in the (non-default) TWOPC `transaction_mode` for metadata state management.  
   This pool will always be empty unless TWOPC is used.
 
-### Pools associated with online DDL
+### Pools Associated with Online DDL
   
 #### online_ddl_executor_pool
 
@@ -82,7 +82,7 @@ As a result, connection pools should be sized mindful of the capacity of the und
  * Potentially uses `--db_app_user`, `--db_dba_user` and `--db_appdebug_user` i.e. defaults 'vt_app', 'vt_dba' and 'vt_appdebug'
  * Used in Online DDL to purge/evac/drop origin tables after Online DDL operations from them have been completed.
 
-## Other DB connections used without pools:
+## Other DB Connections Used Without pools:
 
 ### vttablet user flag:
 
@@ -106,9 +106,9 @@ As a result, connection pools should be sized mindful of the capacity of the und
  * (default 'vt_filtered')
  * Used by VReplication on the source (vstreamer) and target (vplayer) side when copying data.
 
-## Other relevant pool-related variables
+## Other Relevant pool-related Variables
 
-### vttablet user limit
+### vttablet User Limit
 Flag: `--transaction_limit_per_user` 
 
  * (default 0.4)
@@ -118,12 +118,12 @@ Flag: `--transaction_limit_per_user`
  Or disable this limit feature by setting `--transaction_limit_by_username` to `false` as the default is `true`.
  This option only comes into play if the TX limiter is enabled by `--enable_transaction_limit`, which it is not by default.
 
-### vtgate system settings
+### vtgate System Settings
 Flag: `--enable_system_settings`
 
 This vtgate flag allows clients to modify a [subset of system settings](https://github.com/vitessio/vitess/blob/main/go/vt/sysvars/sysvars.go#L174-L217) on the MySQL.
 
-## Calculating maximum db connections used by vttablet
+## Calculating Maximum db Connections Used by vttablet
 
 You can use the following formula to approximate the maximum MySQL connections per vttablet instance:
 ```

--- a/content/en/docs/21.0/reference/features/messaging.md
+++ b/content/en/docs/21.0/reference/features/messaging.md
@@ -184,7 +184,7 @@ thundering herds.
 Messages that have been successfully acked will be deleted after their age
 exceeds the time period specified by `vt_purge_after`.
 
-## Advanced usage
+## Advanced Usage
 
 The `MessageAck` functionality is currently a gRPC API call and cannot be used
 from the SQL interface. However, you can manually ack messages using a regular
@@ -210,7 +210,7 @@ aggressive.
 
 You can also view messages using regular `SELECT` queries against the message table.
 
-## Known limitations
+## Known Limitations
 
 Here is a short list of possible limitations/improvements:
 

--- a/content/en/docs/21.0/reference/features/monitoring.md
+++ b/content/en/docs/21.0/reference/features/monitoring.md
@@ -3,23 +3,23 @@ title: Monitoring
 weight: 8
 ---
 
-# Current state of monitoring
+# Current State of Monitoring
 
 There are currently three main ways that a Vitess cluster can be monitored. Depending on your needs, you can use any of the following methods:
 
-## 1. Vitess status pages
+## 1. Vitess Status Pages
 
 The status HTML pages of various Vitess components can be accessed by pointing your browser to `http://<host>:<port>/debug/status`. The status pages will often display some basic, but useful, information for monitoring. For example, the status page of a vttablet will show the QPS graph for the past few minutes.
 
 Viewing a status page can be useful since it works out of the box, but it only provides very basic monitoring capabilities.
 
-## 2. Pull-based metrics system
+## 2. Pull-based Metrics System
 
 Vitess uses Go’s [expvar package](https://golang.org/pkg/expvar/) to expose various metrics, with the expectation that a user can configure a pull-based metrics system to ingest those metrics. Metrics are published to `http://<host>:<port>/debug/vars` as JSON key-value pairs, which should be easy for any metrics system to parse.
 
 Scraping Vitess variables is a good way to integrate Vitess into an existing monitoring system, and is useful for building up detailed monitoring dashboards. It is also the officially supported way for monitoring Vitess.
 
-## 3. Push-based metrics system
+## 3. Push-based Metrics System
 
 Vitess also includes support for push-based metrics systems via plug-ins. Each Vitess component would need to be run with the `--emit_stats` flag.
 

--- a/content/en/docs/21.0/reference/features/recovery.md
+++ b/content/en/docs/21.0/reference/features/recovery.md
@@ -35,7 +35,7 @@ Point in Time Recovery leverages two Vitess features:
 1. The use of `SNAPSHOT` keyspaces for recovery of the last backup before a requested specific timestamp to restore to.
 2. Integration with a binlog server to allow vttablet to apply binary logs from the recovered backup up to the specified timestamp.
 
-### Use cases
+### Use Cases
 
 - Accidental deletion of data, e.g. dropping a table by mistake, running an UPDATE or DELETE with an incorrect WHERE clause, etc.
 - Corruption of data due to application bugs.
@@ -47,7 +47,7 @@ Point in Time Recovery leverages two Vitess features:
 - There should be continuous binlogs available from the backup time to the desired point in time.
 - This feature is tested using [Ripple](https://github.com/google/mysql-ripple) as the binlog server.  However, it should be possible to use a MySQL instance as source for the binlogs as well.
 
-### Example usage
+### Example Usage
 
 To use this feature, you need a usable backup of Vitess data and continuous binlogs.
 

--- a/content/en/docs/21.0/reference/features/schema-management.md
+++ b/content/en/docs/21.0/reference/features/schema-management.md
@@ -18,7 +18,7 @@ This document describes the [`vtctl`](../../../reference/programs/vtctl/) comman
 
 It is not recommended to run schema changes through this command. Instead, use [managed, online schema changes](../../../user-guides/schema-changes/managed-online-schema-changes/).
 
-## Reviewing your schema
+## Reviewing Your Schema
 
 This section describes the following vtctl commands, which let you look at the schema and validate its consistency across tablets or shards:
 
@@ -68,7 +68,7 @@ The [`GetVSchema`](../../../reference/programs/vtctl/#getvschema) command displa
 
 The [`GetSrvVSchema`](../../../reference/programs/vtctl/#getsrvvschema) command displays the combined VSchema for a given cell.
 
-## Changing your schema
+## Changing Your Schema
 
 This section describes the following commands:
 
@@ -99,7 +99,7 @@ Further reading:
 * [Managed schema changes](../../../user-guides/schema-changes/managed-online-schema-changes/)
 * [DDL strategies](../../../user-guides/schema-changes/ddl-strategies/)
 
-#### Permitted schema changes
+#### Permitted Schema Changes
 
 The `ApplySchema` command supports these commands:
 

--- a/content/en/docs/21.0/reference/features/sharding.md
+++ b/content/en/docs/21.0/reference/features/sharding.md
@@ -25,7 +25,7 @@ Vitess supports the following types of sharding operations:
 
 With these features, you can start with a single keyspace that contains all of your data (in multiple tables). As your database grows, you can move tables to different keyspaces (vertical split) and shard some or all of those keyspaces (horizontal split) without any real downtime for your application.
 
-## Sharding scheme
+## Sharding Scheme
 
 Vitess allows you to choose the type of sharding scheme by the choice of your Primary Vindex for the tables of a shard. Once you have chosen the Primary Vindex, you can choose the partitions depending on how the resulting keyspace IDs are distributed.
 

--- a/content/en/docs/21.0/reference/features/tablet-throttler.md
+++ b/content/en/docs/21.0/reference/features/tablet-throttler.md
@@ -163,7 +163,7 @@ The response includes:
 The response also includes an HTTP status (e.g. `200` for "OK"). This value is being deprecated and will be removed in `v22` or later.
 {{</ info >}}
 
-## How concepts are combined and used
+## How Concepts are Combined and Used
 
 ### Metric thresholds
 
@@ -326,7 +326,7 @@ $ vtctldclient UpdateThrottlerConfig --app-name "all" --app-metrics "" commerce
 
 The special app `vitess` is internally assigned all known metrics, at all times.
 
-### App rules
+### App Rules
 
 The user may impose additional throttling rules on any given app. A rule is limited by a duration (after which the rule expires and removed), and can:
 
@@ -367,7 +367,7 @@ It is possible to expire (remove the rule) early via:
 $ vtctldclient UpdateThrottlerConfig --unthrottle-app "vreplication" commerce
 ```
 
-## Commands and flags
+## Commands and Flags
 
 These are the `vtctldclient` commands to control or query the tablet throttler:
 
@@ -715,9 +715,9 @@ $ vtctldclient GetKeyspace commerce | jq .keyspace.throttler_config
 }
 ```
 
-## Additional notes
+## Additional Notes
 
-### Throttler operation
+### Throttler Operation
 
 - Each tablet owns its own metrics (the `self` scope).
 - In addition, the shard's `PRIMARY` is responsible for collecting metrics from all shard's tablet.
@@ -738,7 +738,7 @@ It does not make much sense to use a lag threshold like `1s` due to the above re
 As a general guideline, it is also not useful to set the lag threshold above `30s` for operational reasons (Online DDL cut-over, plannet reparents, etc.)
 {{</ info >}}
 
-### Response codes
+### Response Codes
 
 Throttler returns one of the following response codes in a check response:
 
@@ -750,20 +750,20 @@ Throttler returns one of the following response codes in a check response:
 
 An `OK` response is the only one where the app should proceed to write. All Vitess internal apps handle these values automatically.
 
-### The custom query
+### The Custom Query
 
 The custom query can be either:
 
 - A `show global status like '<var>'` that returns a single value.
 - A `select` query with a single row, single column numeric result.
 
-### Exempting apps
+### Exempting Apps
 
 Exempting app should be done with caution. When an app is exempted, it had no controls and can negatively impact the shard's health. Moreover, it is likely that an exempted app will push one or more metrics beyond the configured threshold. For example, it may push replication lag beyond a `5s` threshold. In such scenario, no other app could may any progress whatsoever, leading to starvation of all unexempted apps.
 
 Some internal Vitess apps are always exempted. These are critical for the ongoing operation of the cluster, and do not generate high load. An example is the schema tracker, which tails the binary logs for changes, but does not otherwise copy or write any data.
 
-### Heartbeat configuration
+### Heartbeat Configuration
 
 {{< info >}}
 Configuring heartbeats is not strictly required, as the throttler will initiate an on-demand heartbeat lease while serving requests.
@@ -789,7 +789,7 @@ The throttler does also provide a HTTP endpoint for external apps such as `gh-os
 
 The tablet throttler exports several metrics using the expvars interface. These are available at the `/debug/vars` endpoint of vttablet's http status pages. [More details can be found here](../../features/monitoring/#3-push-based-metrics-system).
 
-#### Aggregated metrics
+#### Aggregated Metrics
 
 These are the metrics by which the throttler compares with the threshold and decides whether to accept or reject throttle checks.
 
@@ -812,7 +812,7 @@ Gauge, on the `PRIMARY` tablet only, this is the aggregated collected metric val
 - `ThrottlerAggregatedShardLoadavg`
 - `ThrottlerAggregatedShardThreads_running`
   
-#### Check metrics
+#### Check Metrics
 
 The throttler is checked by apps (`vreplication`, `online-ddl`, etc), and responds with status codes, "OK" for "good to proceed" or any other code for "hold off".
 
@@ -850,7 +850,7 @@ Gauge, number of seconds since the last good self-check across all metrics.
 
 Gauge, number of seconds since the last good shard-check across all metrics.
 
-#### Internal throttler metrics
+#### Internal throttler Metrics
 
 These metrics are helpful when analyzing the throttler behavior, how it interacts with other shard throttlers, its heartbeat mechanism.
 

--- a/content/en/docs/21.0/reference/features/topology-service.md
+++ b/content/en/docs/21.0/reference/features/topology-service.md
@@ -8,7 +8,7 @@ This document describes the Topology Service, a key part of the Vitess architect
 
 Vitess uses a plugin implementation to support multiple backend technologies for the Topology Service (etcd, ZooKeeper, Consul). Concretely, the Topology Service handles two functions: it is both a [distributed lock manager](http://en.wikipedia.org/wiki/Distributed_lock_manager) and a repository for topology metadata. In earlier versions of Vitess, the Topology Serice was also referred to as the Lock Service.
 
-## Requirements and usage
+## Requirements and Usage
 
 The Topology Service is used to store information about the Keyspaces, the
 Shards, the Tablets, the Replication Graph, and the Serving Graph. We store
@@ -58,7 +58,7 @@ If the Global Topology Service dies and is not recoverable, this is more of a
 problem. All the Keyspace / Shard objects have to be recreated or be restored.
 Then the cells should recover.
 
-## Global data
+## Global Data
 
 This section describes the data structures stored in the Global instance of the
 topology service.
@@ -92,12 +92,12 @@ A Shard can be locked. We use this during operations that affect either the
 Shard record, or multiple tablets within a Shard (like reparenting), so multiple
 tasks cannot concurrently alter the data.
 
-### VSchema data
+### VSchema Data
 
 The VSchema data contains sharding and routing information for
 the [VTGate API](https://github.com/vitessio/vitess/blob/main/doc/design-docs/VTGateV3Features.md).
 
-## Local data
+## Local Data
 
 This section describes the data structures stored in the Local instance (per
 cell) of the topology service.
@@ -124,14 +124,14 @@ The only way a Tablet record will be updated is one of:
 * If a tablet becomes unresponsive, it may be forced to spare to make it
   unhealthy when it restarts.
 
-### Replication graph
+### Replication Graph
 
 The Replication Graph allows us to find Tablets in a given Cell / Keyspace /
 Shard. It used to contain information about which Tablet is replicating from
 which other Tablet, but that was too complicated to maintain. Now it is just a
 list of Tablets.
 
-### Serving graph
+### Serving Graph
 
 The Serving Graph is what the clients use to find the per-cell topology of a
 Keyspace. It is a roll-up of global data (Keyspace + Shard). vtgates only open a
@@ -160,7 +160,7 @@ keyspaces in a single object.
 It can be rebuilt by running `vtctl RebuildVSchemaGraph`. It is automatically
 rebuilt when using `vtctl ApplyVSchema` (unless prevented by flags).
 
-## Workflows involving the Topology Service
+## Workflows Involving the Topology Service
 
 The Topology Service is involved in many Vitess workflows.
 
@@ -191,7 +191,7 @@ will change the global Shard records, and the local SrvKeyspace records. A
 vertical split will change the global Keyspace records, and the local
 SrvKeyspace records.
 
-## Exploring the data in a Topology Service
+## Exploring the Data in a Topology Service
 
 We store the proto3 serialized binary data for each object.
 
@@ -294,7 +294,7 @@ specifying the addresses of the observers in the server address, after a `|`,
 for instance:
 `global_server1:p1,global_server2:p2|observer1:po1,observer2:po2`.
 
-#### Implementation details
+#### Implementation Details
 
 We use the following paths for Zookeeper specific data, in addition to the
 regular files:
@@ -349,7 +349,7 @@ If only one cell is used, the same etcd instances can be used for both
 global and local data. A local cell record still needs to be created, just use
 the same server address and, very importantly, a *different* root directory.
 
-#### Implementation details
+#### Implementation Details
 
 For locks, we use a subdirectory named `locks` in the directory to lock, and an
 ephemeral file in that subdirectory (it is associated with a lease, whose TTL
@@ -368,7 +368,7 @@ the `etcdctl` tool, you will have to tell it to use the v3 API, e.g.:
 ETCDCTL_API=3 etcdctl get / --prefix --keys-only
 ```
 
-### Consul `consul` implementation
+### Consul `consul` Implementation
 
 This topology service plugin is meant to use Consul clusters as storage backend
 for the topology data.
@@ -405,7 +405,7 @@ If only one cell is used, the same consul instances can be used for both
 global and local data. A local cell record still needs to be created, just use
 the same server address and, very importantly, a *different* root node path.
 
-#### Implementation details
+#### Implementation Details
 
 For locks, we use a file named `Lock` in the directory to lock, and the regular
 Consul Lock API.
@@ -418,7 +418,7 @@ use a long poll whose duration is set by the
 `-topo_consul_watch_poll_duration` flag. Canceling a watch may have to
 wait until the end of a polling cycle with that duration before returning.
 
-## Running multi cell environments
+## Running Multi Cell Environments
 
 When running an environment with multiple cells, it is essential to first create
 and configure your global topology service. Then define each local topology
@@ -456,7 +456,7 @@ etcd, zookeeper, or consul. At a higher level overview:
   you may connect to multiple local topology services.
 
 
-### Simple local configuration
+### Simple Local Configuration
 
 For this example run through, we will be using two etcd services one for
 the global and one for local topology service.
@@ -578,7 +578,7 @@ vtctldclient --server ${VTCTLD_IP}:15999 RebuildVSchemaGraph
 ```
 
 
-## Running single cell environments
+## Running Single Cell Environments
 
 The topology service is meant to be distributed across multiple cells, and
 survive single cell outages. However, one common usage is to run a Vitess
@@ -595,7 +595,7 @@ cell as well. Let's use a short cell name, like `local`, as the local data in
 that topology service will later on be moved to a different topology service,
 which will have the real cell name.
 
-### Extending to more cells
+### Extending to More Cells
 
 To then run in multiple cells, the current topology service needs to be split
 into a global instance and one local instance per cell. Whereas, the initial
@@ -642,7 +642,7 @@ After this split, the configuration is completely symmetrical:
   contains local topology data about Tablets, and roll-ups of global data for
   efficient access. Typically, it has 3 servers in each cell.
 
-## Migration between implementations
+## Migration Between Implementations
 
 We provide the `topo2topo` utility to migrate between one implementation
 and another of the topology service.
@@ -724,7 +724,7 @@ vtctl ${GLOBAL_TOPOLOGY} RebuildVSchemaGraph
 # any more.
 ```
 
-### Migration using the `Tee` implementation
+### Migration Using the `Tee` Implementation
 
 If your migration is more complex, or has special requirements, we also support
 a 'tee' implementation of the topo service interface. It is defined in

--- a/content/en/docs/21.0/reference/features/two-phase-commit.md
+++ b/content/en/docs/21.0/reference/features/two-phase-commit.md
@@ -49,7 +49,7 @@ set transaction_mode='twopc';
 
 ### gRPC Clients
 
-#### Go driver
+#### Go Driver
 
 For the Go driver, you request the atomicity by adding it to the context using the `WithAtomicity` function. For more details, please refer to the respective GoDocs.
 
@@ -57,7 +57,7 @@ For the Go driver, you request the atomicity by adding it to the context using t
 
 For Python, the begin function of the cursor has an optional `single_db` flag. If the flag is `True`, then the request is for a single-db transaction. If `False` (or unspecified), then the following commit call's twopc flag decides if the commit is 2PC or Best Effort (multi).
 
-#### Adding support in a new driver
+#### Adding Support in a New Driver
 
 The VTGate RPC API extends the Begin and Commit functions to specify atomicity. The API mimics the Python driver: The BeginRequest message provides a `single_db` flag and the `CommitRequest` message provides an atomic flag which is synonymous to twopc.
 
@@ -79,14 +79,14 @@ The usual default values of MySQL are sufficient. However, it is important to ve
 
 A few additional variables have been added to `/debug/vars`. Failures described below should be rare. But these variables are present so you can build an alert mechanism if anything were to go wrong.
 
-## Critical failures
+## Critical Failures
 
 The following errors are not expected to happen. If they do, it means that 2PC transactions have failed to commit atomically:
 
 * **InternalErrors.TwopcCommit**: This is a counter that shows the number of times a prepared transaction failed to fulfil a commit request.
 * **InternalErrors.TwopcResurrection**: This counter is incremented if a new primary failed to resurrect a previously prepared (and unresolved) transaction.
 
-## Alertable failures
+## Alertable Failures
 
 The following failures are not urgent, but require investigation:
 

--- a/content/en/docs/21.0/reference/features/vindexes.md
+++ b/content/en/docs/21.0/reference/features/vindexes.md
@@ -4,7 +4,7 @@ weight: 10
 aliases: ['/docs/schema-management/consistent-lookup/','/docs/reference/vindexes/']
 ---
 
-## A Vindex maps column values to keyspace IDs
+## A Vindex Maps Column Values to Keyspace IDs
 
 A Vindex provides a way to map a column value to a `keyspace ID`. Since each shard in Vitess covers a range of `keyspace ID` values, this mapping can be used to identify which shard contains a row. A variety of vindexes are available to choose from with different trade-offs, and you can choose one that best suits your needs.
 
@@ -58,7 +58,7 @@ Typically, the Primary Vindex for a table is Functional. In some cases, it is th
 A Lookup Vindex is implemented as a MySQL lookup table that maps a column value to the keyspace id. This is usually needed when database user needs to efficiently find a row using a WHERE clause that does not contain the Primary Vindex. At the time of insert, the computed keyspace ID of the row is stored in the lookup table against the column value.
 
 
-### Lookup Vindex types
+### Lookup Vindex Types
 
 The lookup table that implements a Lookup Vindex can be sharded or unsharded.  Note that the lookup row is most likely not going to be in the same shard as the keyspace id it points to.
 
@@ -71,7 +71,7 @@ There are currently two vindex types in Vitess for consistent lookup:
 * `consistent_lookup_unique`
 * `consistent_lookup`
 
-#### Consistent Lookup usage
+#### Consistent Lookup Usage
 
 There are 3 sessions which VTGate can open when a consistent lookup is involved.
 
@@ -105,7 +105,7 @@ As for a `lookup` vindex, it can be changed it to a `consistent_lookup` only if 
 
 Functional Vindexes can be also be shared. However, there is no concept of ownership because the column to keyspace ID mapping is pre-established.
 
-### Lookup Vindex guidance
+### Lookup Vindex Guidance
 
 The guidance for implementing lookup vindexes has been to create a two-column table. The first column (`from` column) should match the type of the column of the main table that needs the vindex. The second column (`to` column) should be a `BINARY` or a `VARBINARY` large enough to accommodate the keyspace id.
 
@@ -153,7 +153,7 @@ Every Vindex has an optional `params` section that contains a map of string key-
 
 There is an optional fourth parameter: `batch_lookup`. To read more about how to use `batch_lookup` see our [Unique Lookup user guide](../../../user-guides/vschema-guide/unique-lookup/).
 
-### How Vindexes are used
+### How Vindexes are Used
 
 #### Cost
 
@@ -261,7 +261,7 @@ There are also the following legacy (deprecated) Vindexes. **Do not use these**:
 | lookup\_unicodeloosemd5\_hash | Lookup NonUnique | No | No | 20 |
 | lookup\_unicodeloosemd5\_hash\_unique | Lookup Unique | If unowned | No | 10 |
 
-### Query Vindex functions
+### Query Vindex Functions
 
 You can query Vindex functions to see the resulting `keyspace_id` it produces (the resulting hash is a 64-bit hexadecimal number) and thus which shard a particular row would be placed on within the keyspace. You would query the Vindex functions by referencing their name as defined in your VSchema, and using query predicates specifically on the fixed name `id` field (this is not related to your actual schema). The Vindex functions support both equality (`WHERE id = X`) and list (`WHERE id IN(...)`) lookups. Here's a full example using the `customer` keyspace:
 
@@ -323,7 +323,7 @@ hex_keyspace_id: d9e62c0ad204fe91658ecc758049e515
 
 ```
 
-### Unknown Vindex parameters
+### Unknown Vindex Parameters
 
 Most Vindexes will accept unknown parameters without complaint. For example, the following `lookup` Vindex can be applied without error:
 

--- a/content/en/docs/21.0/reference/features/vitess-sequences.md
+++ b/content/en/docs/21.0/reference/features/vitess-sequences.md
@@ -22,7 +22,7 @@ Vitess Sequences fill that gap:
 * Transparent use, similar to MySQL `auto_increment`: when the field is omitted in
   an `insert` statement, the next sequence value is used.
 
-## When *not* to use `auto_increment`
+## When *not* to Use `auto_increment`
 
 Let us start by exploring the limitations and drawbacks of using an
 `auto_increment` column.
@@ -145,6 +145,7 @@ Now any table that will be using the new sequence can reference it in its VSchem
 ```
 
 ## Initializing a Sequence
+
 The sequence backing table needs to be pre-populated with a single row where:
 
 * `id` must always be 0.
@@ -160,7 +161,7 @@ For example:
 insert into user_seq(id, next_id, cache) values(0, 1, 1000);
 ```
 
-### Accessing a Sequence directly
+### Accessing a Sequence Directly
 
 If a sequence is used to fill in an ID column for a table, nothing further needs to
 be done. Just sending no value for the column will make vtgate insert the next
@@ -176,7 +177,7 @@ select next value from user_seq;
 select next 5 values from user_seq;
 ```
 
-### Sequence limitations
+### Sequence Limitations
 
 Vitess sequences do not behave like a MySQL `auto_increment` column in all
 ways.  One significant example is if you mix cases where you provide values
@@ -209,8 +210,8 @@ mysql> select * from t1;
 4 rows in set (0.00 sec)
 ```
 
-
 Vitess sequence mixed insert case (`c1` is the sequence column):
+
 ``` sql
 mysql> insert into t1 (c1,c2) values (1,1),(2,2),(3,3);
 Query OK, 3 rows affected (0.04 sec)
@@ -228,6 +229,7 @@ mysql> select * from t1;
 mysql> insert into t1 (c2) values (4);
 ERROR 1062 (23000): transaction rolled back to reverse changes of partial DML execution: target: sharded.-80.primary: vttablet: Duplicate entry '1' for key 't1.PRIMARY' (errno 1062) (sqlstate 23000) (CallerID: user): Sql: "insert into t1(c2, c1) values (:_c2_0, :_c1_0)", BindVars: {__seq0: "type:INT64 value:\"1\""_c1_0: "type:INT64 value:\"1\""_c2_0: "type:INT64 value:\"4\""vtg1: "type:INT64 value:\"4\""}
 mysql> select * from t1;
+
 +----+------+
 | c1 | c2   |
 +----+------+

--- a/content/en/docs/21.0/reference/features/vschema.md
+++ b/content/en/docs/21.0/reference/features/vschema.md
@@ -32,7 +32,7 @@ You can still specify a tablet type for the unspecified mode. For example, you c
 
 Some frameworks require you to specify an explicit database name while connecting. In order to make them work in unspecified mode, you can specify the database name as `@replica` or `@primary` instead of a blank one.
 
-## Sharded keyspaces require a VSchema
+## Sharded Keyspaces Require a VSchema
 
 A VSchema is needed to tie together all the databases that Vitess manages. For a very trivial setup where there is only one unsharded keyspace, there is no need to specify a VSchema because Vitess will know that there is no other place to route a query.
 
@@ -62,7 +62,7 @@ The Vschema contains the [Vindex](../vindexes) for any sharded tables. The Vinde
 
 Auto-increment columns do not work very well for sharded tables. [Vitess sequences](../vitess-sequences) solve this problem. Sequence tables must be specified in the VSchema, and then tied to table columns. At the time of insert, if no value is specified for such a column, VTGate will generate a number for it using the sequence table.
 
-## Reference tables
+## Reference Tables
 
 Vitess allows you to create an unsharded table and deploy it into all shards of a sharded keyspace. The data in such a table is assumed to be identical for all shards. In this case, you can specify that the table is of type `reference`, and should not specify any vindex for it. Any joins of this table with an unsharded table will be treated as a local join.
 
@@ -262,7 +262,7 @@ To recap, a checklist for creating the shared Secondary Vindex is:
 
 Currently, these steps have to be currently performed manually. However, extended DDLs backed by improved automation will simplify these tasks in the future.
 
-### The columns field
+### The Columns Field
 
 For a table, you can specify an additional columns field. This can be used for two purposes:
 
@@ -301,7 +301,7 @@ If `column_list_authoritative` is false or not specified, then VTGate will treat
 
 Vtgates also have the capability to track the schema changes and populate the columns list on its own. To know more about this feature, read [here](../schema-tracking).
 
-### Advanced usage
+### Advanced Usage
 
 The examples/demo also shows more tricks you can perform:
 

--- a/content/en/docs/21.0/reference/features/vtgate-buffering.md
+++ b/content/en/docs/21.0/reference/features/vtgate-buffering.md
@@ -29,7 +29,7 @@ handle errors appropriately if/when they occur (e.g. unplanned outages, planned 
 VReplication migrations, etc.)
 {{< /warning >}}
 
-## VTGate flags to enable buffering
+## VTGate Flags to Enable Buffering
 
 First, let us cover the flags that need to be set in VTGate to enable
 buffering:
@@ -64,13 +64,13 @@ buffering:
   buffer again. The purpose of this setting is to avoid consecutive fail over
   events where vtgate may be buffering, but never purging the buffer.
 
-## Types of queries that can be buffered
+## Types of Queries That Can Be Buffered
 
  * Only requests to tablets of type `PRIMARY` are buffered. In-flight requests
  to a `REPLICA` in the process of transitioning to `PRIMARY` because of a PRS
  should be unaffected, and do not require buffering.
 
-## What happens during a PlannedReparentShard with Buffering
+## What Happens During a PlannedReparentShard with Buffering
 
 Fundamentally Vitess will:
 
@@ -82,7 +82,7 @@ Fundamentally Vitess will:
  * Drain the buffered queries to the new `PRIMARY` tablet.
  * Begin the countdown timer for `buffer_max_failover_duration`.
 
-## What happens during a MoveTables or Reshard SwitchTraffic or ReverseTraffic with Buffering
+## What Happens During a MoveTables or Reshard SwitchTraffic or ReverseTraffic with Buffering
 
 Fundamentally Vitess will:
 
@@ -90,7 +90,7 @@ Fundamentally Vitess will:
  * Perform the traffic switching work so that application traffic against the tables (MoveTables) or shards (Reshard) are transparently switched to the new keyspace (MoveTables) or shards (Reshard).
  * Drain the buffered queries to the new keyspace or shards — or if the switch failed then back to the original keyspace or shards.
 
-## How does it work?
+## How Does it work?
 
 The following steps are considerably simplified, but to give a high level
 overview of how buffering works:
@@ -113,7 +113,7 @@ overview of how buffering works:
   do not buffer again if another fail over starts within that period.
 
 
-## What the application sees
+## What the Application Sees
 
 When buffering executes as expected the application will see a pause in their
 query processing. Each query will consume a slot from the configured
@@ -131,7 +131,7 @@ Buffering was implemented to minimize downtime, but there is still potential for
 errors to occur, and your application should be configured to handle them
 appropriately. Below are a few errors which may occur:
 
-### Lost connection
+### Lost Connection
 
 ```
 Error Number: 2013
@@ -143,7 +143,7 @@ delays in their query request. If your client has a `read_timeout` or
 `write_timeout` set, the value should be greater than the `buffer_window` value set
 in vtgate.
 
-### Primary not serving
+### Primary not Serving
 
 ```
 Error Number: 1105

--- a/content/en/docs/21.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/_index.md
@@ -3,6 +3,7 @@ title: mysqlctl
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl
 
 mysqlctl initializes and controls mysqld with Vitess-specific configuration.
@@ -95,7 +96,7 @@ This helps ensure that `mysqld` is automatically restarted after failures.
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl init](./mysqlctl_init/)	 - Initializes the directory structure and starts mysqld.
 * [mysqlctl init_config](./mysqlctl_init_config/)	 - Initializes the directory structure, creates my.cnf file, but does not start mysqld.

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -3,6 +3,7 @@ title: init
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl init
 
 Initializes the directory structure and starts mysqld.
@@ -34,7 +35,7 @@ mysqlctl \
       --wait_time duration        How long to wait for mysqld startup. (default 5m0s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -113,7 +114,7 @@ mysqlctl \
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -3,6 +3,7 @@ title: init config
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl init_config
 
 Initializes the directory structure, creates my.cnf file, but does not start mysqld.
@@ -32,7 +33,7 @@ mysqlctl \
   -h, --help   help for init_config
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -111,7 +112,7 @@ mysqlctl \
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -3,6 +3,7 @@ title: position
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl position
 
 Compute operations on replication positions
@@ -17,7 +18,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
   -h, --help   help for position
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -96,7 +97,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -3,6 +3,7 @@ title: reinit config
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl reinit_config
 
 Reinitializes my.cnf file with new server_id.
@@ -32,7 +33,7 @@ mysqlctl \
   -h, --help   help for reinit_config
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -111,7 +112,7 @@ mysqlctl \
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -3,6 +3,7 @@ title: shutdown
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl shutdown
 
 Shuts down mysqld, without removing any files.
@@ -30,7 +31,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --wait_time duration   How long to wait for mysqld shutdown. (default 5m0s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -109,7 +110,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -3,6 +3,7 @@ title: start
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl start
 
 Starts mysqld on an already 'init'-ed directory.
@@ -29,7 +30,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --wait_time duration    How long to wait for mysqld startup. (default 5m0s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -108,7 +109,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -3,6 +3,7 @@ title: teardown
 series: mysqlctl
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctl teardown
 
 Shuts mysqld down and removes the directory.
@@ -33,7 +34,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --wait_time duration   How long to wait for mysqld shutdown. (default 5m0s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -112,7 +113,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
 ```
 
-### SEE ALSO
+### See Also
 
 * [mysqlctl](../)	 - mysqlctl initializes and controls mysqld with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctld/_index.md
@@ -3,6 +3,7 @@ title: mysqlctld
 series: mysqlctld
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## mysqlctld
 
 mysqlctld is a daemon that starts or initializes mysqld.

--- a/content/en/docs/21.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/21.0/reference/programs/topo2topo/_index.md
@@ -3,6 +3,7 @@ title: topo2topo
 series: topo2topo
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## topo2topo
 
 topo2topo copies Vitess topology data from one topo server to another.

--- a/content/en/docs/21.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtaclcheck/_index.md
@@ -3,6 +3,7 @@ title: vtaclcheck
 series: vtaclcheck
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtaclcheck
 
 vtaclcheck checks that the access-control list (ACL) rules in a given file are valid.

--- a/content/en/docs/21.0/reference/programs/vtadmin.md
+++ b/content/en/docs/21.0/reference/programs/vtadmin.md
@@ -6,7 +6,7 @@ title: vtadmin
 
 These flags are provided to the `vtadmin` process. They are also referenced in [cmd/vtadmin/main.go](https://github.com/vitessio/vitess/blob/main/go/cmd/vtadmin/main.go).
 
-### Common flags
+### Common Flags
 
 | Name | Required | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |--------- |
@@ -16,7 +16,7 @@ These flags are provided to the `vtadmin` process. They are also referenced in [
 
 [duration]: https://pkg.go.dev/time#ParseDuration
 
-### Cluster config flags
+### Cluster Config Flags
 
 One of `cluster`, `cluster-defaults`, or `cluster-config` file is required. Multiple configurations are permitted; precedence is noted below.
 
@@ -27,7 +27,7 @@ One of `cluster`, `cluster-defaults`, or `cluster-config` file is required. Mult
 | `cluster-defaults` | Default options for all clusters. |
 | `enable-dynamic-clusters` | Defaults to `false`. Whether to enable dynamic clusters that are set by request header cookies or gRPC metadata. | 
 
-### Tracing flags
+### Tracing Flags
 
 | Name | Required | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |--------- |
@@ -37,14 +37,15 @@ One of `cluster`, `cluster-defaults`, or `cluster-config` file is required. Mult
 | `tracing-enable-logging` | Optional | boolean | `false` | Whether to enable logging in the tracing service; see [go/trace/trace.go](https://github.com/vitessio/vitess/blob/main/go/trace/trace.go).  |
 | `tracing-sampling-type` | Optional | string | - | Sampling strategy to use for jaeger. Possible values are "const", "probabilistic", "rateLimiting", or "remote"; see [go/trace/plugin_jaeger.go](https://github.com/vitessio/vitess/blob/main/go/trace/plugin_jaeger.go). |
 | `tracing-sampling-rate` | Optional | float | 0.1 | Sampling rate for the probabilistic jaeger sampler; see [go/trace/plugin_jaeger.go](https://github.com/vitessio/vitess/blob/main/go/trace/plugin_jaeger.go). |
-### gRPC server flags
+
+### gRPC Server Flags
 
 | Name | Required | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |--------- |
 | `grpc-allow-reflection` | Optional | boolean | `false` | Whether to register the gRPC server for reflection; this is required to use tools like `grpc_cli`.
 | `grpc-enable-channelz` | Optional | boolean | `false` | Whether to enable the [channelz](https://grpc.io/blog/a-short-introduction-to-channelz/) service on the gRPC server. |
 
-### HTTP server flags
+### HTTP Server Flags
 
 | Name | Required | Type | Default | Definition |
 | -------- | --------- | --------- | --------- |--------- |
@@ -57,7 +58,7 @@ One of `cluster`, `cluster-defaults`, or `cluster-config` file is required. Mult
 | `http-no-debug` | Optional | boolean | `false` | Whether to disable `/debug/pprof/*` and `/debug/env` HTTP endpoints | 
 
 
-### RBAC flags
+### RBAC Flags
 
 If using RBAC, both the `--rbac` and `--rbac-config` flags must be set. If not using RBAC, the `--no-rbac` must be set.
 
@@ -67,7 +68,7 @@ If using RBAC, both the `--rbac` and `--rbac-config` flags must be set. If not u
 | `rbac` | Optional | boolean | `false` | Whether to enable RBAC. |
 | `rbac-config` | Optional | string | - | Path to an RBAC config file. Must be set if passing `--rbac`. |
 
-### glog flags
+### glog Flags
 
 See https://pkg.go.dev/github.com/golang/glog.
 

--- a/content/en/docs/21.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtbackup/_index.md
@@ -3,6 +3,7 @@ title: vtbackup
 series: vtbackup
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtbackup
 
 vtbackup is a batch command to perform a single pass of backup maintenance for a shard.

--- a/content/en/docs/21.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtclient/_index.md
@@ -3,6 +3,7 @@ title: vtclient
 series: vtclient
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtclient
 
 vtclient connects to a vtgate server using the standard go driver API.

--- a/content/en/docs/21.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtcombo/_index.md
@@ -3,6 +3,7 @@ title: vtcombo
 series: vtcombo
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtcombo
 
 vtcombo is a single binary containing several vitess components.

--- a/content/en/docs/21.0/reference/programs/vtctl/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/_index.md
@@ -163,7 +163,6 @@ Note that wherever `vtctl` commands produced master or MASTER for tablet type, t
 
 The following global options apply to `vtctl`:
 
-
 | Name | Type | Definition |
 | :------------------------------------ | :--------- | :----------------------------------------------------------------------------------------- |
 | --alsologtostderr | | log to standard error as well as files |

--- a/content/en/docs/21.0/reference/programs/vtctl/cell-aliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/cell-aliases.md
@@ -46,7 +46,6 @@ Updates the content of a CellAlias with the provided parameters. Empty values an
 | :-------- | :--------- | :--------- |
 | cells | string |The list of cell names that are members of this alias. |
 
-
 #### Arguments
 
 * <code>&lt;alias&gt;</code> &ndash; Required. Alias name group to update.

--- a/content/en/docs/21.0/reference/programs/vtctl/cells.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/cells.md
@@ -23,7 +23,6 @@ Registers a local topology service in a new cell by creating the CellInfo with t
 | root | string | The root path the topology service is using for that cell. |
 | server_address | string | The address the topology service is using for that cell. |
 
-
 #### Arguments
 
 * <code>&lt;addr&gt;</code> &ndash; Required.

--- a/content/en/docs/21.0/reference/programs/vtctl/generic.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/generic.md
@@ -22,7 +22,6 @@ Validates that all nodes reachable from the global replication graph and that al
 | :-------- | :--------- | :--------- |
 | ping-tablets | Boolean | Indicates whether all tablets should be pinged during the validation process |
 
-
 ### ListAllTablets
 
 Lists all tablets in an awk-friendly way.

--- a/content/en/docs/21.0/reference/programs/vtctl/keyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/keyspaces.md
@@ -382,7 +382,6 @@ VDiff -- [--source_cell=&lt;cell&gt;] [--target_cell=&lt;cell&gt;] [--tablet_typ
 | wait | Boolean | When creating or resuming a vdiff, wait for it to finish before exiting |
 | wait-update-interval | Duration |When waiting on a vdiff to finish, check and display the current status this often (default 1m0s) |
 
-
 ## See Also
 
 * [vtctl command index](../../vtctl)

--- a/content/en/docs/21.0/reference/programs/vtctl/schema-version-permissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/schema-version-permissions.md
@@ -25,7 +25,6 @@ Displays the full schema for a tablet, or just the schema for the specified tabl
 | table_names_only | Boolean | Only displays table names that match |
 | tables | string | Specifies a comma-separated list of tables for which we should gather information. Each is either an exact match, or a regular expression of the form /regexp/ |
 
-
 #### Arguments
 
 * <code>&lt;tablet alias&gt;</code> &ndash; Required. A Tablet Alias uniquely identifies a vttablet. The argument value is in the format <code>&lt;cell name&gt;-&lt;uid&gt;</code>.
@@ -138,7 +137,6 @@ Validates that the schema on the primary tablet for shard 0 matches the schema o
 | exclude_tables | string | Specifies a comma-separated list of tables to exclude. Each is either an exact match, or a regular expression of the form /regexp/ |
 | include-views | Boolean | Includes views in the validation |
 
-
 #### Arguments
 
 * <code>&lt;keyspace name&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables. Vitess distributes keyspace shards into multiple machines and provides an SQL interface to query the data. The argument value must be a string that does not contain whitespace.
@@ -191,7 +189,6 @@ Copies the schema from a source shard's primary (or a specific tablet) to a dest
 | include-views | Boolean | Includes views in the output |
 | tables | string | Specifies a comma-separated list of tables to copy. Each is either an exact match, or a regular expression of the form /regexp/ |
 | wait_replicas_timeout | Duration | The amount of time to wait for replicas to receive the schema change via replication. |
-
 
 #### Arguments
 
@@ -359,7 +356,6 @@ ApplyRoutingRules -- {--rules=<rules> | --rules_file=<rules_file>} [--cells=c1,c
 | rules | string | Specify rules as a string. |
 | rules_file | string | Specify rules in a file. |
 
-
 ### RebuildVSchemaGraph
 
 Rebuilds the cell-specific SrvVSchema from the global VSchema objects in the provided cells (or all cells if none provided).
@@ -373,7 +369,6 @@ Rebuilds the cell-specific SrvVSchema from the global VSchema objects in the pro
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
 | cells | string | Specifies a comma-separated list of cells to look for tablets |
-
 
 #### Errors
 

--- a/content/en/docs/21.0/reference/programs/vtctl/serving-graph.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/serving-graph.md
@@ -64,7 +64,6 @@ Outputs a JSON structure that contains information about the SrvVSchema.
 DeleteSrvVSchema  <cell>
 ```
 
-
 ## See Also
 
 * [vtctl command index](../../vtctl)

--- a/content/en/docs/21.0/reference/programs/vtctl/shards.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/shards.md
@@ -24,7 +24,6 @@ Creates the specified shard.
 | force | Boolean | Proceeds with the command even if the keyspace already exists |
 | parent | Boolean | Creates the parent keyspace if it doesn't already exist |
 
-
 #### Arguments
 
 * <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitespace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
@@ -63,7 +62,6 @@ Validates that all nodes that are reachable from this shard are consistent.
 | :-------- | :--------- | :--------- |
 | ping-tablets | Boolean | Indicates whether all tablets should be pinged during the validation process |
 
-
 #### Arguments
 
 * <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitespace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
@@ -87,7 +85,6 @@ Shows the replication status of each replica machine in the shard graph. In this
 #### Errors
 
 * the <code>&lt;keyspace/shard&gt;</code> argument is required for the <code>&lt;ShardReplicationPositions&gt;</code> command This error occurs if the command is not called with exactly one argument.
-
 
 ### ListShardTablets
 
@@ -158,7 +155,6 @@ RefreshStateByShard &lt;keyspace/shard&gt;</pre>
 | disable_query_service | Boolean | Disables query service on the provided nodes. This flag requires 'denied_tables' and 'remove' to be unset, otherwise it's ignored.                                      |
 | remove | Boolean | Removes cells for MoveTables.                                                                                                                                           |
 
-
 #### Arguments
 
 * <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitespace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
@@ -173,7 +169,6 @@ RefreshStateByShard &lt;keyspace/shard&gt;</pre>
   * <code>replica</code> &ndash; A replicated copy of data ready to be promoted to primary
   * <code>restore</code> &ndash; A tablet that is restoring from a snapshot. Typically, this happens at tablet startup, then it goes to its right state.
   * <code>spare</code> &ndash; A replicated copy of data that is ready but not serving query traffic. The data could be a potential primary tablet.
-
 
 #### Errors
 
@@ -276,7 +271,6 @@ Removes the cell from the shard's Cells list.
 | force | Boolean | Proceeds even if the cell's topology service cannot be reached. The assumption is that you turned down the entire cell, and just need to update the global topo data. |
 | recursive | Boolean | Also delete all tablets in that cell belonging to the specified shard. |
 
-
 #### Arguments
 
 * <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitespace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
@@ -300,7 +294,6 @@ Deletes the specified shard(s). In recursive mode, it also deletes all tablets b
 | :-------- | :--------- | :--------- |
 | even_if_serving | Boolean | Remove the shard even if it is serving. Use with caution. |
 | recursive | Boolean | Also delete all tablets belonging to the shard. |
-
 
 #### Arguments
 
@@ -361,7 +354,6 @@ Sets the initial primary for a shard. Will make all other tablets in the shard r
 | force | Boolean | will force the reparent even if the provided tablet is not writable or the shard primary |
 | wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
-
 #### Arguments
 
 * <code>&lt;keyspace/shard&gt;</code> &ndash; Required. The name of a sharded database that contains one or more tables as well as the shard associated with the command. The keyspace must be identified by a string that does not contain whitespace, while the shard is typically identified by a string in the format <code>&lt;range start&gt;-&lt;range end&gt;</code>.
@@ -401,7 +393,6 @@ failover time.
 | new_primary | string | alias of a tablet that should be the new primary |
 | wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
-
 #### Errors
 
 * action <code>&lt;PlannedReparentShard&gt;</code> requires --keyspace_shard=<code>&lt;keyspace/shard&gt;</code> [--new_primary=<code>&lt;tablet alias&gt;</code>] [--avoid_tablet=<code>&lt;tablet alias&gt;</code>] This error occurs if the command is not called with exactly 0 arguments.
@@ -424,13 +415,11 @@ Reparents the shard to the new primary. Assumes the old primary is dead and not 
 | new_primary | string | alias of a tablet that should be the new primary |
 | wait_replicas_timeout | Duration | time to wait for replicas to catch up in reparenting |
 
-
 #### Errors
 
 * action <code>&lt;EmergencyReparentShard&gt;</code> requires --keyspace_shard=<code>&lt;keyspace/shard&gt;</code> --new_primary=<code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly 0 arguments.
 * active reparent commands disabled (unset the --disable_active_reparents flag to enable)
 * cannot use legacy syntax and flag --<code>&lt;new_primary&gt;</code> for action <code>&lt;EmergencyReparentShard&gt;</code> at the same time
-
 
 ### TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctl/tablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/tablets.md
@@ -33,7 +33,6 @@ Deprecated. It is no longer necessary to run this command to initialize a tablet
 | shard | string | The shard to which this tablet belongs |
 | tags | string | A comma-separated list of key:value pairs that are used to tag the tablet |
 
-
 #### Arguments
 
 * <code>&lt;tablet alias&gt;</code> &ndash; Required. A Tablet Alias uniquely identifies a vttablet. The argument value is in the format <code>&lt;cell name&gt;-&lt;uid&gt;</code>.
@@ -49,11 +48,9 @@ Deprecated. It is no longer necessary to run this command to initialize a tablet
   * <code>restore</code> &ndash; A tablet that is restoring from a snapshot. Typically, this happens at tablet startup, then it goes to its right state.
   * <code>spare</code> &ndash; A replicated copy of data that is ready but not serving query traffic. The data could be a potential primary tablet.
 
-
 #### Errors
 
 * the <code>&lt;tablet alias&gt;</code> and <code>&lt;tablet type&gt;</code> arguments are both required for the <code>&lt;InitTablet&gt;</code> command This error occurs if the command is not called with exactly 2 arguments.
-
 
 ### GetTablet
 
@@ -70,7 +67,6 @@ Outputs a JSON structure that contains information about the Tablet.
 #### Errors
 
 * the <code>&lt;tablet alias&gt;</code> argument is required for the <code>&lt;GetTablet&gt;</code> command This error occurs if the command is not called with exactly one argument.
-
 
 ### IgnoreHealthError
 
@@ -94,7 +90,6 @@ Deprecated. Updates the IP address and port numbers of a tablet.
 | mysql_host | string | The mysql host for the mysql server |
 | vt-port | Int | The main port for the vttablet process |
 
-
 #### Arguments
 
 * <code>&lt;tablet alias&gt;</code> &ndash; Required. A Tablet Alias uniquely identifies a vttablet. The argument value is in the format <code>&lt;cell name&gt;-&lt;uid&gt;</code>.
@@ -116,7 +111,6 @@ Deletes tablet(s) from the topology.
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
 | allow_primary | Boolean | Allows for the primary tablet of a shard to be deleted. Use with caution. |
-
 
 #### Arguments
 
@@ -207,7 +201,6 @@ Changes the db type for the specified tablet, if possible. This command is used 
 | Name | Type | Definition |
 | :-------- | :--------- | :--------- |
 | dry-run | Boolean | Lists the proposed change without actually executing it |
-
 
 #### Arguments
 
@@ -430,7 +423,6 @@ Reparent a tablet to the current primary in the shard. This only works if the cu
 
 * action <code>&lt;ReparentTablet&gt;</code> requires <code>&lt;tablet alias&gt;</code> This error occurs if the command is not called with exactly one argument.
 * active reparent commands disabled (unset the -disable_active_reparents flag to enable)
-
 
 ## See Also
 

--- a/content/en/docs/21.0/reference/programs/vtctl/throttler.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/throttler.md
@@ -26,7 +26,6 @@ Update tablet throttler configuration for all tablets of a given keyspace.
 
 ```UpdateThrottlerConfig -- --unthrottle-app="vreplication" commerce```
 
-
 #### Flags
 
 | Name | Type | Definition |
@@ -37,7 +36,6 @@ Update tablet throttler configuration for all tablets of a given keyspace.
 | `custom-query` | String | override the default replication lag measurement, and suggest a different query. Valid values are:<br />  - _empty_, meaning the throttler should use the default replication lag query<br />  - A `SELECT` that returns a single line, single column, floating point value<br />  - A `SHOW GLOBAL STATUS|VARIABLES LIKE '...'`, for example `show global status like 'threads_running'` |
 | `check-as-check-shard` | Boolean | this is the default behavior. A `/throttler/check` request checks the shard health. When using the default replication lag query, this is the desired check: the primary tablet's throttler responds by evaluating the overall lag throughout the shard/replicas |
 | `check-as-check-self` | Boolean | override default behavior, and this can be useful when a `--custom-query` is set. A `/throttler/check` request will only consider the tablet's own metrics, and not the overall shard metrics |
-
 
 #### Arguments
 

--- a/content/en/docs/21.0/reference/programs/vtctl/topo.md
+++ b/content/en/docs/21.0/reference/programs/vtctl/topo.md
@@ -25,7 +25,6 @@ Retrieves the file(s) at &lt;path&gt; from the topo service, and displays it. It
 | decode_proto_json | Boolean | decode proto files and display them as json. Defaults to false. |
 | long | Boolean | long listing. Defaults to false.                                |
 
-
 #### Arguments
 
 * <code>&lt;cell&gt;</code> &ndash; Required. A cell is a location for a service. Generally, a cell resides in only one cluster. In Vitess, the terms "cell" and "data center" are interchangeable. The argument value is a string that does not contain whitespace.
@@ -62,7 +61,6 @@ Copy data at given path from topo service to local file or vice versa.
 #### Errors
 
 * <code>&lt;TopoCp&gt;</code>: need source and destination. This error occurs if the command is not called with proper `src` and `dst`.
-
 
 ## See Also
 

--- a/content/en/docs/21.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctld/_index.md
@@ -3,6 +3,7 @@ title: vtctld
 series: vtctld
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtctld
 
 The Vitess cluster management daemon.
@@ -197,4 +198,3 @@ vtctld \
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
       --vtctld_sanitize_log_messages                                     When true, vtctld sanitizes logging.
 ```
-

--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -3,6 +3,7 @@ title: vtctldclient
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient
 
 Executes a cluster management command on the remote vtctld server.
@@ -31,7 +32,7 @@ vtctldclient [flags]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient AddCellInfo](./vtctldclient_addcellinfo/)	 - Registers a local topology service in a new cell by creating the CellInfo.
 * [vtctldclient AddCellsAlias](./vtctldclient_addcellsalias/)	 - Defines a group of cells that can be referenced by a single name (the alias).

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -3,6 +3,7 @@ title: AddCellInfo
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient AddCellInfo
 
 Registers a local topology service in a new cell by creating the CellInfo.
@@ -27,7 +28,7 @@ vtctldclient AddCellInfo --root <root> [--server-address <addr>] <cell>
   -a, --server-address string   The address the topology server will connect to for this cell.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient AddCellInfo --root <root> [--server-address <addr>] <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -3,6 +3,7 @@ title: AddCellsAlias
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient AddCellsAlias
 
 Defines a group of cells that can be referenced by a single name (the alias).
@@ -26,7 +27,7 @@ vtctldclient AddCellsAlias --cells <cell1,cell2,...> [--cells <cell3> ...] <alia
   -h, --help            help for AddCellsAlias
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient AddCellsAlias --cells <cell1,cell2,...> [--cells <cell3> ...] <alia
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -3,6 +3,7 @@ title: ApplyKeyspaceRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ApplyKeyspaceRoutingRules
 
 Applies the provided keyspace routing rules.
@@ -22,7 +23,7 @@ vtctldclient ApplyKeyspaceRoutingRules {--rules RULES | --rules-file RULES_FILE}
       --skip-rebuild        Skip rebuilding the SrvVSchema objects.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient ApplyKeyspaceRoutingRules {--rules RULES | --rules-file RULES_FILE}
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -3,6 +3,7 @@ title: ApplyRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ApplyRoutingRules
 
 Applies the VSchema routing rules.
@@ -22,7 +23,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
       --skip-rebuild        Skip rebuilding the SrvVSchema objects.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient ApplyRoutingRules {--rules RULES | --rules-file RULES_FILE} [--cell
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -3,6 +3,7 @@ title: ApplySchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ApplySchema
 
 Applies the schema change to the specified keyspace on every primary, running in parallel on all shards. The changes are then propagated to replicas via replication.
@@ -41,7 +42,7 @@ vtctldclient ApplySchema [--ddl-strategy <strategy>] [--uuid <uuid> ...] [--migr
       --wait-replicas-timeout duration   Amount of time to wait for replicas to receive the schema change via replication. (default 10s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -52,7 +53,7 @@ vtctldclient ApplySchema [--ddl-strategy <strategy>] [--uuid <uuid> ...] [--migr
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -3,6 +3,7 @@ title: ApplyShardRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ApplyShardRoutingRules
 
 Applies the provided shard routing rules.
@@ -22,7 +23,7 @@ vtctldclient ApplyShardRoutingRules {--rules RULES | --rules-file RULES_FILE} [-
       --skip-rebuild        Skip rebuilding the SrvVSchema objects.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient ApplyShardRoutingRules {--rules RULES | --rules-file RULES_FILE} [-
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -3,6 +3,7 @@ title: ApplyVSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ApplyVSchema
 
 Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
@@ -25,7 +26,7 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
       --vschema-file string                     Path to a file containing the vschema to apply, in JSON form.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient ApplyVSchema {--vschema=<vschema> || --vschema-file=<vschema file> 
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -3,6 +3,7 @@ title: Backup
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Backup
 
 Uses the BackupStorage service on the given tablet to create and store a new backup.
@@ -21,7 +22,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -3,6 +3,7 @@ title: BackupShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient BackupShard
 
 Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard and uses the BackupStorage service on that tablet to create and store a new backup.
@@ -27,7 +28,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
       --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -3,6 +3,7 @@ title: ChangeTabletType
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ChangeTabletType
 
 Changes the db type for the specified tablet, if possible.
@@ -25,7 +26,7 @@ vtctldclient ChangeTabletType [--dry-run] <alias> <tablet-type>
   -h, --help      help for ChangeTabletType
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient ChangeTabletType [--dry-run] <alias> <tablet-type>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -3,6 +3,7 @@ title: CheckThrottler
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient CheckThrottler
 
 Issue a throttler check on the given tablet.
@@ -27,7 +28,7 @@ CheckThrottler --app-name online-ddl zone1-0000000101
       --scope string         check scope ('shard', 'self' or leave empty for per-metric defaults)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ CheckThrottler --app-name online-ddl zone1-0000000101
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -3,6 +3,7 @@ title: CreateKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient CreateKeyspace
 
 Creates the specified keyspace in the topology.
@@ -31,7 +32,7 @@ vtctldclient CreateKeyspace <keyspace> [--force|-f] [--type KEYSPACE_TYPE] [--ba
       --type cli.KeyspaceTypeFlag   The type of the keyspace. (default NORMAL)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -42,7 +43,7 @@ vtctldclient CreateKeyspace <keyspace> [--force|-f] [--type KEYSPACE_TYPE] [--ba
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -3,6 +3,7 @@ title: CreateShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient CreateShard
 
 Creates the specified shard in the topology.
@@ -19,7 +20,7 @@ vtctldclient CreateShard [--force|-f] [--include-parent|-p] <keyspace/shard>
   -p, --include-parent   Creates the parent keyspace record if does not already exist.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient CreateShard [--force|-f] [--include-parent|-p] <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -3,6 +3,7 @@ title: DeleteCellInfo
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteCellInfo
 
 Deletes the CellInfo for the provided cell.
@@ -22,7 +23,7 @@ vtctldclient DeleteCellInfo [--force] <cell>
   -h, --help    help for DeleteCellInfo
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient DeleteCellInfo [--force] <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -3,6 +3,7 @@ title: DeleteCellsAlias
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteCellsAlias
 
 Deletes the CellsAlias for the provided alias.
@@ -21,7 +22,7 @@ vtctldclient DeleteCellsAlias <alias>
   -h, --help   help for DeleteCellsAlias
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient DeleteCellsAlias <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -3,6 +3,7 @@ title: DeleteKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteKeyspace
 
 Deletes the specified keyspace from the topology.
@@ -26,7 +27,7 @@ vtctldclient DeleteKeyspace [--recursive|-r] [--force|-f] <keyspace>
   -r, --recursive   Recursively delete all shards in the keyspace, and all tablets in those shards.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient DeleteKeyspace [--recursive|-r] [--force|-f] <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -3,6 +3,7 @@ title: DeleteShards
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteShards
 
 Deletes the specified shards from the topology.
@@ -28,7 +29,7 @@ vtctldclient DeleteShards [--recursive|-r] [--even-if-serving] [--force|-f] <key
   -r, --recursive         Also delete all tablets belonging to the shard. This is required to delete a non-empty shard.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -39,7 +40,7 @@ vtctldclient DeleteShards [--recursive|-r] [--even-if-serving] [--force|-f] <key
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -3,6 +3,7 @@ title: DeleteSrvVSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteSrvVSchema
 
 Deletes the SrvVSchema object in the given cell.
@@ -17,7 +18,7 @@ vtctldclient DeleteSrvVSchema <cell>
   -h, --help   help for DeleteSrvVSchema
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient DeleteSrvVSchema <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -3,6 +3,7 @@ title: DeleteTablets
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient DeleteTablets
 
 Deletes tablet(s) from the topology.
@@ -18,7 +19,7 @@ vtctldclient DeleteTablets <alias> [ <alias> ... ]
   -h, --help            help for DeleteTablets
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient DeleteTablets <alias> [ <alias> ... ]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -3,6 +3,7 @@ title: EmergencyReparentShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient EmergencyReparentShard
 
 Reparents the shard to the new primary. Assumes the old primary is dead and not responding.
@@ -22,7 +23,7 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
       --wait-replicas-timeout duration   Time to wait for replicas to catch up in reparenting. (default 15s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -3,6 +3,7 @@ title: ExecuteFetchAsApp
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ExecuteFetchAsApp
 
 Executes the given query as the App user on the remote tablet.
@@ -20,7 +21,7 @@ vtctldclient ExecuteFetchAsApp [--max-rows <max-rows>] [--json|-j] [--use-pool] 
       --use-pool       Use the tablet connection pool instead of creating a fresh connection.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -31,7 +32,7 @@ vtctldclient ExecuteFetchAsApp [--max-rows <max-rows>] [--json|-j] [--use-pool] 
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -3,6 +3,7 @@ title: ExecuteFetchAsDBA
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ExecuteFetchAsDBA
 
 Executes the given query as the DBA user on the remote tablet.
@@ -21,7 +22,7 @@ vtctldclient ExecuteFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disable-bi
       --reload-schema     Instructs the tablet to reload its schema after executing the query.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient ExecuteFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disable-bi
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -3,6 +3,7 @@ title: ExecuteHook
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ExecuteHook
 
 Runs the specified hook on the given tablet.
@@ -31,7 +32,7 @@ vtctldclient ExecuteHook <alias> <hook_name> [<param1=value1> ...]
   -h, --help   help for ExecuteHook
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -42,7 +43,7 @@ vtctldclient ExecuteHook <alias> <hook_name> [<param1=value1> ...]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -3,6 +3,7 @@ title: ExecuteMultiFetchAsDBA
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ExecuteMultiFetchAsDBA
 
 Executes given multiple queries as the DBA user on the remote tablet.
@@ -21,7 +22,7 @@ vtctldclient ExecuteMultiFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disab
       --reload-schema     Instructs the tablet to reload its schema after executing the query.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient ExecuteMultiFetchAsDBA [--max-rows <max-rows>] [--json|-j] [--disab
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -3,6 +3,7 @@ title: FindAllShardsInKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient FindAllShardsInKeyspace
 
 Returns a map of shard names to shard references for a given keyspace.
@@ -17,7 +18,7 @@ vtctldclient FindAllShardsInKeyspace <keyspace>
   -h, --help   help for FindAllShardsInKeyspace
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient FindAllShardsInKeyspace <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -3,6 +3,7 @@ title: GenerateShardRanges
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GenerateShardRanges
 
 Print a set of shard ranges assuming a keyspace with N shards.
@@ -17,7 +18,7 @@ vtctldclient GenerateShardRanges <num_shards>
   -h, --help   help for GenerateShardRanges
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GenerateShardRanges <num_shards>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -3,6 +3,7 @@ title: GetBackups
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetBackups
 
 Lists backups for the given shard.
@@ -19,7 +20,7 @@ vtctldclient GetBackups [--limit <limit>] [--json] <keyspace/shard>
   -l, --limit uint32   Retrieve only the most recent N backups.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient GetBackups [--limit <limit>] [--json] <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -3,6 +3,7 @@ title: GetCellInfo
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetCellInfo
 
 Gets the CellInfo object for the given cell.
@@ -17,7 +18,7 @@ vtctldclient GetCellInfo <cell>
   -h, --help   help for GetCellInfo
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetCellInfo <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -3,6 +3,7 @@ title: GetCellInfoNames
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetCellInfoNames
 
 Lists the names of all cells in the cluster.
@@ -17,7 +18,7 @@ vtctldclient GetCellInfoNames
   -h, --help   help for GetCellInfoNames
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetCellInfoNames
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -3,6 +3,7 @@ title: GetCellsAliases
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetCellsAliases
 
 Gets all CellsAlias objects in the cluster.
@@ -17,7 +18,7 @@ vtctldclient GetCellsAliases
   -h, --help   help for GetCellsAliases
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetCellsAliases
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -3,6 +3,7 @@ title: GetFullStatus
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetFullStatus
 
 Outputs a JSON structure that contains full status of MySQL including the replication information, semi-sync information, GTID information among others.
@@ -17,7 +18,7 @@ vtctldclient GetFullStatus <alias>
   -h, --help   help for GetFullStatus
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetFullStatus <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -3,6 +3,7 @@ title: GetKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetKeyspace
 
 Returns information about the given keyspace from the topology.
@@ -17,7 +18,7 @@ vtctldclient GetKeyspace <keyspace>
   -h, --help   help for GetKeyspace
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetKeyspace <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -3,6 +3,7 @@ title: GetKeyspaceRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetKeyspaceRoutingRules
 
 Displays the currently active keyspace routing rules.
@@ -17,7 +18,7 @@ vtctldclient GetKeyspaceRoutingRules
   -h, --help   help for GetKeyspaceRoutingRules
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetKeyspaceRoutingRules
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -3,6 +3,7 @@ title: GetKeyspaces
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetKeyspaces
 
 Returns information about every keyspace in the topology.
@@ -17,7 +18,7 @@ vtctldclient GetKeyspaces
   -h, --help   help for GetKeyspaces
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetKeyspaces
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -3,6 +3,7 @@ title: GetMirrorRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetMirrorRules
 
 Displays the VSchema mirror rules.
@@ -17,7 +18,7 @@ vtctldclient GetMirrorRules
   -h, --help   help for GetMirrorRules
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetMirrorRules
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -3,6 +3,7 @@ title: GetPermissions
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetPermissions
 
 Displays the permissions for a tablet.
@@ -17,7 +18,7 @@ vtctldclient GetPermissions <tablet_alias>
   -h, --help   help for GetPermissions
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetPermissions <tablet_alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -3,6 +3,7 @@ title: GetRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetRoutingRules
 
 Displays the VSchema routing rules.
@@ -17,7 +18,7 @@ vtctldclient GetRoutingRules
   -h, --help   help for GetRoutingRules
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetRoutingRules
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -3,6 +3,7 @@ title: GetSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetSchema
 
 Displays the full schema for a tablet, optionally restricted to the specified tables/views.
@@ -23,7 +24,7 @@ vtctldclient GetSchema [--tables TABLES ...] [--exclude-tables EXCLUDE_TABLES ..
       --tables /regexp/           List of tables to display the schema for. Each is either an exact match, or a regular expression of the form /regexp/.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ vtctldclient GetSchema [--tables TABLES ...] [--exclude-tables EXCLUDE_TABLES ..
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -3,6 +3,7 @@ title: GetShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetShard
 
 Returns information about a shard in the topology.
@@ -17,7 +18,7 @@ vtctldclient GetShard <keyspace/shard>
   -h, --help   help for GetShard
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetShard <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -3,6 +3,7 @@ title: GetShardReplication
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetShardReplication
 
 Returns information about the replication relationships for a shard in the given cell(s).
@@ -17,7 +18,7 @@ vtctldclient GetShardReplication <keyspace/shard> [cell1 [cell2...]]
   -h, --help   help for GetShardReplication
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetShardReplication <keyspace/shard> [cell1 [cell2...]]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -3,6 +3,7 @@ title: GetShardRoutingRules
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetShardRoutingRules
 
 Displays the currently active shard routing rules as a JSON document.
@@ -25,7 +26,7 @@ vtctldclient GetShardRoutingRules
   -h, --help   help for GetShardRoutingRules
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient GetShardRoutingRules
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -3,6 +3,7 @@ title: GetSrvKeyspaceNames
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetSrvKeyspaceNames
 
 Outputs a JSON mapping of cell=>keyspace names served in that cell. Omit to query all cells.
@@ -17,7 +18,7 @@ vtctldclient GetSrvKeyspaceNames [<cell> ...]
   -h, --help   help for GetSrvKeyspaceNames
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetSrvKeyspaceNames [<cell> ...]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -3,6 +3,7 @@ title: GetSrvKeyspaces
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetSrvKeyspaces
 
 Returns the SrvKeyspaces for the given keyspace in one or more cells.
@@ -17,7 +18,7 @@ vtctldclient GetSrvKeyspaces <keyspace> [<cell> ...]
   -h, --help   help for GetSrvKeyspaces
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetSrvKeyspaces <keyspace> [<cell> ...]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -3,6 +3,7 @@ title: GetSrvVSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetSrvVSchema
 
 Returns the SrvVSchema for the given cell.
@@ -17,7 +18,7 @@ vtctldclient GetSrvVSchema cell
   -h, --help   help for GetSrvVSchema
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetSrvVSchema cell
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -3,6 +3,7 @@ title: GetSrvVSchemas
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetSrvVSchemas
 
 Returns the SrvVSchema for all cells, optionally filtered by the given cells.
@@ -17,7 +18,7 @@ vtctldclient GetSrvVSchemas [<cell> ...]
   -h, --help   help for GetSrvVSchemas
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetSrvVSchemas [<cell> ...]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -3,6 +3,7 @@ title: GetTablet
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetTablet
 
 Outputs a JSON structure that contains information about the tablet.
@@ -17,7 +18,7 @@ vtctldclient GetTablet <alias>
   -h, --help   help for GetTablet
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetTablet <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -3,6 +3,7 @@ title: GetTabletVersion
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetTabletVersion
 
 Print the version of a tablet from its debug vars.
@@ -17,7 +18,7 @@ vtctldclient GetTabletVersion <alias>
   -h, --help   help for GetTabletVersion
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetTabletVersion <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -3,6 +3,7 @@ title: GetTablets
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetTablets
 
 Looks up tablets according to filter criteria.
@@ -45,7 +46,7 @@ vtctldclient GetTablets [--strict] [{--cell $c1 [--cell $c2 ...] [--tablet-type 
       --tablet-type topodatapb.TabletType   Tablet type to filter by (e.g. primary or replica). (default UNKNOWN)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -56,7 +57,7 @@ vtctldclient GetTablets [--strict] [{--cell $c1 [--cell $c2 ...] [--tablet-type 
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -3,6 +3,7 @@ title: GetThrottlerStatus
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetThrottlerStatus
 
 Get the throttler status for the given tablet.
@@ -23,7 +24,7 @@ GetThrottlerStatus zone1-0000000101
   -h, --help   help for GetThrottlerStatus
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ GetThrottlerStatus zone1-0000000101
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -3,6 +3,7 @@ title: GetTopologyPath
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetTopologyPath
 
 Gets the value associated with the particular path (key) in the topology server.
@@ -19,7 +20,7 @@ vtctldclient GetTopologyPath <path>
       --version int    The version of the path's key to get. If not specified, the latest version is returned.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient GetTopologyPath <path>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -3,6 +3,7 @@ title: GetVSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetVSchema
 
 Prints a JSON representation of a keyspace's topo record.
@@ -17,7 +18,7 @@ vtctldclient GetVSchema <keyspace>
   -h, --help   help for GetVSchema
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient GetVSchema <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -3,6 +3,7 @@ title: GetWorkflows
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient GetWorkflows
 
 Gets all vreplication workflows (Reshard, MoveTables, etc) in the given keyspace.
@@ -19,7 +20,7 @@ vtctldclient GetWorkflows <keyspace>
   -a, --show-all       Show all workflows instead of just active workflows.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient GetWorkflows <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_InitShardPrimary.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_InitShardPrimary.md
@@ -28,14 +28,14 @@ vtctldclient InitShardPrimary <keyspace/shard> <primary alias>
       --wait-replicas-timeout duration   Time to wait for replicas to catch up in reparenting. (default 30s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration   timeout for the total command (default 1h0m0s)
       --server string             server to use for connection (required)
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -3,6 +3,7 @@ title: LegacyVtctlCommand
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LegacyVtctlCommand
 
 Invoke a legacy vtctlclient command. Flag parsing is best effort.
@@ -50,7 +51,7 @@ LegacyVtctlCommand -- AddCellInfo --server_address "localhost:5678" --root "/vit
   -h, --help   help for LegacyVtctlCommand
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -61,7 +62,7 @@ LegacyVtctlCommand -- AddCellInfo --server_address "localhost:5678" --root "/vit
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -3,6 +3,7 @@ title: LookupVindex
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LookupVindex
 
 Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
@@ -15,7 +16,7 @@ Perform commands related to creating, backfilling, and externalizing Lookup Vind
       --table-keyspace string   The keyspace to create the lookup table in. This is also where the VReplication workflow is created to backfill the Lookup Vindex.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -26,7 +27,7 @@ Perform commands related to creating, backfilling, and externalizing Lookup Vind
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient LookupVindex cancel](./vtctldclient_lookupvindex_cancel/)	 - Cancel the VReplication workflow that backfills the Lookup Vindex.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -3,6 +3,7 @@ title: LookupVindex cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LookupVindex cancel
 
 Cancel the VReplication workflow that backfills the Lookup Vindex.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
   -h, --help   help for cancel
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -3,6 +3,7 @@ title: LookupVindex create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LookupVindex create
 
 Create the Lookup Vindex in the specified keyspace and backfill it with a VReplication workflow.
@@ -34,7 +35,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --type string                        The type of Lookup Vindex to create.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -47,7 +48,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -3,6 +3,7 @@ title: LookupVindex externalize
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LookupVindex externalize
 
 Externalize the Lookup Vindex. If the Vindex has an owner the VReplication workflow will also be deleted.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --keyspace string   The keyspace containing the Lookup Vindex. If no value is specified then the table-keyspace will be used.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -3,6 +3,7 @@ title: LookupVindex show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient LookupVindex show
 
 Show the status of the VReplication workflow that backfills the Lookup Vindex.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
   -h, --help   help for show
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup_vdx --ta
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient LookupVindex](../)	 - Perform commands related to creating, backfilling, and externalizing Lookup Vindexes using VReplication workflows.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -3,6 +3,7 @@ title: Materialize
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize
 
 Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
@@ -16,7 +17,7 @@ Perform commands related to materializing query results from the source keyspace
   -w, --workflow string          The workflow you want to perform the command on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -27,7 +28,7 @@ Perform commands related to materializing query results from the source keyspace
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Materialize cancel](./vtctldclient_materialize_cancel/)	 - Cancel a Materialize VReplication workflow.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -3,6 +3,7 @@ title: Materialize cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize cancel
 
 Cancel a Materialize VReplication workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -h, --help   help for cancel
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -3,6 +3,7 @@ title: Materialize create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize create
 
 Create and run a Materialize VReplication workflow.
@@ -62,7 +63,7 @@ vtctldclient --server localhost:15999 materialize --workflow product_sales --tar
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -76,7 +77,7 @@ vtctldclient --server localhost:15999 materialize --workflow product_sales --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -3,6 +3,7 @@ title: Materialize show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize show
 
 Show the details for a Materialize VReplication workflow.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
       --include-logs   Include recent logs for the workflow. (default true)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -3,6 +3,7 @@ title: Materialize start
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize start
 
 Start a Materialize workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -h, --help   help for start
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -3,6 +3,7 @@ title: Materialize stop
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Materialize stop
 
 Stop a Materialize workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -h, --help   help for stop
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Materialize --workflow product_sales --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Materialize](../)	 - Perform commands related to materializing query results from the source keyspace into tables in the target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -3,6 +3,7 @@ title: Migrate
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Migrate
 
 Migrate is used to import data from an external cluster into the current cluster.
@@ -16,7 +17,7 @@ Migrate is used to import data from an external cluster into the current cluster
   -w, --workflow string          The workflow you want to perform the command on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -27,7 +28,7 @@ Migrate is used to import data from an external cluster into the current cluster
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Migrate cancel](./vtctldclient_migrate_cancel/)	 - Cancel a Migrate VReplication workflow.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -3,6 +3,7 @@ title: Migrate cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Migrate cancel
 
 Cancel a Migrate VReplication workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -h, --help   help for cancel
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -3,6 +3,8 @@ title: Migrate complete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
+
 ## vtctldclient Migrate complete
 
 Complete a Migrate VReplication workflow.
@@ -23,7 +25,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -h, --help   help for complete
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +39,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -3,6 +3,7 @@ title: Migrate create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Migrate create
 
 Create and optionally run a Migrate VReplication workflow.
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 migrate --workflow import --target-keyspac
       --tablet-types-in-preference-order   When performing source tablet selection, look for candidates in the type order as they are listed in the tablet-types flag. (default true)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -52,7 +53,7 @@ vtctldclient --server localhost:15999 migrate --workflow import --target-keyspac
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -3,6 +3,7 @@ title: Migrate show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Migrate show
 
 Show the details for a Migrate VReplication workflow.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
       --include-logs   Include recent logs for the workflow. (default true)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -3,6 +3,8 @@ title: Migrate status
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
+
 ## vtctldclient Migrate status
 
 Show the current status for a Migrate VReplication workflow.
@@ -23,7 +25,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -h, --help   help for status
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +39,7 @@ vtctldclient --server localhost:15999 Migrate --workflow import --target-keyspac
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Migrate](../)	 - Migrate is used to import data from an external cluster into the current cluster.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -3,6 +3,7 @@ title: Mount
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Mount
 
 Mount is used to link an external Vitess cluster in order to migrate data from it.
@@ -13,7 +14,7 @@ Mount is used to link an external Vitess cluster in order to migrate data from i
   -h, --help   help for Mount
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -24,7 +25,7 @@ Mount is used to link an external Vitess cluster in order to migrate data from i
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Mount list](./vtctldclient_mount_list/)	 - List all mounted external Vitess Clusters.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -3,6 +3,7 @@ title: Mount list
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Mount list
 
 List all mounted external Vitess Clusters.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 mount list
   -h, --help   help for list
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ vtctldclient --server localhost:15999 mount list
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -3,6 +3,7 @@ title: Mount register
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Mount register
 
 Register an external Vitess Cluster.
@@ -27,7 +28,7 @@ vtctldclient --server localhost:15999 mount register --name ext1 --topo-type etc
       --topo-type string     Topo server implementation to use.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 mount register --name ext1 --topo-type etc
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -3,6 +3,7 @@ title: Mount show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Mount show
 
 Show attributes of a previously mounted external Vitess Cluster.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 mount show --name ext1
       --name string   Name of the mount.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -35,7 +36,7 @@ vtctldclient --server localhost:15999 mount show --name ext1
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -3,6 +3,7 @@ title: Mount unregister
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Mount unregister
 
 Unregister a previously mounted external Vitess Cluster.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 mount unregister --name ext1
       --name string   Name of the mount.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -35,7 +36,7 @@ vtctldclient --server localhost:15999 mount unregister --name ext1
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Mount](../)	 - Mount is used to link an external Vitess cluster in order to migrate data from it.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -3,6 +3,7 @@ title: MoveTables
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables
 
 Perform commands related to moving tables from a source keyspace to a target keyspace.
@@ -16,7 +17,7 @@ Perform commands related to moving tables from a source keyspace to a target key
   -w, --workflow string          The workflow you want to perform the command on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -27,7 +28,7 @@ Perform commands related to moving tables from a source keyspace to a target key
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient MoveTables cancel](./vtctldclient_movetables_cancel/)	 - Cancel a MoveTables VReplication workflow.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -3,6 +3,7 @@ title: MoveTables cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables cancel
 
 Cancel a MoveTables VReplication workflow.
@@ -26,7 +27,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -40,7 +41,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -3,6 +3,7 @@ title: MoveTables complete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables complete
 
 Complete a MoveTables VReplication workflow.
@@ -28,7 +29,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -42,7 +43,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -3,6 +3,7 @@ title: MoveTables create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables create
 
 Create and optionally run a MoveTables VReplication workflow.
@@ -42,7 +43,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
       --tenant-id string                   (EXPERIMENTAL: Multi-tenant migrations only) The tenant ID to use for the MoveTables workflow into a multi-tenant keyspace.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -56,7 +57,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -3,6 +3,7 @@ title: MoveTables mirrortraffic
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables mirrortraffic
 
 Mirror traffic for a MoveTables MoveTables workflow.
@@ -25,7 +26,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --tablet-types strings   Tablet types to mirror traffic for.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -39,7 +40,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -3,6 +3,7 @@ title: MoveTables reversetraffic
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables reversetraffic
 
 Reverse traffic for a MoveTables VReplication workflow.
@@ -30,7 +31,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -44,7 +45,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -3,6 +3,7 @@ title: MoveTables show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables show
 
 Show the details for a MoveTables VReplication workflow.
@@ -25,7 +26,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -39,7 +40,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -3,6 +3,7 @@ title: MoveTables start
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables start
 
 Start a MoveTables workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help   help for start
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -3,6 +3,7 @@ title: MoveTables status
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables status
 
 Show the current status for a MoveTables VReplication workflow.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -3,6 +3,7 @@ title: MoveTables stop
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables stop
 
 Stop a MoveTables workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -h, --help   help for stop
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -3,6 +3,7 @@ title: MoveTables switchtraffic
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient MoveTables switchtraffic
 
 Switch traffic for a MoveTables VReplication workflow.
@@ -31,7 +32,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -45,7 +46,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient MoveTables](../)	 - Perform commands related to moving tables from a source keyspace to a target keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -3,6 +3,7 @@ title: OnlineDDL
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL
 
 Operates on online DDL (schema migrations).
@@ -13,7 +14,7 @@ Operates on online DDL (schema migrations).
   -h, --help   help for OnlineDDL
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -24,7 +25,7 @@ Operates on online DDL (schema migrations).
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient OnlineDDL cancel](./vtctldclient_onlineddl_cancel/)	 - Cancel one or all migrations, terminating any running ones as needed.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -3,6 +3,7 @@ title: OnlineDDL cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL cancel
 
 Cancel one or all migrations, terminating any running ones as needed.
@@ -23,7 +24,7 @@ OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for cancel
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL cancel test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -3,6 +3,7 @@ title: OnlineDDL cleanup
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL cleanup
 
 Mark a given schema migration ready for artifact cleanup.
@@ -23,7 +24,7 @@ OnlineDDL cleanup test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for cleanup
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL cleanup test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -3,6 +3,7 @@ title: OnlineDDL complete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL complete
 
 Complete one or all migrations executed with --postpone-completion
@@ -23,7 +24,7 @@ OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for complete
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL complete test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -3,6 +3,7 @@ title: OnlineDDL force-cutover
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL force-cutover
 
 Mark a given schema migration, or all pending migrations, for forced cut over.
@@ -23,7 +24,7 @@ OnlineDDL force-cutover test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for force-cutover
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL force-cutover test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -3,6 +3,7 @@ title: OnlineDDL launch
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL launch
 
 Launch one or all migrations executed with --postpone-launch
@@ -23,7 +24,7 @@ OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for launch
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL launch test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -3,6 +3,7 @@ title: OnlineDDL retry
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL retry
 
 Mark a given schema migration for retry.
@@ -23,7 +24,7 @@ vtctl OnlineDDL retry test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
   -h, --help   help for retry
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ vtctl OnlineDDL retry test_keyspace 82fa54ac_e83e_11ea_96b7_f875a4d24e90
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -3,6 +3,7 @@ title: OnlineDDL show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL show
 
 Display information about online DDL operations.
@@ -34,7 +35,7 @@ OnlineDDL show test_keyspace failed
       --skip uint    Skip specified number of rows returned in output.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -45,7 +46,7 @@ OnlineDDL show test_keyspace failed
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -3,6 +3,7 @@ title: OnlineDDL throttle
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL throttle
 
 Throttles one or all migrations
@@ -23,7 +24,7 @@ OnlineDDL throttle all
   -h, --help   help for throttle
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL throttle all
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -3,6 +3,7 @@ title: OnlineDDL unthrottle
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient OnlineDDL unthrottle
 
 Unthrottles one or all migrations
@@ -23,7 +24,7 @@ OnlineDDL unthrottle all
   -h, --help   help for unthrottle
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ OnlineDDL unthrottle all
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient OnlineDDL](../)	 - Operates on online DDL (schema migrations).
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -3,6 +3,7 @@ title: PingTablet
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient PingTablet
 
 Checks that the specified tablet is awake and responding to RPCs. This command can be blocked by other in-flight operations.
@@ -17,7 +18,7 @@ vtctldclient PingTablet <alias>
   -h, --help   help for PingTablet
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient PingTablet <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -3,6 +3,7 @@ title: PlannedReparentShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient PlannedReparentShard
 
 Reparents the shard to a new primary, or away from an old primary. Both the old and new primaries must be up and running.
@@ -21,7 +22,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
       --wait-replicas-timeout duration       Time to wait for replicas to catch up on replication both before and after reparenting. (default 15s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -3,6 +3,7 @@ title: RebuildKeyspaceGraph
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RebuildKeyspaceGraph
 
 Rebuilds the serving data for the keyspace(s). This command may trigger an update to all connected clients.
@@ -19,7 +20,7 @@ vtctldclient RebuildKeyspaceGraph [--cells=c1,c2,...] [--allow-partial] ks1 [ks2
   -h, --help            help for RebuildKeyspaceGraph
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient RebuildKeyspaceGraph [--cells=c1,c2,...] [--allow-partial] ks1 [ks2
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -3,6 +3,7 @@ title: RebuildVSchemaGraph
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RebuildVSchemaGraph
 
 Rebuilds the cell-specific SrvVSchema from the global VSchema objects in the provided cells (or all cells if none provided).
@@ -18,7 +19,7 @@ vtctldclient RebuildVSchemaGraph [--cells=c1,c2,...]
   -h, --help            help for RebuildVSchemaGraph
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient RebuildVSchemaGraph [--cells=c1,c2,...]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -3,6 +3,7 @@ title: RefreshState
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RefreshState
 
 Reloads the tablet record on the specified tablet.
@@ -17,7 +18,7 @@ vtctldclient RefreshState <alias>
   -h, --help   help for RefreshState
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient RefreshState <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -3,6 +3,7 @@ title: RefreshStateByShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RefreshStateByShard
 
 Reloads the tablet record all tablets in the shard, optionally limited to the specified cells.
@@ -18,7 +19,7 @@ vtctldclient RefreshStateByShard [--cell <cell1> ...] <keyspace/shard>
   -h, --help            help for RefreshStateByShard
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient RefreshStateByShard [--cell <cell1> ...] <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -3,6 +3,7 @@ title: ReloadSchema
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ReloadSchema
 
 Reloads the schema on a remote tablet.
@@ -17,7 +18,7 @@ vtctldclient ReloadSchema <tablet_alias>
   -h, --help   help for ReloadSchema
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient ReloadSchema <tablet_alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -3,6 +3,7 @@ title: ReloadSchemaKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ReloadSchemaKeyspace
 
 Reloads the schema on all tablets in a keyspace. This is done on a best-effort basis.
@@ -19,7 +20,7 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
       --include-primary     Also reload the primary tablets.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient ReloadSchemaKeyspace [--concurrency=<concurrency>] [--include-prima
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -3,6 +3,7 @@ title: ReloadSchemaShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ReloadSchemaShard
 
 Reloads the schema on all tablets in a shard. This is done on a best-effort basis.
@@ -19,7 +20,7 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
       --include-primary     Also reload the primary tablet.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient ReloadSchemaShard [--concurrency=10] [--include-primary] <keyspace/
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -3,6 +3,7 @@ title: RemoveBackup
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RemoveBackup
 
 Removes the given backup from the BackupStorage used by vtctld.
@@ -17,7 +18,7 @@ vtctldclient RemoveBackup <keyspace/shard> <backup name>
   -h, --help   help for RemoveBackup
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient RemoveBackup <keyspace/shard> <backup name>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -3,6 +3,7 @@ title: RemoveKeyspaceCell
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RemoveKeyspaceCell
 
 Removes the specified cell from the Cells list for all shards in the specified keyspace (by calling RemoveShardCell on every shard). It also removes the SrvKeyspace for that keyspace in that cell.
@@ -19,7 +20,7 @@ vtctldclient RemoveKeyspaceCell [--force|-f] [--recursive|-r] <keyspace> <cell>
   -r, --recursive   Also delete all tablets in that cell beloning to the specified keyspace.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient RemoveKeyspaceCell [--force|-f] [--recursive|-r] <keyspace> <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -3,6 +3,7 @@ title: RemoveShardCell
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RemoveShardCell
 
 Remove the specified cell from the specified shard's Cells list.
@@ -19,7 +20,7 @@ vtctldclient RemoveShardCell [--force|-f] [--recursive|-r] <keyspace/shard> <cel
   -r, --recursive   Also delete all tablets in that cell beloning to the specified shard.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient RemoveShardCell [--force|-f] [--recursive|-r] <keyspace/shard> <cel
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -3,6 +3,7 @@ title: ReparentTablet
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ReparentTablet
 
 Reparent a tablet to the current primary in the shard.
@@ -17,7 +18,7 @@ vtctldclient ReparentTablet <alias>
   -h, --help   help for ReparentTablet
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient ReparentTablet <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -3,6 +3,7 @@ title: Reshard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard
 
 Perform commands related to resharding a keyspace.
@@ -16,7 +17,7 @@ Perform commands related to resharding a keyspace.
   -w, --workflow string          The workflow you want to perform the command on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -27,7 +28,7 @@ Perform commands related to resharding a keyspace.
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Reshard cancel](./vtctldclient_reshard_cancel/)	 - Cancel a Reshard VReplication workflow.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -3,6 +3,7 @@ title: Reshard cancel
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard cancel
 
 Cancel a Reshard VReplication workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -h, --help   help for cancel
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -3,6 +3,7 @@ title: Reshard complete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard complete
 
 Complete a Reshard VReplication workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -h, --help   help for complete
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -3,6 +3,7 @@ title: Reshard create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard create
 
 Create and optionally run a Reshard VReplication workflow.
@@ -34,7 +35,7 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
       --target-shards strings              Target shards.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -48,7 +49,7 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -3,6 +3,7 @@ title: Reshard reversetraffic
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard reversetraffic
 
 Reverse traffic for a Reshard VReplication workflow.
@@ -29,7 +30,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -43,7 +44,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -3,6 +3,7 @@ title: Reshard show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard show
 
 Show the details for a Reshard VReplication workflow.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
       --include-logs   Include recent logs for the workflow. (default true)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -3,6 +3,7 @@ title: Reshard start
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard start
 
 Start a Reshard workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -h, --help   help for start
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -3,6 +3,7 @@ title: Reshard status
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard status
 
 Show the current status for a Reshard VReplication workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -h, --help   help for status
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -3,6 +3,7 @@ title: Reshard stop
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard stop
 
 Stop a Reshard workflow.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -h, --help   help for stop
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -3,6 +3,7 @@ title: Reshard switchtraffic
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Reshard switchtraffic
 
 Switch traffic for a Reshard VReplication workflow.
@@ -29,7 +30,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
       --timeout duration                       Specifies the maximum time to wait, in seconds, for VReplication to catch up on primary tablets. The traffic switch will be cancelled on timeout. (default 30s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -43,7 +44,7 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Reshard](../)	 - Perform commands related to resharding a keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -3,6 +3,7 @@ title: RestoreFromBackup
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RestoreFromBackup
 
 Stops mysqld on the specified tablet and restores the data from either the latest backup or closest before `backup-timestamp`.
@@ -21,7 +22,7 @@ vtctldclient RestoreFromBackup [--backup-timestamp|-t <YYYY-mm-DD.HHMMSS>] [--re
       --restore-to-timestamp 2006-01-02T15:04:05Z07:00   Run a point in time recovery that restores up to, and excluding, given timestamp in RFC3339 format (2006-01-02T15:04:05Z07:00). This will attempt to use one full backup followed by zero or more incremental backups
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient RestoreFromBackup [--backup-timestamp|-t <YYYY-mm-DD.HHMMSS>] [--re
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -3,6 +3,7 @@ title: RunHealthCheck
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient RunHealthCheck
 
 Runs a healthcheck on the remote tablet.
@@ -17,7 +18,7 @@ vtctldclient RunHealthCheck <tablet_alias>
   -h, --help   help for RunHealthCheck
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient RunHealthCheck <tablet_alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -3,6 +3,7 @@ title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SetKeyspaceDurabilityPolicy
 
 Sets the durability-policy used by the specified keyspace.
@@ -27,7 +28,7 @@ vtctldclient SetKeyspaceDurabilityPolicy [--durability-policy=policy_name] <keys
   -h, --help                       help for SetKeyspaceDurabilityPolicy
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient SetKeyspaceDurabilityPolicy [--durability-policy=policy_name] <keys
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -3,6 +3,7 @@ title: SetShardIsPrimaryServing
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SetShardIsPrimaryServing
 
 Add or remove a shard from serving. This is meant as an emergency function. It does not rebuild any serving graphs; i.e. it does not run `RebuildKeyspaceGraph`.
@@ -17,7 +18,7 @@ vtctldclient SetShardIsPrimaryServing <keyspace/shard> <true/false>
   -h, --help   help for SetShardIsPrimaryServing
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient SetShardIsPrimaryServing <keyspace/shard> <true/false>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -3,6 +3,7 @@ title: SetShardTabletControl
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SetShardTabletControl
 
 Sets the TabletControl record for a shard and tablet type. Only use this for an emergency fix or after a finished MoveTables.
@@ -39,7 +40,7 @@ vtctldclient SetShardTabletControl [--cells=c1,c2...] [--denied-tables=t1,t2,...
   -r, --remove                  Removes the specified cells for MoveTables operations.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -50,7 +51,7 @@ vtctldclient SetShardTabletControl [--cells=c1,c2...] [--denied-tables=t1,t2,...
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -3,6 +3,7 @@ title: SetWritable
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SetWritable
 
 Sets the specified tablet as writable or read-only.
@@ -17,7 +18,7 @@ vtctldclient SetWritable <alias> <true/false>
   -h, --help   help for SetWritable
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient SetWritable <alias> <true/false>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -3,6 +3,7 @@ title: ShardReplicationFix
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ShardReplicationFix
 
 Walks through a ShardReplication object and fixes the first error encountered.
@@ -17,7 +18,7 @@ vtctldclient ShardReplicationFix <cell> <keyspace/shard>
   -h, --help   help for ShardReplicationFix
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient ShardReplicationFix <cell> <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -3,6 +3,7 @@ title: ShardReplicationPositions
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ShardReplicationPositions
 
 
@@ -23,7 +24,7 @@ vtctldclient ShardReplicationPositions <keyspace/shard>
   -h, --help   help for ShardReplicationPositions
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -34,7 +35,7 @@ vtctldclient ShardReplicationPositions <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -3,6 +3,7 @@ title: SleepTablet
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SleepTablet
 
 Blocks the action queue on the specified tablet for the specified amount of time. This is typically used for testing.
@@ -33,7 +34,7 @@ vtctldclient SleepTablet <alias> <duration>
   -h, --help   help for SleepTablet
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -44,7 +45,7 @@ vtctldclient SleepTablet <alias> <duration>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -3,6 +3,7 @@ title: SourceShardAdd
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SourceShardAdd
 
 Adds the SourceShard record with the provided index for emergencies only. It does not call RefreshState for the shard primary.
@@ -19,7 +20,7 @@ vtctldclient SourceShardAdd [--key-range <keyrange>] [--tables <table1,table2,..
       --tables strings     Comma-separated lists of tables to replicate (for MoveTables). Each table name is either an exact match, or a regular expression of the form "/regexp/".
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -30,7 +31,7 @@ vtctldclient SourceShardAdd [--key-range <keyrange>] [--tables <table1,table2,..
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -3,6 +3,7 @@ title: SourceShardDelete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient SourceShardDelete
 
 Deletes the SourceShard record with the provided index. This should only be used for emergency cleanup. It does not call RefreshState for the shard primary.
@@ -17,7 +18,7 @@ vtctldclient SourceShardDelete <keyspace/shard> <uid>
   -h, --help   help for SourceShardDelete
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient SourceShardDelete <keyspace/shard> <uid>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -3,6 +3,7 @@ title: StartReplication
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient StartReplication
 
 Starts replication on the specified tablet.
@@ -17,7 +18,7 @@ vtctldclient StartReplication <alias>
   -h, --help   help for StartReplication
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient StartReplication <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -3,6 +3,7 @@ title: StopReplication
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient StopReplication
 
 Stops replication on the specified tablet.
@@ -17,7 +18,7 @@ vtctldclient StopReplication <alias>
   -h, --help   help for StopReplication
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient StopReplication <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -3,6 +3,7 @@ title: TabletExternallyReparented
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient TabletExternallyReparented
 
 Updates the topology record for the tablet's shard to acknowledge that an external tool made this tablet the primary.
@@ -24,7 +25,7 @@ vtctldclient TabletExternallyReparented <alias>
   -h, --help   help for TabletExternallyReparented
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -35,7 +36,7 @@ vtctldclient TabletExternallyReparented <alias>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -3,6 +3,7 @@ title: UpdateCellInfo
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient UpdateCellInfo
 
 Updates the content of a CellInfo with the provided parameters, creating the CellInfo if it does not exist.
@@ -25,7 +26,7 @@ vtctldclient UpdateCellInfo [--root <root>] [--server-address <addr>] <cell>
   -a, --server-address string   The address the topology server will connect to for this cell.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient UpdateCellInfo [--root <root>] [--server-address <addr>] <cell>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -3,6 +3,7 @@ title: UpdateCellsAlias
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient UpdateCellsAlias
 
 Updates the content of a CellsAlias with the provided parameters, creating the CellsAlias if it does not exist.
@@ -22,7 +23,7 @@ vtctldclient UpdateCellsAlias [--cells <cell1,cell2,...> [--cells <cell4> ...]] 
   -h, --help            help for UpdateCellsAlias
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -33,7 +34,7 @@ vtctldclient UpdateCellsAlias [--cells <cell1,cell2,...> [--cells <cell4> ...]] 
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -3,6 +3,7 @@ title: UpdateThrottlerConfig
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient UpdateThrottlerConfig
 
 Update the tablet throttler configuration for all tablets in the given keyspace (across all cells)
@@ -31,7 +32,7 @@ vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] 
       --unthrottle-app string            an app name to unthrottle
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -42,7 +43,7 @@ vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] 
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -3,6 +3,7 @@ title: VDiff
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff
 
 Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
@@ -16,7 +17,7 @@ Perform commands related to diffing tables involved in a VReplication workflow b
   -w, --workflow string          The workflow you want to perform the command on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -27,7 +28,7 @@ Perform commands related to diffing tables involved in a VReplication workflow b
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient VDiff create](./vtctldclient_vdiff_create/)	 - Create and run a VDiff to compare the tables involved in a VReplication workflow between the source and target.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -3,6 +3,7 @@ title: VDiff create
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff create
 
 Create and run a VDiff to compare the tables involved in a VReplication workflow between the source and target.
@@ -40,7 +41,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --wait-update-interval duration             When waiting on a vdiff to finish, check and display the current status this often. (default 1m0s)
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -54,7 +55,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient VDiff](../)	 - Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -3,6 +3,7 @@ title: VDiff delete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff delete
 
 Delete VDiffs.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -h, --help   help for delete
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient VDiff](../)	 - Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -3,6 +3,7 @@ title: VDiff resume
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff resume
 
 Resume a VDiff.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -h, --help   help for resume
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient VDiff](../)	 - Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -3,6 +3,7 @@ title: VDiff show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff show
 
 Show the status of a VDiff.
@@ -26,7 +27,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --verbose   Show verbose output in summaries
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -40,7 +41,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient VDiff](../)	 - Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -3,6 +3,7 @@ title: VDiff stop
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient VDiff stop
 
 Stop a running VDiff.
@@ -23,7 +24,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -h, --help   help for stop
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
   -w, --workflow string                      The workflow you want to perform the command on.
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient VDiff](../)	 - Perform commands related to diffing tables involved in a VReplication workflow between the source and target.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -3,6 +3,7 @@ title: Validate
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Validate
 
 Validates that all nodes reachable from the global replication graph, as well as all tablets in discoverable cells, are consistent.
@@ -18,7 +19,7 @@ vtctldclient Validate [--ping-tablets]
   -p, --ping-tablets   Indicates whether all tablets should be pinged during the validation process.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient Validate [--ping-tablets]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -3,6 +3,7 @@ title: ValidateKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ValidateKeyspace
 
 Validates that all nodes reachable from the specified keyspace are consistent.
@@ -18,7 +19,7 @@ vtctldclient ValidateKeyspace [--ping-tablets] <keyspace>
   -p, --ping-tablets   Indicates whether all tablets should be pinged during the validation process.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient ValidateKeyspace [--ping-tablets] <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -3,6 +3,7 @@ title: ValidateSchemaKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ValidateSchemaKeyspace
 
 Validates that the schema on the primary tablet for shard 0 matches the schema on all other tablets in the keyspace.
@@ -21,7 +22,7 @@ vtctldclient ValidateSchemaKeyspace [--exclude-tables=<exclude_tables>] [--inclu
       --skip-no-primary          Skips validation on whether or not a primary exists in shards.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -32,7 +33,7 @@ vtctldclient ValidateSchemaKeyspace [--exclude-tables=<exclude_tables>] [--inclu
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -3,6 +3,7 @@ title: ValidateShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ValidateShard
 
 Validates that all nodes reachable from the specified shard are consistent.
@@ -18,7 +19,7 @@ vtctldclient ValidateShard [--ping-tablets] <keyspace/shard>
   -p, --ping-tablets   Indicates whether all tablets should be pinged during the validation process.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient ValidateShard [--ping-tablets] <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -3,6 +3,7 @@ title: ValidateVersionKeyspace
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ValidateVersionKeyspace
 
 Validates that the version on the primary tablet of shard 0 matches all of the other tablets in the keyspace.
@@ -17,7 +18,7 @@ vtctldclient ValidateVersionKeyspace <keyspace>
   -h, --help   help for ValidateVersionKeyspace
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient ValidateVersionKeyspace <keyspace>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -3,6 +3,7 @@ title: ValidateVersionShard
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient ValidateVersionShard
 
 Validates that the version on the primary matches all of the replicas.
@@ -17,7 +18,7 @@ vtctldclient ValidateVersionShard <keyspace/shard>
   -h, --help   help for ValidateVersionShard
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -28,7 +29,7 @@ vtctldclient ValidateVersionShard <keyspace/shard>
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -3,6 +3,7 @@ title: Workflow
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow
 
 Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
@@ -18,7 +19,7 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
   -k, --keyspace string   Keyspace context for the workflow.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -29,7 +30,7 @@ vtctldclient Workflow --keyspace <keyspace> [command] [command-flags]
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient Workflow delete](./vtctldclient_workflow_delete/)	 - Delete a VReplication workflow.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -3,6 +3,7 @@ title: Workflow delete
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow delete
 
 Delete a VReplication workflow.
@@ -27,7 +28,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
   -w, --workflow string      The workflow you want to delete.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -39,7 +40,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -3,6 +3,7 @@ title: Workflow list
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow list
 
 List the VReplication workflows in the given keyspace.
@@ -24,7 +25,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
       --shards strings   (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -36,7 +37,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer list
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -3,6 +3,7 @@ title: Workflow show
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow show
 
 Show the details for a VReplication workflow.
@@ -26,7 +27,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
   -w, --workflow string   The workflow you want the details for.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -38,7 +39,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer show --workfl
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -3,6 +3,7 @@ title: Workflow start
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow start
 
 Start a VReplication workflow.
@@ -25,7 +26,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
   -w, --workflow string   The workflow you want to start.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -3,6 +3,7 @@ title: Workflow stop
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow stop
 
 Stop a VReplication workflow.
@@ -25,7 +26,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
   -w, --workflow string   The workflow you want to stop.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -37,7 +38,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer stop --workfl
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -3,6 +3,7 @@ title: Workflow update
 series: vtctldclient
 commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
 ---
+
 ## vtctldclient Workflow update
 
 Update the configuration parameters for a VReplication workflow.
@@ -29,7 +30,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
   -w, --workflow string         The workflow you want to update.
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
@@ -41,7 +42,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer update --work
       --topo-implementation string           the topology implementation to use (default "etcd2")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
 

--- a/content/en/docs/21.0/reference/programs/vtexplain.md
+++ b/content/en/docs/21.0/reference/programs/vtexplain.md
@@ -55,7 +55,7 @@ mapping will be used and `--shards` will be ignored.
 
 ## Limitations
 
-### The VSchema must use a keyspace name.
+### The VSchema must Use a Keyspace Name
 
 VTExplain requires a keyspace name for each keyspace in an input VSchema:
 

--- a/content/en/docs/21.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtgate/_index.md
@@ -3,6 +3,7 @@ title: vtgate
 series: vtgate
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtgate
 
 VTGate is a stateless proxy responsible for accepting requests from applications and routing them to the appropriate tablet server(s) for query execution. It speaks both the MySQL Protocol and a gRPC protocol.

--- a/content/en/docs/21.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtgateclienttest/_index.md
@@ -3,6 +3,7 @@ title: vtgateclienttest
 series: vtgateclienttest
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtgateclienttest
 
 vtgateclienttest is a chain of vtgateservice.VTGateService implementations, each one being responsible for one test scenario.

--- a/content/en/docs/21.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtorc/_index.md
@@ -3,6 +3,7 @@ title: vtorc
 series: vtorc
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vtorc
 
 VTOrc is the automated fault detection and repair tool in Vitess.

--- a/content/en/docs/21.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttablet/_index.md
@@ -3,6 +3,7 @@ title: vttablet
 series: vttablet
 commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
 ---
+
 ## vttablet
 
 The VTTablet server controls a running MySQL server.

--- a/content/en/docs/21.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/_index.md
@@ -18,7 +18,7 @@ vttlstest is a tool for generating test certificates, keys, and related artifact
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest CreateCA](./vttlstest_createca/)	 - Create certificate authority
 * [vttlstest CreateCRL](./vttlstest_createcrl/)	 - Create certificate revocation list

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -27,13 +27,13 @@ CreateCA --root /tmp
   -h, --help   help for CreateCA
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest](../)	 - vttlstest is a tool for generating test certificates, keys, and related artifacts for TLS tests.
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -27,13 +27,13 @@ CreateCRL --root /tmp mail.mycoolsite.com
   -h, --help   help for CreateCRL
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest](../)	 - vttlstest is a tool for generating test certificates, keys, and related artifacts for TLS tests.
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -30,13 +30,13 @@ CreateIntermediateCA --root /tmp --parent ca mail.mycoolsite.com
       --serial string        Serial number for the certificate to create. Should be different for two certificates with the same parent. (default "01")
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest](../)	 - vttlstest is a tool for generating test certificates, keys, and related artifacts for TLS tests.
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -30,13 +30,13 @@ CreateSignedCert --root /tmp --common-name mail.mysite.com --parent mail.mycools
       --serial string        Serial number for the certificate to create. Should be different for two certificates with the same parent. (default "01")
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest](../)	 - vttlstest is a tool for generating test certificates, keys, and related artifacts for TLS tests.
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -28,13 +28,13 @@ RevokeCert --root /tmp --parent mail.mycoolsite.com postman1
       --parent string   Parent cert name to use. Use 'ca' for the toplevel CA. (default "ca")
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --root string   root directory for all artifacts (default ".")
 ```
 
-### SEE ALSO
+### See Also
 
 * [vttlstest](../)	 - vttlstest is a tool for generating test certificates, keys, and related artifacts for TLS tests.
 

--- a/content/en/docs/21.0/reference/programs/zk/_index.md
+++ b/content/en/docs/21.0/reference/programs/zk/_index.md
@@ -32,7 +32,7 @@ variable.
       --server string                  server(s) to connect to
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk addAuth](./zk_addauth/)	 - 
 * [zk cat](./zk_cat/)	 - 

--- a/content/en/docs/21.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_addAuth.md
@@ -17,7 +17,7 @@ zk addAuth <digest> <user:pass> [flags]
   -h, --help   help for addAuth
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_cat.md
@@ -29,7 +29,7 @@ zk cat -l /zk/path1 /zk/path2
   -l, --longListing   long listing
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_chmod.md
@@ -24,7 +24,7 @@ zk chmod n+mode /zk/path
   -h, --help   help for chmod
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_cp.md
@@ -27,7 +27,7 @@ zk cp ./config /zk/path/
   -h, --help   help for cp
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_edit.md
@@ -18,7 +18,7 @@ zk edit <path> [flags]
   -h, --help    help for edit
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_ls.md
@@ -34,7 +34,7 @@ zk ls -R /zk
   -R, --recursivelisting   recursive listing
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_rm.md
@@ -31,7 +31,7 @@ zk rm -f /zk/path
   -r, --recursivedelete   recursive delete
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_stat.md
@@ -18,7 +18,7 @@ zk stat <path> [flags]
   -h, --help    help for stat
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_touch.md
@@ -38,7 +38,7 @@ zk touch -p /zk/path
   -c, --touchonly      touch only - don't create
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_unzip.md
@@ -24,7 +24,7 @@ zk unzip zktree.zip /zk/prefix
   -h, --help   help for unzip
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_wait.md
@@ -28,7 +28,7 @@ zk wait /zk/path/children/
   -h, --help   help for wait
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_watch.md
@@ -23,7 +23,7 @@ watch /zk/path
   -h, --help   help for watch
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_zip.md
@@ -24,7 +24,7 @@ zk zip <path> [<path> ...] <archive> [flags]
   -h, --help   help for zip
 ```
 
-### SEE ALSO
+### See Also
 
 * [zk](../)	 - zk is a tool for wrangling zookeeper.
 

--- a/content/en/docs/21.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/_index.md
@@ -37,7 +37,7 @@ Initializes and controls zookeeper with Vitess-specific configuration.
       --zk.myid uint                                                which server do you want to be? only needed when running multiple instance on one box, otherwise myid is implied by hostname
 ```
 
-### SEE ALSO
+### See Also
 
 * [zkctl init](./zkctl_init/)	 - Generates a new config and then starts zookeeper.
 * [zkctl shutdown](./zkctl_shutdown/)	 - Terminates a zookeeper server but keeps its data dir intact.

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_init.md
@@ -17,7 +17,7 @@ zkctl init [flags]
   -h, --help   help for init
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -46,7 +46,7 @@ zkctl init [flags]
       --zk.myid uint                                                which server do you want to be? only needed when running multiple instance on one box, otherwise myid is implied by hostname
 ```
 
-### SEE ALSO
+### See Also
 
 * [zkctl](../)	 - Initializes and controls zookeeper with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -17,7 +17,7 @@ zkctl shutdown [flags]
   -h, --help   help for shutdown
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -46,7 +46,7 @@ zkctl shutdown [flags]
       --zk.myid uint                                                which server do you want to be? only needed when running multiple instance on one box, otherwise myid is implied by hostname
 ```
 
-### SEE ALSO
+### See Also
 
 * [zkctl](../)	 - Initializes and controls zookeeper with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_start.md
@@ -17,7 +17,7 @@ zkctl start [flags]
   -h, --help   help for start
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -46,7 +46,7 @@ zkctl start [flags]
       --zk.myid uint                                                which server do you want to be? only needed when running multiple instance on one box, otherwise myid is implied by hostname
 ```
 
-### SEE ALSO
+### See Also
 
 * [zkctl](../)	 - Initializes and controls zookeeper with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_teardown.md
@@ -17,7 +17,7 @@ zkctl teardown [flags]
   -h, --help   help for teardown
 ```
 
-### Options inherited from parent commands
+### Options Inherited from Parent Commands
 
 ```
       --alsologtostderr                                             log to standard error as well as files
@@ -46,7 +46,7 @@ zkctl teardown [flags]
       --zk.myid uint                                                which server do you want to be? only needed when running multiple instance on one box, otherwise myid is implied by hostname
 ```
 
-### SEE ALSO
+### See Also
 
 * [zkctl](../)	 - Initializes and controls zookeeper with Vitess-specific configuration.
 

--- a/content/en/docs/21.0/reference/query-serving/reserved-conn.md
+++ b/content/en/docs/21.0/reference/query-serving/reserved-conn.md
@@ -26,7 +26,7 @@ effectiveness of the `vttablet` connection pooling. This may also reduce, or eve
 eliminate, the advantages of using connection pooling between `vttablet` and 
 MySQL.
 
-### Reserved connections
+### Reserved Connections
 
 `SET` statements used to cause use of `reserved connections`. This is no longer the case with the new connection pool implementation used by vttablet.
 The connection pool now tracks connections with modified settings instead of pinning connections to specific client sessions. 
@@ -36,7 +36,7 @@ because the scenarios where we still need reserved connections have drastically 
 
 There are still cases like [temporary tables](#temporary-tables-and-reserved-connections) and [advisory locks](#get_lock-and-reserved-connections) where reserved connections will continue to be used.
 
-### Temporary tables and reserved connections
+### Temporary Tables and Reserved Connections
 
 Temporary tables exist only in the context of a particular MySQL connection.
 If using a temporary table, Vitess will mark the session as needing a
@@ -44,7 +44,7 @@ reserved connection. It will continue to use the reserved connection
 until the user disconnects. Note that removing the temporary table is not enough to reset the connection.
 More info can be found [here](../../compatibility/mysql-compatibility/#temporary-tables).
 
-### GET_LOCK() and reserved connections
+### GET_LOCK() and Reserved Connections
 
 The MySQL locking functions allow users to work with user level locks. Since
 the locks are tied to the connection, and the lock must be released in the
@@ -53,7 +53,7 @@ connection to become a reserved connection. This connection is also kept alive
 so it does not time out due to inactivity.  More information can be found
 [here](../../../../design-docs/query-serving/locking-functions/).
 
-### Shutting down reserved connections
+### Shutting Down Reserved Connections
 
 Whenever a connection gets transformed into a reserved connection, a fresh
 connection is created in the connection pool to replace it. Once the `vtgate`
@@ -64,7 +64,7 @@ connector to disconnect idle sessions that are likely to use
 reserved connections promptly. In order to release resources that cannot
 otherwise be reused.
 
-### Number of vttablet <-> MySQL connections
+### Number of vttablet <-> MySQL Connections
 
 As a result of how reserved connections work, it is possible for there
 to be significantly more `vttablet` <-> MySQL connections than the limit you

--- a/content/en/docs/21.0/reference/vreplication/internal/vstream-skew-detection.md
+++ b/content/en/docs/21.0/reference/vreplication/internal/vstream-skew-detection.md
@@ -80,5 +80,4 @@ This is how you would turn on the skew detection and alignment feature in a [VSt
     flags.MinimizeSkew = true;
 
     reader, err := conn.VStream(ctx, topodatapb.TabletType_PRIMARY, vgtid, filter, flags)
-
 ```

--- a/content/en/docs/21.0/reference/vreplication/reshard.md
+++ b/content/en/docs/21.0/reference/vreplication/reshard.md
@@ -150,7 +150,7 @@ You can alternatively specify `--all-cells` if you want to replicate from source
 
 #### --defer-secondary-keys
 **optional**\
-**default** false
+**defaulteserved connections** false
 
 {{< warning >}}
 This flag is currently **experimental**.

--- a/content/en/docs/21.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/21.0/reference/vtadmin/operators_guide.md
@@ -21,7 +21,7 @@ minimal invocation of the `vtadmin` and `vtadmin-web` binaries.
 
 - Building `vtadmin-web` requires [node](https://nodejs.org/en/) at the version given in the [package.json file](https://github.com/vitessio/vitess/blob/main/web/vtadmin/package.json).
 
-### 1. Define the cluster configuration
+### 1. Define the Cluster Configuration
 
 VTAdmin is mapped to one or more Vitess clusters two ways:
 
@@ -101,7 +101,7 @@ For example, you should avoid applying a `*` actor to a write action, or a `*` a
 
 For further reading on VTAdmin's RBAC design, please refer to the [reference page][rbac_docs].
 
-### Deploy in a trusted environment
+### Deploy in a Trusted Environment
 
 There is no trust boundary between `vtadmin-web` and `vtadmin-api`, with deployment-specific authentication mechanisms being left to the operator to design for their specific environment.
 As such, you should deploy VTAdmin **within** a trusted environment, for example, behind a single sign-on (SSO) integration, such as [okta](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/go/main/).

--- a/content/en/docs/21.0/reference/vtadmin/vtctld-api-transition.md
+++ b/content/en/docs/21.0/reference/vtadmin/vtctld-api-transition.md
@@ -12,6 +12,7 @@ Some methods do not have a 1:1 mapping from vtctld to VTAdmin. These cases inclu
 - VTAdmin methods that were not supported by vtctld API; noted here because they may be useful
 
 One of the main differences between vtctld and VTAdmin API is that VTAdmin API returns results across all clusters discovered by VTAdmin [cluster discovery](https://vitess.io/docs/17.0/reference/vtadmin/cluster_discovery/). VTAdmin API methods that accept a `cluster_id` parameter are methods that will return results from all clusters, unless the aforementioned filter parameter is provided.
+
 ## vtctld and VTAdmin API methods
 
 | Summary | `vtctld` API (old) | `vtctld` params (old) | `vtadmin` API (new) | `vtadmin` params (new)| Notes |

--- a/content/en/docs/21.0/reference/vtctldclient-transition/overview.md
+++ b/content/en/docs/21.0/reference/vtctldclient-transition/overview.md
@@ -15,12 +15,12 @@ rpc ExecuteVtctlCommand(ExecuteVtctlCommandRequest) returns (stream ExecuteVtctl
 The new interface has individual RPCs for each command, with command-specific request and response types.
 Most RPCs are unary, while a few (`Backup`, for example) are streaming RPCs.
 
-### Enabling the new service
+### Enabling the New Service
 
 In order to enable the new service interface, add `grpc-vtctld` to the list of services in the `--service_map` flag provided to `vtctld`.
 Both the new and old interfaces may be run from the same `vtctld` instance, so during transition, most users will set `--service_map="grpc-vtctl,grpc-vtctld"`.
 
-### Transitioning clients
+### Transitioning Clients
 
 The new service implementation comes with a corresponding client implementation, which is called [`vtctldclient`][vtctldclient_docs].
 Most existing commands can be run directly from the new client, for example:

--- a/content/en/docs/21.0/reference/vtorc/architecture.md
+++ b/content/en/docs/21.0/reference/vtorc/architecture.md
@@ -29,7 +29,7 @@ stateDiagram-v2
   problems --> fixes: RPCs to Vttablets
 ```
 
-# Coordination among VTOrc instances and `vtctld`
+# Coordination among VTOrc Instances and `vtctld`
 
 Users are encouraged to run multiple instances of VTOrc monitoring the same cluster because VTOrc too, like any other service is liable to failure
 for reasons out of its control. Also, users run `vtctld` instances which can be used to run commands which alter the desired topology ([PlannedReparentShard](../../../user-guides/configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting))

--- a/content/en/docs/21.0/user-guides/configuration-advanced/authorization.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/authorization.md
@@ -23,7 +23,7 @@ characteristics:
  * Permissions are applied on a specified set of tables, which can be
    enumerated or specified by regex.
 
-## VTTablet parameters for table ACLs
+## VTTablet Parameters for Table ACLs
 
 Note that the Vitess authorization via ACLs are applied at the VTTablet
 level, as opposed to on VTGate, where authentication is enforced.
@@ -58,7 +58,7 @@ behavior of ACLs.  Let's review these:
    VTTablet to reload the ACL config file from disk by sending a SIGHUP
    signal to your VTTablet process.
 
-## Warning regarding ACL reloading
+## Warning Regarding ACL Reloading
 
 If you choose to reload the ACL config manually or on an interval,
 and you are using the `-enforce-tableacl-config` option, your VTTablet
@@ -68,7 +68,7 @@ the highest level of security. Accordingly, it is very important to test
 your ACL config thoroughly before applying, pay attention to access
 permissions on the ACL config file, etc.
 
-## Format of the table ACL config file
+## Format of the Table ACL Config File
 
 The file specified in the `--table-acl-config` parameter above is a JSON
 file with the following example to explain the format:

--- a/content/en/docs/21.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -181,7 +181,6 @@ vtgate_buffer_requests_skipped{keyspace="commerce",reason="Shutdown",shard_name=
 
 NOTE: Once again no queries are being buffered in these examples.
 
-
 ### Scenario 3: Solving with Buffering
 
 Another approach to this problem, is to employ buffering on vtgate. It is highly
@@ -257,8 +256,6 @@ vtgate_buffer_requests_skipped{keyspace="commerce",reason="Shutdown",shard_name=
 NOTE: You will see each of our 6 established connections were buffered during
 the PRS event.
 
-
-
 ### Scenario 4: Quickly issued PRS events
 
 In this scenario we are going to look at the buffering behavior when quickly
@@ -327,8 +324,6 @@ should be doing. Another way to handle the issue is to ensure you are waiting
 for the `--buffer_min_time_between_failovers` timer to expire before issuing
 the next PlannedReparentShard command.
 
-
-
 ### Scenario 5: Too many connections
 
 Another aspect to be aware of is the `--buffer_size`. For this scenario we will
@@ -387,8 +382,6 @@ vtgate_buffer_requests_skipped{keyspace="commerce",reason="Shutdown",shard_name=
 NOTE: Here we can see the `BufferFull` metric set to 4 to let us know the buffer
 had an overflow.
 
-
-
 ### Scenario 6: Buffer time too Short
 
 In this scenario we are going to set the `buffer_window` to a short period of
@@ -442,8 +435,6 @@ vtgate_buffer_requests_skipped{keyspace="commerce",reason="Shutdown",shard_name=
 
 NOTE: Reviewing these results we can see value for `WindowExceeded` at 6;
 informing us the `buffer_window` was not long enough for these request.
-
-
 
 ### Scenario 7: Replica never becomes Primary
 

--- a/content/en/docs/21.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/comment-directives.md
@@ -26,7 +26,7 @@ ERROR 1317 (70100): target: keyspace1.0.primary: vttablet: rpc error: code = Dea
 
 As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in milliseconds.
 
-### Limitation and caveats:
+### Limitation and Caveats:
 
 - Only works for `SELECT` (read) queries.
 - Does not work when doing manual shard-targeting. See [this issue](https://github.com/vitessio/vitess/issues/7031).
@@ -36,7 +36,7 @@ As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in millisec
 
 Using this in, for example, an insert statement will cause individual shard autocommit to be used for the shards where the rows for the insert are routed. This means that if one of the individual shard inserts fails, it will not be possible to roll back the inserts on all the other shards. This is the default behavior. A helpful way to think of this is as best-effort cross-shard writes, with the application being responsible for repairs in the case of errors. For an example, read our [Shard Isolation and Atomicity guide](../../configuration-advanced/shard-isolation-atomicity/#method-1--the-naive-way).
 
-## Skip query plan cache (`SKIP_QUERY_PLAN_CACHE`)
+## Skip Query Plan Cache (`SKIP_QUERY_PLAN_CACHE`)
 
 Vitess maintains a query/plan cache in both `vtgate` and `vttablet`. These caches serve different purposes:
 
@@ -47,25 +47,25 @@ The `SKIP_QUERY_PLAN_CACHE` comment directive tells `vttablet` to skip caching t
 
 Since vttablet places a memory size limit on the query cache, it is much less likely for this cache to get overrun by queries like bulk inserts. As a result, it should be less necessary to use this comment directive, other than as a performance optimization.  Previously, it was unbounded in memory, or in other words it was only bounded by number of entries. At that point it might have been necessary to use to avoid vttablet out-of-memory (OOM) situations.
 
-## Scatter errors as warnings (`SCATTER_ERRORS_AS_WARNINGS`)
+## Scatter Errors as Warnings (`SCATTER_ERRORS_AS_WARNINGS`)
 
 Vitess will, by default, return only an error if any of the shards involved in a scatter query reports an error. This is important for strong correctness, however, in some cases it may be necessary or desirable to have Vitess return partial results from the available shards anyway. The application can then act accordingly based on the results.
 
 The `SCATTER_ERRORS_AS_WARNINGS` comment directive enables exactly this, by returning the partial results from the healthy shards in the scatter query, and returning the error(s) from the unhealthy shard(s) as warnings. The application can then potentially use the warning information to guide its subsequent action.
 
-## Ignore max payload size (`IGNORE_MAX_PAYLOAD_SIZE`)
+## Ignore Max Payload Size (`IGNORE_MAX_PAYLOAD_SIZE`)
 
 By default, Vitess will try to handle queries of any size. It is possible to use the `vtgate` parameter `--max_payload_size` (default unlimited) to limit the size of an incoming query to a certain number of bytes. Queries larger than this limit will then be rejected by `vtgate`.
 
 The `IGNORE_MAX_PAYLOAD_SIZE` comment directive allows a Vitess-aware application to bypass this limit, essentially setting it to the default of unlimited for that query.
 
-## Ignore max memory rows (`IGNORE_MAX_MEMORY_ROWS`)
+## Ignore Max Memory Rows (`IGNORE_MAX_MEMORY_ROWS`)
 
 By default, `vtgate` will allow intermediate results for things like in-vtgate sorting and joining, up to a maximum of number of rows per query. This is to avoid using massive amounts of memory in `vtgate`. This limit is set using the `vtgate` parameter `--max_memory_rows`, which defaults to 300,000. Note that this limit is not a direct memory usage limit, since 300,000 very large rows could still be a huge amount of memory.
 
 The `IGNORE_MAX_MEMORY_ROWS` comment directive allows a Vitess-aware application to bypass this limit, essentially setting it to an unlimited number of rows for that query. Since this override can result in very large, and even potentially effectively unbounded, amounts of memory being used by `vtgate`, it should be used with extreme caution.
 
-## Allow scatter (`ALLOW_SCATTER`)
+## Allow Scatter (`ALLOW_SCATTER`)
 
 In Vitess, it is possible to use the `vtgate` parameter `--no_scatter` to prevent `vtgate` from issuing scatter queries. Thus only queries that do not scatter will be allowed.
 
@@ -91,7 +91,7 @@ select /*vt+ PLANNER=gen4 */ * from user;
 
 Valid values are the same as for the planner flag - `Gen4`, `Gen4Greedy` and `Gen4Left2Right`.
 
-### Workload name (`WORKLOAD_NAME`)
+### Workload Name (`WORKLOAD_NAME`)
 
 Specifies the client application workload name. This does not affect query execution, but can be used to instrument
 some `vttablet` metrics to include a label specifying the workload name. It can be useful if you are interested in

--- a/content/en/docs/21.0/user-guides/configuration-advanced/query-consolidation.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/query-consolidation.md
@@ -3,6 +3,7 @@ title: Query Consolidation
 weight: 50
 aliases: []
 ---
+
 Query consolidation is a VTTablet feature meant to protect your database from an overload caused by a spike in QPS for a specific query.
 
 Without this feature enabled such spikes can completely overwhelm the database. With this feature enabled the following will occur: when a vttablet receives a query, if an identical query is already in the process of being executed, the query will then wait.

--- a/content/en/docs/21.0/user-guides/configuration-advanced/reparenting.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/reparenting.md
@@ -11,7 +11,7 @@ This document explains the types of reparenting that Vitess supports:
 * [Active reparenting](../../configuration-advanced/reparenting/#active-reparenting) occurs when Vitess manages the entire reparenting process.
 * [External reparenting](../../configuration-advanced/reparenting/#external-reparenting) occurs when another tool handles the reparenting process, and Vitess just updates its topology service, replication graph, and serving graph to accurately reflect primary-replica relationships.
 
-## MySQL requirements
+## MySQL Requirements
 
 ### GTIDs
 
@@ -20,7 +20,7 @@ Vitess requires the use of global transaction identifiers ([GTIDs](https://dev.m
 * During active reparenting, Vitess uses GTIDs to initialize the replication process and then depends on the GTID stream to be correct when reparenting. (During external reparenting, Vitess assumes the external tool manages the replication process.)
 * During resharding, Vitess uses GTIDs for [VReplication](../../../reference/vreplication), the process by which source tablet data is transferred to the proper destination tablets.
 
-### Semisynchronous replication
+### Semisynchronous Replication
 
 Vitess does not depend on [semisynchronous replication](https://dev.mysql.com/doc/refman/8.0/en/replication-semisync.html) but encourages its usage. Larger Vitess deployments typically do implement semisynchronous replication.
 
@@ -35,7 +35,7 @@ Both commands lock the Shard record in the global topology service. The two comm
 
 Both commands are both dependent on the global topology service being available, and they both insert rows in the topology service's `_vt.reparent_journal` table. As such, you can review your database's reparenting history by inspecting that table.
 
-### PlannedReparentShard: Planned reparenting
+### PlannedReparentShard: Planned Reparenting
 
 The `PlannedReparentShard` command reparents a healthy shard to a new primary. It can be used to initialize the shard primary when the shard is brought up. If it is used to change the primary of an already running shard, then both the current and new primary must be up and running. In case the current primary is down, use `EmergencyReparentShard` instead.
 
@@ -58,7 +58,7 @@ This command performs the following actions when used to initialize the first pr
 
 The new primary (if unspecified) is chosen using the configured [Durability Policy](../../configuration-basic/durability_policy).
 
-### EmergencyReparentShard: Emergency reparenting
+### EmergencyReparentShard: Emergency Reparenting
 
 The `EmergencyReparentShard` command is used to force a reparent to a new primary when the current primary is unavailable. The command assumes that data cannot be retrieved from the current primary because it is dead or not working properly.
 

--- a/content/en/docs/21.0/user-guides/configuration-advanced/shard-isolation-atomicity.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/shard-isolation-atomicity.md
@@ -21,7 +21,7 @@ When it comes to dealing with **isolation** and **atomicity** in the database se
 
 Before we dive in, let us state that in the simple case, where a read (`SELECT`) or write (`INSERT`, `UPDATE`, `DELETE`) only addresses data in a single shard, there are no cross-shard concerns, and in general, both the isolation and atomicity guarantees are similar (or the same) to that of MySQL.
 
-## Cross-shard isolation
+## Cross-shard Isolation
 
 Because cross-shard writes might not be [completely atomic](../shard-isolation-atomicity/#cross-shard-atomicity), cross-shard primary reads (even if they all go to the primary) might not display **isolation**, i.e. they may show partial results for in-flight cross-shard write operations. A simple example may be that the all the rows for a multi-valued insert might not become visible across all shards at the same time.
 
@@ -35,7 +35,7 @@ This is typically not a big issue for most applications, since so-called read-af
 
 If you perform replica or rdonly reads instead of primary reads (using the `@replica` or `@rdonly` Vitess dbname syntax extension), you will face the same issues you would if you read from a single MySQL replica instance. Accordingly, writes might not become visible for an extended period of time, depending on **replica lag**. That being said, since Vitess helps you to keep your individual primary instances smaller, replica lag should be less of an issue than it would be with an unsharded large MySQL setup.
 
-## Cross-shard atomicity
+## Cross-shard Atomicity
 
 When performing a write (`INSERT`, `UPDATE`, `DELETE`) across multiple shards, Vitess attempts to optimize performance, while also trying to ensure as much **atomicity** as possible. That is, Vitess will attempt to ensure that the whole write operation succeeds across all shards, or is rolled back.  However, if you think about what actually needs to happen across the multiple shards, achieving full atomicity across a (potentially large) number of shards can be very expensive. As a result, Vitess does not even try to guarantee cross-shard **isolation**, but rather focuses on trying to optimize cross-shard **atomicity**. The difference here is that while the results of a single transaction might not become visible across all shards in the same instant, Vitess does try to ensure that write failures on a subset of the shards are:
 
@@ -44,7 +44,7 @@ When performing a write (`INSERT`, `UPDATE`, `DELETE`) across multiple shards, V
 
 As an example, imagine an insert of 20 rows into a sharded table with 4 shards. There are many ways for Vitess to take an insert like this and perform the inserts to the backend shards:
 
-### Method 1:  The naive way
+### Method 1:  The Naive Way
 
 The first method would be to launch an autocommit insert of the subset of rows for each shard to the 4 shards. This would insert concurrently across the 4 shards, so would be great for performance. However, there are significant drawbacks:
 
@@ -77,7 +77,7 @@ INSERT /*vt+ MULTI_SHARD_AUTOCOMMIT=1 */ INTO t1 (c1) values (1),(2),(3),(4),(5)
 
 As can be seen from this output, we just issue all the inserts with the subset of values destined for each shard without any transactions.
 
-### Method 2:  The I-don't-want-this way (a.k.a. SINGLE)
+### Method 2:  The I-don't-want-this Way (a.k.a. SINGLE)
 
 In certain situations, a schema may be constructed in a fashion where cross-shard writes are very rare (or should not happen). In a situation like this Vitess provides for a transaction mode (set via the MySQL set statement `set transaction_mode = 'single'`) called **SINGLE**.  In this transaction mode, any write that needs to span multiple shards will fail with an error. Similarly, any **transactional read** (i.e. using `BEGIN` & `COMMIT`) that spans multiple shards will also get an error.
 
@@ -129,7 +129,7 @@ multi-db transaction attempted: [target:{keyspace:"ks1" shard:"c0-" tablet_type:
 ```
 
 
-### Method 3:  The default way
+### Method 3:  The Default Way
 
 By default, Vitess employs a default setting for `transaction_mode` of **MULTI** (`set transaction_mode = 'multi'`).  This mode is a tradeoff between atomicity, isolation and performance, where Vitess will attempt to minimize (but not guarantee) the chances of a partial cross-shard update.  What Vitess does in a case like this is:
 
@@ -195,6 +195,6 @@ In TWOPC mode, Vitess uses the `_vt` sidecar database to record metadata related
 Unfortunately, we cannot use `vtexplain` to illustrate the working of TWOPC mode.
 
 
-## In closing
+## In Closing
 
 From the above examples, it should be clear that as the number of shards increase, large write operations that span multiple shards become more problematic from a performance point of view. It is therefore important for Vitess keyspaces (databases) that will span a large number of shards to be designed in a way that individual writes will affect a minimum of shards.

--- a/content/en/docs/21.0/user-guides/configuration-advanced/static-auth.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/static-auth.md
@@ -57,7 +57,7 @@ $ mysql -h 127.0.0.1 -u myuser1 -pincorrect_password -e "select 1"
 ERROR 1045 (28000): Access denied for user 'myuser1'
 ```
 
-## Password format
+## Password Format
 
 In the above example we used plaintext passwords.  Vitess supports the
 MySQL [mysql_native_password](https://dev.mysql.com/doc/refman/8.0/en/native-pluggable-authentication.html)
@@ -115,7 +115,7 @@ equivalent to the authorization layer (i.e. multiple users having the same
 `UserData` strings), but are different in the authentication layer (i.e.
 have different usernames and passwords).
 
-## Multiple passwords
+## Multiple Passwords
 
 A very convenient feature of the VTGate authorization is that, as can be
 seen in the example JSON authentication files, you have a **list** of

--- a/content/en/docs/21.0/user-guides/configuration-advanced/tracing.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/tracing.md
@@ -4,15 +4,15 @@ weight: 40
 aliases: ['/docs/user-guides/tracing/'] 
 ---
 
-# Vitess tracing
+# Vitess Tracing
 
 Vitess allows you to generate Jaeger / OpenTracing compatible trace events from the Vitess major server components: `vtgate`, `vttablet`, and `vtctld`. To sync these trace events you need an OpenTracing compatible server (e.g. Jaeger). Vitess can send tracing events to this server in the Jaeger compact Thrift protocol wire format which is usually UDP on port 6381.
 
-## Configuring tracing
+## Configuring Tracing
 
 The first step of configuring tracing is to make sure you have tracing collectors properly setup. The tracing collectors must be located where they can be reached from the various Vitess components on which you want to configure tracing.  We will not cover the entire setup process in this guide. The guide will cover the minimal config for testing/running locally, using the Jaeger docker container running on `localhost`. You can read more about Jaeger [here](https://www.jaegertracing.io/docs/1.20/features/).
 
-### Running Jaeger in docker
+### Running Jaeger in Docker
 
 You can follow the Jaeger getting started documentation [here](https://www.jaegertracing.io/docs/1.20/getting-started/). In essence you need to run the Jaeger docker container:
 
@@ -32,7 +32,7 @@ $ docker run -d --name jaeger \
 
 Note that you don't need to expose all these ports, Vitess only cares about port 6831 (the UDP compact Thrift Jaeger protocol listener). You will also need port 16686 for the Jaeger web UI to browse the spans reported.
 
-### Configuring tracing for vtgate, vttablet and vtctld
+### Configuring Tracing for vtgate, vttablet and vtctld
 
 Now that you have the Jaeger server running, you can add the necessary startup options to `vtgate`, `vttablet` and `vtctld`. This will enable you to send trace spans to the server.  The command line options for doing this are the same across `vtgate`, `vttablet` and `vtctld`. Add the following options for a tracing agent running on the `localhost`:
 
@@ -69,7 +69,7 @@ Now that you have the Vitess components setup, you can start instrumenting your 
     * The underlying tracing libraries are very particular about the base64 value, so if you have any formatting problems (including trailing spaces between the base64 value and the closing of the comment); you will get many warnings in your `vtgate` logs.
     * When testing with, for example, the `mysql` CLI tool, make sure you are using the `-c` (or `--comments` flag), since the default is `--skip-comments`, which will never send your comments to the server (`vtgate`).
 
-### Inspecting trace spans in the Jaeger web UI
+### Inspecting Trace Spans in the Jaeger Web UI
 
 This is beyond the scope of this guide. However, in general, if you have set everything above up correctly and you have instrumented and executed some queries appropriately, you can now access the Jager web UI to look at the spans recorded. If you are using the local docker container version of Jaeger, you can access the web UI in your browser at http://localhost:16686/. 
 

--- a/content/en/docs/21.0/user-guides/configuration-advanced/transport-security-model.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/transport-security-model.md
@@ -22,7 +22,7 @@ It should also be noted that while Vitess provides the mechanism for securing th
 
 Indeed, the hardest part of deploying TLS with Vitess in a large organization may be to integrate with whatever certificate policies and procedures the organization mandates. It should be noted that the manual issuing and rotation of certificates in a Vitess environment of a non-trivial size is impractical, and some provisioning and configuration management automation will need to be built.
 
-## Protocols involved
+## Protocols Involved
 
 Of all the data, meta-data and control paths enumerated above, they use one of three protocols:
 
@@ -49,7 +49,7 @@ All three the protocol types above use TLS in one form or another to encrypt com
     * If required, adjust other Vitess component options to enforce/require
       TLS-only communications.
 
-## Server authentication
+## Server Authentication
 
 In addition to encrypting the connection, you may want or need to configure client-side server authentication.  This is the process by which the client verifies that the server it is trying to establish a TLS connection to is who they claim to be, and not an imposter or man-in-the-middle.  We achieve this by:
 
@@ -57,7 +57,7 @@ In addition to encrypting the connection, you may want or need to configure clie
     * Install the CA cert used by your certificate issuing process to sign the server component certificates.
     * Adjust the Vitess client component options to verify the server certificate using the installed CA cert.  This would typically involve specifying the CA cert, as well as the server or common name to expect from the server component, if it isn't the same as the DNS name (or has an IP SAN configured).
 
-## Client authentication
+## Client Authentication
 
 Client authentication in Vitess can take two forms, depending on the protocol in question:
 
@@ -68,7 +68,7 @@ Client authentication in Vitess can take two forms, depending on the protocol in
 
 We will now cover how to setup the various TLS component combinations. We will start with the data path, then move on to the control paths. We will handle [encryption](#encryption) and [server authentication](#server-authentication) together, and then handle [client authentication](#client-authentication) separately.
 
-### Certificate generation
+### Certificate Generation
 
 As discussed above, large organizations will often have established tools to secure a TLS certificate hierarchy and issue certificates. For the purpose of these walkthroughs, we could use bare `openssl` commands to step through every detail. However, since we consider this an implementation detail that is likely to vary from user to user, we will leverage a shell-script-based tool called [easy-rsa](https://github.com/OpenVPN/easy-rsa) that uses `openssl` under the covers, and hides much of the complexity.
 
@@ -371,7 +371,7 @@ If you just wish to encrypt the vttablet -> MySQL server communication and you d
 
 Note that using the above `db_flags` will also result in the MySQL to MySQL communication for replication between the replica/rdonly instances of a Vitess shard and its primary to be encrypted, as long as the upstream MySQL instance the replica is connecting to has been configured correctly to support TLS MySQL protocol connections (see above).
 
-## vttablet data and control paths
+## vttablet Data and Control Paths
 
 In Vitess, communication between vtgate and vttablet instances are via gRPC. gRPC uses HTTP/2 as a transport protocol, but by default this is not encrypted in Vitess.  To secure this data path you need to, at a minimum, configure TLS for gRPC on the server (vttablet) side.
 
@@ -495,7 +495,7 @@ In case of VTOrc, you will need to add following to VTOrc instance to successful
   --tablet_manager_grpc_server_name vttablet1 --tablet_manager_grpc_ca /home/user/config/ca.crt
 ```
 
-#### vttablet to vtablet:  vreplication within or across shards
+#### vttablet to vtablet:  vreplication within or Across Shards
 
 For vreplication to work between vttablet instances once the gRPC server TLS options above are activated, you will need to add the following additional vttablet options:
 
@@ -616,7 +616,7 @@ At this point, all vtctldclient connections to vtctld will need the appropriate 
   --vtctld_grpc_ca /home/user/config/ca.crt --vtctld_grpc_server_name vtctld1
 ```
 
-## Topology server data paths
+## Topology Server Data Paths
 
 Vitess supports several topology server implementations, with the major ones being `etcd` and `ZooKeeper`. Since each of these use their own protocols, securing communications between Vitess components (like vtgate, vttablet and vtctld) and the topology server is specific to the topology server implementation.  We we will cover `etcd` first, then `ZooKeeper`.
 
@@ -628,11 +628,11 @@ It should be noted that regardless of the implementation, no sensitive data is s
  * Only metadata (VSchema, keyspace and shard information) is stored in the
    topology server data store.
 
-### Configuring etcd for secure connections
+### Configuring etcd for Secure Connections
 
 We will not cover setting up `etcd` with certificates in this guide. You can consult the `etcd` documenation [here](https://etcd.io/docs/v3.5/op-guide/security/). Note that you can use `easy-rsa` as above to generate your server private key and certificate pairs. If you do not require client authentication, that is sufficient, and you then just have to distribute your CA certificate (`/home/user/CA/pki/ca.crt` in the examples above) to your clients, and proceed as in the next section.
 
-### Configuring secure connectivity between vtgate/vttablet/vtctld and etcd
+### Configuring Secure Connectivity between vtgate/vttablet/vtctld and etcd
 
 The Vitess servers (vtgate/vttablet/vtctld) share the same set of parameters to connect via TLS to `etcd`:
 
@@ -642,7 +642,7 @@ The Vitess servers (vtgate/vttablet/vtctld) share the same set of parameters to 
 
 As is necessary for your design/architecture, add one or more of the above options to your vtgate, vttablet and vtctld instances.
 
-### Configuring etcd for secure connections
+### Configuring etcd for Secure Connections
 
 We will just mention the basic flags here for getting `etcd` to accept encrypted client connections.  We will not cover the flags to make sure that communication between `etcd` cluster members (peers) are encrypted.
 
@@ -658,11 +658,11 @@ Note that the Vitess client components will negotiate any of the standard golang
 
 It is also possible to configure `etcd` to require/verify client certificates from the clients; for that use the `--trusted-ca-file` option to point to the PEM CA cert that the client certs are signed with.
 
-### Configuring ZooKeeper for secure connections
+### Configuring ZooKeeper for Secure Connections
 
 We will not cover setting up `Zookeeper` with certificates in this guide. You can consult the `Zookeeper` documenation [here](https://cwiki.apache.org/confluence/display/ZOOKEEPER/ZooKeeper+SSL+User+Guide), specifically the `Server` section. Note that you can use `easy-rsa` as above to generate your server private key and certificate pairs. If you do not require client authentication, that is sufficient, and you then just have to distribute your CA certificate (`/home/user/CA/pki/ca.crt` in the examples above) to your clients, and proceed as in the next section.
 
-### Configuring secure connectivity between vtgate/vttablet/vtctld and ZooKeeper
+### Configuring Secure Connectivity between vtgate/vttablet/vtctld and ZooKeeper
 
 The Vitess servers (vtgate/vttablet/vtctld) share the same set of parameters to connect via TLS to `Zookeeper`:
 
@@ -673,7 +673,7 @@ The Vitess servers (vtgate/vttablet/vtctld) share the same set of parameters to 
 
 As is necessary for your design/architecture, add one or more of the above options to your vtgate, vttablet and vtctld instances.
 
-## Generating client certificates with easy-rsa
+## Generating client Certificates with easy-rsa
 
 `easy-rsa` can also be used to generate client certificates (i.e for mTLS or mutual TLS).  Mutual TLS needs at least two additional parameters on the client side, and one additional parameter on the server side:
 

--- a/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -10,7 +10,7 @@ This guide follows on from the [local](../../../get-started/local) installation 
 
 This guide uses the Vitess components vtctld, Topology Service and VTGate which have already been started in the local installation guide. It assumes that you have an existing MySQL Server setup that you would like to add to Vitess as a new keyspace, which we will call `legacy`. The same set of steps can be used to create a tablet that uses Amazon RDS, AWS Aurora, or Google CloudSQL.
 
-## Ensure all components are up
+## Ensure all Components are Up
 
 You should have previously executed `./101_initial_cluster.sh` in the get-started guide. This will ensure that you have a Topology Service, vtgate, vtctld. For the unmanaged MySQL instance, I will be using an instance running on `127.0.0.1:5726`:
 
@@ -48,7 +48,7 @@ mysql: [Warning] Using a password on the command line interface can be insecure.
 +------------------+
 ```
 
-## Start a tablet to correspond to legacy
+## Start a Tablet to Correspond to Legacy
 
 The variables `TOPOLOGY_FLAGS` and `VTDATAROOT` should already be in the environment from sourcing env.sh earlier. We will call the new tablet UID 401.
 
@@ -117,7 +117,7 @@ mysql> select corder.order_id from corder inner join legacy.legacytable on corde
 Empty set (0.01 sec)
 ```
 
-## Move legacytable to the commerce keyspace
+## Move legacytable to the Commerce Keyspace
 
 Move the table:
 

--- a/content/en/docs/21.0/user-guides/configuration-basic/collations.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/collations.md
@@ -8,7 +8,7 @@ MySQL is a Unicode-aware database, and as explained on [the MySQL documentation]
 
 Likewise, Vitess is also Unicode-aware, and it supports the vast majority of the collations and charsets in the underlying MySQL server. On a basic level, this support means that Vitess handles gracefully textual Unicode columns and queries, and relays this information to MySQL clients without losing or corrupting the encoding of the data. On top of this, newer versions of Vitess are also capable of performing textual comparison and sorting operations in SQL queries directly on VTGate instances, greatly speeding up complex operations such as cross-shard joins.
 
-### Supported collations
+### Supported Collations
 
 The collation environment (i.e. the set of support collations and charsets) of a Vitess cluster is defined by the MySQL server version flag (`--mysql_server_version`) provided to the VTGate and VTTablet instances in the cluster. Higher (newer) MySQL versions will enable built-in support for more collations.
 
@@ -400,7 +400,7 @@ Using collations that are not supported by Vitess but implemented in the underly
 | utf8mb4_unicode_nopad_ci | utf8mb4 | ❌ | ❌ | ❌ | ⚠️ | ⚠️ | ❌ | ❌ |
 | utf8mb4_unicode_520_nopad_ci | utf8mb4 | ❌ | ❌ | ❌ | ⚠️ | ⚠️ | ❌ | ❌ |
 
-### Configuring the default connection charset for a Vitess cluster
+### Configuring the Default Connection Charset for a Vitess Cluster
 
 **The default connection charset for a Vitess cluster is configured in your VTTablet instances** via the `--db_charset` flag. This flag modifies the behavior of the _connections_ that the tablet creates, not the underlying MySQL instance: it defines the charset that VTTablet uses when opening connections to MySQL.
 If the `--db_charset` flag is left empty, VTTablet will default to an `utf8mb4` charset based on the underlying MySQL version. For instance, MySQL 5.x will default to `utf8mb4_general_ci`, while MySQL 8.x defaults to `utf8mb4_0900_ai_ci`. Because the handshake packet of MySQL leaves only 1 byte to reference the charset ID, only charset IDs <= 255 are supported.

--- a/content/en/docs/21.0/user-guides/configuration-basic/create-cell.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/create-cell.md
@@ -24,7 +24,7 @@ The cell information is saved in the global toposerver. Vitess takes care of dep
 You will only need to specify the topo global root for launching the Vitess servers. The cell-specific information including its root path will be automatically loaded from the cell info.
 {{< /info >}}
 
-## Mapping cells to zones and regions
+## Mapping Cells to Zones and Regions
 
 Most public clouds offer a hierarchy of failure boundaries. Regions are data centers that are far apart. Depending on the distance, the latency between two regions can be in the 10s to 100s of milliseconds. Zones are partitions within a region where the machines are in different buildings. Latency between zones is typically in the range of sub-millisecond to 1-2ms.
 

--- a/content/en/docs/21.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/global-topo.md
@@ -36,7 +36,7 @@ Note that the topo implementation for etcd is `etcd2`. This is because Vitess us
 To be safe, you may want to bring up etcd with `--enable-v2=true`, even though it is the default value. Also, you will need to set the `ETCDCTL_API=2` environment variable before bringing up etcd.
 {{< /info >}}
 
-## Moving to a different TopoServer
+## Moving to a Different TopoServer
 
 It is generally not recommended that you migrate from one type of toposerver to another. However, if absolutely necessary, you can use the [topo2topo](../../../reference/features/topology-service/#migration-between-implementations) command line tool to perform this migration.
 

--- a/content/en/docs/21.0/user-guides/configuration-basic/planning.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/planning.md
@@ -33,7 +33,7 @@ Vitess resource consumption is mostly driven by QPS, but there may be variations
 
 Resources for other servers like the toposerver, vtctld, Vtadmin and VTOrc are minimal. They are likely not going to exceed one CPU per server instance.
 
-## Environment variables
+## Environment Variables
 
 Setting up a few environment variables upfront will improve the manageability of the system:
 

--- a/content/en/docs/21.0/user-guides/configuration-basic/ports.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/ports.md
@@ -3,7 +3,8 @@ title: Ports
 weight: 16
 aliases: ['/docs/launching/server-configuration/', '/docs/user-guides/server-configuration/', '/docs/user-guides/configuring-components/']
 ---
-# Ports and Network interactions in Vitess
+
+# Ports and Network Interactions in Vitess
 
 Many/most of these ports are fully configurable, but we are listing their
 defaults or the defaults we use in examples here. Your

--- a/content/en/docs/21.0/user-guides/configuration-basic/vtorc.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/vtorc.md
@@ -8,7 +8,6 @@ An overview of the architecture of VTOrc can be found on this [page](../../../re
 
 Setting up VTOrc lets you avoid performing the `InitShardPrimary` step. It automatically detects that the new shard doesn't have a primary and elects one for you.
 
-
 ### Flags
 
 For a full list of supported flags, please look at [VTOrc reference page](../../../reference/programs/vtorc).
@@ -17,7 +16,7 @@ For a full list of supported flags, please look at [VTOrc reference page](../../
 
 For information about the UI, API and metrics that VTOrc exports, please consult this [page](../../../reference/vtorc/ui_api_metrics).
 
-### Example invocation of VTOrc
+### Example Invocation of VTOrc
 
 You can bring VTOrc using the following invocation:
 
@@ -35,12 +34,11 @@ vtorc --topo_implementation etcd2 \
 
 You can optionally add a `clusters_to_watch` flag that contains a comma separated list of keyspaces or `keyspace/shard` values. If specified, VTOrc will manage only those clusters.
 
-
 ### Durability Policies
 
 All the failovers that VTOrc performs will be honoring the [durability policies](../../configuration-basic/durability_policy). Please be careful in setting the
 desired durability policies for your keyspace because this will affect what situations VTOrc can recover from and what situations will require manual intervention.
 
-### Running VTOrc using the Vitess Operator
+### Running VTOrc Using the Vitess Operator
 
 To find information about deploying VTOrc using Vitess Operator please take a look at this [page](../../../reference/vtorc/running_with_vtop).

--- a/content/en/docs/21.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -164,7 +164,7 @@ vttablet <topo_flags> <backup_flags> \
   --queryserver-config-stream-pool-size= 16
 ```
 
-### Key configuration notes
+### Key Configuration Notes
 
 * It is important to set MySQL’s `max_connections` property to be 50%-100% higher than the total number of connections in the various pools. 
 	* This is because Vitess may have to kill connections and open new ones. MySQL accounting has a delay in how it counts closed connections, which may cause its view of the number of connections to exceed the ones currently opened by Vitess. For example, in the above example, the `max_connections` settings should be around 800.

--- a/content/en/docs/21.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/21.0/user-guides/migration/move-tables.md
@@ -69,7 +69,7 @@ Notice that all of the tables are currently in the `commerce` schema/keyspace he
 
 In this scenario, we are going to add the `customer` [keyspace](../../../concepts/keyspace) in addition to the `commerce` keyspace we already have.  This new keyspace will be backed by its own set of mysqld instances. We will then move the `customer` and `corder` tables from the `commerce` keyspace to the newly created `customer` keyspace while the `product` table will remain in the `commerce` keyspace. This operation happens online, which means that it does not block either read or write operations to the tables, *except* for a very small window during the final cut-over.
 
-## Show our current tablets
+## Show our Current Tablets
 
 ```bash
 $ mysql -e "show vitess_tablets"

--- a/content/en/docs/21.0/user-guides/migration/troubleshooting.md
+++ b/content/en/docs/21.0/user-guides/migration/troubleshooting.md
@@ -73,7 +73,6 @@ Those can later be applied this way:
 $ vtctldclient ApplyRoutingRules --rules-file=/tmp/routingrules.backup.json
 ```
 
-
 ## Specific Errors and Issues
 
 ### Stream Never Starts
@@ -156,6 +155,7 @@ This can be caused by a DDL executed on the source table as by default — contr
 [`on-ddl` flag value](../../../reference/vreplication/vreplication/#handle-ddl) — DDL is ignored in the stream.
 
 #### Corrective Action
+
 If you want the same or similar DDL to be applied on the target then you can apply that DDL on the target keyspace
 and then restart the workflow. For example, using the example above:
 

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
@@ -5,6 +5,7 @@ aliases: ['/docs/user-guides/backup-and-restore/']
 ---
 
 Restores can be done automatically by way of seeding/bootstrapping new tablets, or they can be invoked manually on a tablet to restore a full backup or do a point-in-time recovery.
+
 ## Auto restoring a backup on startup
 
 When a tablet starts, Vitess checks the value of the `--restore_from_backup` command-line flag to determine whether to restore a backup to that tablet. Restores will always be done with whichever engine was used to create the backup.
@@ -36,11 +37,11 @@ Bootstrapping a new tablet is almost identical to restoring an existing tablet. 
 
 The bootstrapped tablet will restore the data from the backup and then apply changes, which occurred after the backup, by restarting replication.
 
-## Manual restore
+## Manual Restore
 
 A manual restore is done on a specific tablet. The tablet's MySQL server is shut down and its data is wiped out.
 
-### Restore a full backup
+### Restore a Full Backup
 
 To restore the tablet from the most recent full backup, run:
 
@@ -60,7 +61,7 @@ If successful, the tablet's MySQL server rejoins the shard's replication stream,
 
 Vitess supports restoring to a _timestamp_ or to a specific _position_. Either way, this restore method assumes backups have been taken that cover the specified position. The restore process will first determine a restore path: a sequence of backups, starting with a full backup followed by zero or more incremental backups, that when combined, include the specified timestamp or position. See more on [Restore Types](../overview/#restore-types) and on [Taking Incremental Backup](../creating-a-backup/#create-an-incremental-backup-with-vtctl).
 
-#### Restore to timestamp
+#### Restore to Timestamp
 
 Starting with `v18`, it is possible to restore to a given timestamp. The restore process will apply all events up to, and excluding, the given timestamp, at 1 second granularity. That is, the restore will bring the database to a point in time which is _about_ 1 second before the specified timestamp. Example:
 
@@ -70,7 +71,7 @@ vtctldclient RestoreFromBackup --restore-to-timestamp "2023-06-15T09:49:50Z" zon
 
 The timestamp must be in `RFC3339` format.
 
-#### Restore to a position
+#### Restore to a Position
 
 It is possible to restore onto a precise GTID position. Vitess will restore up to, and including, the exact requested position. This gives you the utmost granularity into the state of the restored database.
 
@@ -84,7 +85,7 @@ Example:
 vtctldclient RestoreFromBackup --restore-to-pos "MySQL56/0d7aaca6-1666-11ee-aeaf-0a43f95f28a3:1-60" zone1-0000000102
 ```
 
-#### Dry run
+#### Dry Run
 
 It is possible to verify whether a restore-to-timestamp or restore-to-pos is possible without actually performing the restore. Run:
 

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -4,7 +4,7 @@ weight: 2
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---
 
-## Choosing the backup type
+## Choosing the Backup Type
 
 As described in [Backup types](../overview/#backup-types), you choose to run a full Backup (the default) or an incremental Backup.
 
@@ -80,7 +80,7 @@ I0310 12:49:32.279773  215835 backup.go:163] I0310 20:49:32.279485 xtrabackupeng
 
 To continue with risk: Set `--xtrabackup_backup_flags=--no-server-version-check`. Note this occurs when your MySQL server version is technically unsupported by `xtrabackup`.
 
-## Create a full backup with vtctl
+## Create a Full Backup with vtctl
 
 __Run the following vtctl command to create a backup:__
 
@@ -98,7 +98,7 @@ __Run the following vtctl command to backup a specific shard:__
 vtctldclient --server=<vtctld_host>:<vtctld_port> BackupShard [--allow_primary=false] [--upgrade-safe=false] <keyspace/shard>
 ```
 
-## Create an incremental backup with vtctl
+## Create an Incremental Backup with vtctl
 
 An incremental backup requires additional information: the point from which to start the backup. An incremental backup is taken by supplying `--incremental-from-pos` to the `Backup` or `BackupShard` command. The argument may either indicate:
 

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
@@ -17,9 +17,9 @@ This guide is useful only if you are using the vitess-operator.
 
 If you are not already familiar with [how backups work](../overview/) in Vitess we suggest you familiarize yourself with them first.
 
-## Scheduling backups
+## Scheduling Backups
 
-### Adding the schedule
+### Adding the Schedule
 
 {{< warning >}}
 Please note that is not recommended to run production backups every minute. These schedules are only an example.
@@ -47,7 +47,7 @@ example-vbsc-every-minute-customer-8aaaa771-1715963880-n7cm7   0/1     Completed
 ...
 ```
 
-### Listing backups
+### Listing Backups
 
 Now we can list the available backups, by getting the `vtb` (`VitessBackup`) objects in our Kubernetes cluster.
 We can see we have three backups, that is because the schedule `every-minute-customer` takes two backups (one for each shard, `-80` and `80-`),

--- a/content/en/docs/21.0/user-guides/schema-changes/_index.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/_index.md
@@ -18,7 +18,7 @@ It is recommended to use Vitess' managed, online schema changes.
 
 Some background on schema changes follows.
 
-## The schema change problem
+## The Schema Change Problem
 
 Schema change is one of the oldest problems in MySQL and in the relational world in general. With accelerated development and deployment flows, engineers find they need to deploy schema changes sometimes on a daily basis. With the growth of data this task becomes more and more difficult. A direct MySQL `ALTER TABLE` statement is a blocking (no reads nor writes are possible on the migrated table) and resource heavy operation; variants of `ALTER TABLE` include `InnoDB` [Online DDL](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html), which allows for some concurrency on a `primary` server, but still blocking on replicas, leading to unacceptable replication lags once the statement hits the replicas. 
 
@@ -28,7 +28,7 @@ MySQL's [Instant DDL](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-
 
 Such direct `ALTER TABLE` is fine in development or possibly staging environments, where datasets are either small, or where table locking is acceptable.
 
-## ALTER TABLE solutions
+## ALTER TABLE Solutions
 
 Busy production systems tend to use either of these two approaches, to make schema changes less disruptive to ongoing production traffic:
 
@@ -39,7 +39,7 @@ Busy production systems tend to use either of these two approaches, to make sche
   - Each migration requires a failover (aka _successover_, aka _planned reparent_).
   - Total wall clock time is higher since we run the same migration in sequence on different servers.
 
-## Schema change cycle and operation
+## Schema Change Cycle and Operation
 
 The cycle of schema changes, from idea to production, is complex, involves multiple environments and possibly multiple teams. Below is one possible breakdown common in production. Notice how even interacting with the database itself takes multiple steps:
 
@@ -59,7 +59,7 @@ The cycle of schema changes, from idea to production, is complex, involves multi
 
 Steps `4` - `10` are tightly coupled with the database or with the infrastructure around the database.
 
-## Schema change and Vitess
+## Schema Change and Vitess
 
 Vitess solves or automates multiple parts of the flow:
 
@@ -102,7 +102,7 @@ Vitess automatically garbage-collects the "old" tables, artifacts of `vitess`, `
 
 In the case of managed, online schema changes via `pt-online-schema-change`, Vitess will ensure to drop the triggers in case the tool failed to do so for whatever reason.
 
-## The various approaches
+## The Various Approaches
 
 Vitess allows a variety of approaches to schema changes, from fully automated to fully owned by the user.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/advanced-usage.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/advanced-usage.md
@@ -10,7 +10,7 @@ Listed below are recipes for advanced online DDL usage:
 - [Duplicate migration indication](#duplicate-migration-indication)
 - [Near instant REVERTs](#near-instant-reverts)
 
-## Duplicate migration detection
+## Duplicate Migration Detection
 
 Two migrations sharing the same context and DDL are considered duplicate, and only one will run to completion.
 
@@ -59,7 +59,7 @@ mysql> alter table customer add column status int unsigned not null;
 
 By default, the migration context for an Online DDL issued via VTGate is the value of `@@session_uuid`. If `@@migration_context` is non-empty, then its value is used.
 
-## Duplicate migration indication
+## Duplicate Migration Indication
 
 You may go one step beyond [duplicate migration detection](#duplicate-migration-detection) by explicitly supplying migration UUIDs such that duplicate migrations are never submitted in the first place.
 
@@ -164,7 +164,7 @@ $ vtctldclient ApplySchema --sql "alter vitess_migration '3cc4ae0e_776f_11ec_a65
 
 Which means we want to apply the revert. Since the revert is already running in the background, it is likely that binary log processing is up to date, and cut-over is near instantaneous.
 
-## Inter-dependent migrations
+## Inter-dependent Migrations
 
 It is possible to submit inter-dependent migrations within the same `ApplySchema` command, and have them complete in the correct order, even if they run concurrently. Examples for inter-dependent migrations:
 

--- a/content/en/docs/21.0/user-guides/schema-changes/audit-and-control.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/audit-and-control.md
@@ -22,7 +22,7 @@ Supported interactions are:
 - [Cleaning migration artifacts](#cleaning-migration-artifacts)
 - [Reverting a migration](#reverting-a-migration)
 
-## Running migrations
+## Running Migrations
 
 To run a managed schema migration, you should:
 
@@ -78,7 +78,7 @@ d72d230d_6b52_11ee_808b_0a43f95f28a3
 - `--migration-context <unique-value>`: all migrations in a `ApplySchema` command are logically grouped via a unique _context_. A unique value will be supplied automatically. The user may choose to supply their own value, and it's their responsibility to provide with a unique value. Any string format is accepted.
   The context can then be used to search for migrations, via `SHOW VITESS_MIGRATIONS LIKE '<the-context>'`. It is visible in `SHOW VITESS_MIGRATIONS ...` output as the `migration_context` column.
 
-## Tracking migrations
+## Tracking Migrations
 
 You may track the status of a single or of multiple migrations. Since migrations run asycnhronously, it is the user's responsibility to audit the progress and state of submitted migrations. Users are likely to want to know when a migration is complete (or failed) so as to be able to deploy code changes or run other operations.
 
@@ -285,7 +285,7 @@ Or launch all:
 $ vtctldclient ApplySchema --sql "alter vitess_migration launch all" commerce
 ```
 
-## Completing a migration
+## Completing a Migration
 
 Migrations submitted with [`--postpone-completion`](../postponed-migrations) remain `ready` or `running` until told to complete. The user may complete a specific migration or they may complete all postponed migrations:
 
@@ -328,7 +328,7 @@ $ vtctldclient OnlineDDL complete commerce 9e8a9249_3976_11ed_9442_0a43f95f28a3
 }
 ```
 
-## Forcing a migration cut-over
+## Forcing a Migration cut-over
 
 Applicable to `ALTER TABLE` migrations in `vitess` strategy and on MySQL `8.0`. The final step of the migration, the cut-over, involves acquiring locks on the migrated table. This operation can time out when the table is otherwise locked by the user or the app, in which case Vitess retries it later on, until successful. On very busy workloads, or in workloads where the app holds long running transactions locking the table, the migration may never be able to complete.
 
@@ -389,7 +389,7 @@ $ vtctldclient OnlineDDL force-cutover commerce all
 }
 ```
 
-## Cancelling a migration
+## Cancelling a Migration
 
 The user may cancel a migration, as follows:
 
@@ -544,7 +544,7 @@ $ vtctldclient OnlineDDL cancel commerce all
 }
 ```
 
-## Retrying a migration
+## Retrying a Migration
 
 The user may retry running a migration. If the migration is in `failed` or in `cancelled` state, Vitess will re-run the migration, with exact same arguments as previously intended. If the migration is in any other state, `retry` does nothing.
 
@@ -626,7 +626,7 @@ $ vtctldclient OnlineDDL retry customer 075088b9_6b56_11ee_808b_0a43f95f28a3
 }
 ```
 
-## Cleaning migration artifacts
+## Cleaning Migration Artifacts
 
 Migrations yield artifacts: these are leftover tables, such as the ghost or shadow tables in an `ALTER` DDL. These tables are audited and collected as part of [table lifecycle](../table-lifecycle/).
 
@@ -673,7 +673,7 @@ $ vtctldclient OnlineDDL cleanup customer 075088b9_6b56_11ee_808b_0a43f95f28a3
 }
 ```
 
-## Reverting a migration
+## Reverting a Migration
 
 Vitess offers _lossless revert_ for online schema migrations: the user may regret a table migration after completion, and roll back the table's schema to previous state _without loss of data_. See [Revertible Migrations](../revertible-migrations/).
 
@@ -742,7 +742,7 @@ Create Table: CREATE TABLE `corder` (
 $ vtctldclient ApplySchema --ddl-strategy "vitess" --sql "revert vitess_migration '1a689113_8d77_11eb_815f_f875a4d24e90'" commerce
 ```
 
-## Controlling throttling
+## Controlling Throttling
 
 Managed migrations [use](../managed-online-schema-changes/#throttling) the [tablet throttler](../../../reference/features/tablet-throttler/) to ensure a sustainable impact to the MySQL servers and replication stream. Normally, the user doesn't need to get involved, as the throttler auto-identifies load scenarios, and pushes back on migration progress. However, Vitess makes available these commands for additional control over migration throttling:
 
@@ -756,7 +756,7 @@ show vitess_throttled_apps;
 
 **Note:** the tablet throttler must be enabled for these command to run.
 
-### Throttling a migration
+### Throttling a Migration
 
 To fully throttle a migration, run:
 
@@ -772,7 +772,7 @@ You may supply either or both these options: `expire`, `ratio`:
 - `alter vitess_migration 'aa89f255_8d68_11eb_815f_f875a4d24e90' throttle expire '2h'` will fully throttle the migration for the next `2` hours, after which the migration resumes normal work. You may specify these units: `s` (seconds), `m` (minutes), `h` (hours) or combinations. Example values: `90s`, `30m`, `1h`, `1h30m`, etc.
 - `alter vitess_migration 'aa89f255_8d68_11eb_815f_f875a4d24e90' throttle ratio 0.7` will partially throttle the migration. This instructs the throttler to reject, on average, `7` migration throttling check requests out of `10`. Any value between `0` (no throttling at all) and `1.0` (fully throttled) are allowed. This is a fine tune way to slow down a migration.
 
-### Throttling all migrations
+### Throttling All Migrations
 
 It's likely that you will want to throttle migrations in general, and not a specific migration. Use:
 
@@ -790,7 +790,7 @@ Use:
 
 **Note** that this does not disable throttling altogether. If, for example, replication lag grows on replicas, the throttler may still throttle the migration until replication is caught up. Unthrottling only cancels an explicit throttling request as described above.
 
-### Showing throttled apps
+### Showing Throttled Apps
 
 The command `show vitess_throttled_apps` is a general purpose throttler command, and shows all apps for which there are throttling rules. It will list any specific or general migration throttling status.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/concurrent-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/concurrent-migrations.md
@@ -6,7 +6,7 @@ aliases: ['/docs/user-guides/schema-changes/concurrent-migrations/']
 
 By default, Vitess schedules all migrations to run sequentially. Only a single migration is expected to run at any given time. However, there are cases for concurrent execution of migrations, and the user may request concurrent execution via `--allow-concurrent` flag in `ddl_strategy`.
 
-## Why not run concurrent migrations by default
+## Why not Run Concurrent Migrations by Default
 
 At the heart of schema migration management we are interested in `ALTER` DDLs that run for long periods of time. These will copy large amounts of data, perform many reads and writes, and overall affect the production server. They use built-in throttling mechanism to prevent harming production. The migration essentially competes with production traffic over resources.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/ddl-strategies.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/ddl-strategies.md
@@ -57,7 +57,7 @@ mysql> alter table corder force;
 +--------------------------------------+
 ```
 
-## Choosing a DDL strategy
+## Choosing a DDL Strategy
 
 Different strategies have different behavior for `ALTER` statements. Sections below first break down specific handling and notes for each strategy, followed by an evaluation of the differences.
 
@@ -134,7 +134,7 @@ Do not override the following flags: `alter, pid, plugin, dry-run, execute, new-
 `pt-osc` strategy is **experimental** and slated to be removed in future versions.
 {{< /warning >}}
 
-### Comparing the options
+### Comparing the Options
 
 There are pros and cons to using any of the strategies. Some notable differences:
 
@@ -171,7 +171,7 @@ There are pros and cons to using any of the strategies. Some notable differences
   `pt-online-schema-change` partially supports foreign keys.
   `gh-ost` does not allow making changes to a table participating in a foreign key relationship.
 
-## Vitess functionality comparison
+## Vitess Functionality Comparison
 
 | Strategy | Managed | Online | Trackable | Declarative | Revertible          | Recoverable | Backoff |
 |----------|---------|--------|-----------|-------------|---------------------|-------------|---------|

--- a/content/en/docs/21.0/user-guides/schema-changes/ddl-strategy-flags.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/ddl-strategy-flags.md
@@ -6,7 +6,7 @@ aliases: ['/docs/user-guides/schema-changes/ddl-strategy-flags/']
 
 [`ddl_strategy`](../ddl-strategies) accepts flags in command line format. The flags can be vitess-specific, or, if unrecognized by Vitess, are passed on the underlying online schema change tools.
 
-## Vitess flags
+## Vitess Flags
 
 Vitess respects the following flags. They can be combined unless specifically indicated otherwise:
 
@@ -47,7 +47,7 @@ Vitess respects the following flags. They can be combined unless specifically in
 
   It does not make sense to combine `--singleton` and `--singleton-context`.
 
-## Pass-through flags
+## Pass-through Flags
 
 Flags unrecognized by Vitess are passed on to the underlying schema change tools. For example, a `gh-ost` migration can run with:
 ```sql

--- a/content/en/docs/21.0/user-guides/schema-changes/declarative-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/declarative-migrations.md
@@ -96,7 +96,7 @@ set @@ddl_strategy='gh-ost --declarative --max-load=Threads_running=100';
 
 Vitess notes down the `--declarative` flag and does not pass it to `gh-ost`, `pt-osc` or `VReplication`.
 
-## Implementation details
+## Implementation Details
 
 The user submits a declarative DDL. Tables schedule the migration to execute, but at time of execution, may modify the migration on the fly and end up running a different migration.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/managed-online-schema-changes.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/managed-online-schema-changes.md
@@ -32,7 +32,7 @@ As general overview:
   - `ALTER VIEW` and `DROP VIEW` are internally modified to allow quick revert.
 - Vitess provides the user a mechanism to view migration status, launch (if required), complete (if required), cancel or retry migrations, based on the job ID.
 
-## Syntax and supported statements
+## Syntax and Supported Statements
 
 Online DDL applies to the following statements:
 
@@ -164,7 +164,7 @@ $ vtctldclient ApplySchema --ddl-strategy "vitess" --sql "ALTER TABLE demo MODIF
 - `--migration_context <unique-value>`: all migrations in a `ApplySchema` command are logically grouped via a unique _context_. A unique value will be supplied automatically. The user may choose to supply their own value, and it's their responsibility to provide with a unique value. Any string format is accepted.
   The context can then be used to search for migrations, via `SHOW VITESS_MIGRATIONS LIKE 'the-context'`. It is visible in `SHOW VITESS_MIGRATIONS ...` output as the `migration_context` column.
 
-## Migration flow and states
+## Migration Flow and States
 
 A migration can be in any one of these states:
 
@@ -193,7 +193,7 @@ For more about internals of the scheduler and how migration states are controlle
 
   Example: `vtgate --enable_online_ddl=false` to disable access to Online DDL via `VTGate`.
  
-## Auto resume after failure
+## Auto Resume after Failure
 
 VReplication based migrations (`ddl_strategy="vitess"`) are [failover agnostic](../recoverable-migrations/). They automatically resume after either planned promotion ([PlannedReparentShard](../../configuration-advanced/reparenting/#plannedreparentshard-planned-reparenting)), emergency promotion ([EmergencyReparentShard](../../configuration-advanced/reparenting/#emergencyreparentshard-emergency-reparenting)) or completely external reparenting.
 
@@ -201,7 +201,7 @@ Once the new primary is in place and turns active, it auto-resumes the VReplicat
 
 The new primary must be available within `10 minutes`, or else the migration is considered to be stale and is aborted.
 
-## Auto retry after failure
+## Auto Retry after Failure
 
 Neither `gh-ost` and `pt-osc` are able to resume from point of failure, or after a failover. However, Vitess management can issue an automated retry (starting the migration afresh).
 
@@ -229,7 +229,7 @@ All three strategies: `vitess`, `gh-ost` and `pt-osc` utilize the tablet throttl
 
 **NOTE** that at this time (and subject to change) the tablet throttler is disabled by default. Enable it via `vtctldclient UpdateThrottlerConfig --enable <keyspace>`. If the tablet throttler is disabled, schema migrations will not throttle on replication lag.
 
-## Table cleanup
+## Table Cleanup
 
 All `ALTER` strategies leave artifacts behind. Whether successful or failed, either the original table or the _ghost_ table is left still populated at the end of the migration. Vitess explicitly makes sure the tables are not dropped at the end of the migration. This is for two reasons:
 

--- a/content/en/docs/21.0/user-guides/schema-changes/postponed-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/postponed-migrations.md
@@ -13,7 +13,7 @@ In both cases, it takes an explicit user interaction to launch or to complete th
 
 Normally, migrations are executed by Vitess and are launched and completed automatically. For example, an `ALTER` on a large table can take hours or more to complete. Vitess automatically instates the new schema in place whenever it is satisfied that the `ALTER` is complete. Or, a `DROP` statement could wait in queue while other statements are running, only to actually execute hours later.
 
-## Postpone launch
+## Postpone Launch
 
 A postponed-launch migration will remain in queued state and will not start executing, until instructed to launch.
 
@@ -57,7 +57,7 @@ mysql> show vitess_migrations like '62cc734d_6b59_11ee_b0cf_0a43f95f28a3' \G
                migration_status: queued
 ```
 
-### Use case
+### Use Case
 
 The use case is specific to multi sharded environments. In some cases, a user may wish to experiment a migration on a single shard:
 

--- a/content/en/docs/21.0/user-guides/schema-changes/recoverable-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/recoverable-migrations.md
@@ -17,7 +17,7 @@ Normally, schema migrations are coupled with the original MySQL server they oper
 - An unexpected external reparent
 - As long as no more than `10` minutes pass between failure/demotion of previous `primary` tablet and the promotion of the new `primary` tablet. 
 
-## Behavior and limitations
+## Behavior and Limitations
 
 Whether by planned operation or an unplanned failure, a `vitess` migration's VReplication stream is interrupted while copying/applying data. VReplication's mechanism persists the state of data transfer transactionally with the transfer itself. Any replica will have a _consistent_ state of the migration, even if that replica lags behind the primary.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/revertible-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/revertible-migrations.md
@@ -13,7 +13,7 @@ Revertible migrations supported for:
 - `ALTER TABLE` statements: supported in `vitess` strategy, the _revert_ is to reapply previous table schema, without losing any data added/modified since migration completion.
 - Another `revert` migration. It is possible to revert a _revert_, revert the revert of a _revert_, and so forth.
 
-## Behavior and limitations
+## Behavior and Limitations
 
 - A revert is a migration of its own, with a migration UUID, similarly to normal migrations.
 - Migrations are only for revertible for `24h` since completion.
@@ -50,7 +50,7 @@ $ vtctldclient ApplySchema --ddl-strategy "vitess" --sql "revert vitess_migratio
 
 Both operations return a UUID for the revert migration. The user can track the revert migration to find its state.
 
-## Usage & walkthrough
+## Usage & Walkthrough
 
 Consider the following annotated flow:
 ```sql
@@ -220,7 +220,7 @@ mysql> select * from t;
 +----+---------------------+
 ```
 
-## Implementation details
+## Implementation Details
 
 Revert for `CREATE` and `DROP` are implemented similarly for all online strategies.
 

--- a/content/en/docs/21.0/user-guides/schema-changes/table-lifecycle.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/table-lifecycle.md
@@ -34,7 +34,7 @@ various factors:
 It is common practice to avoid direct `DROP TABLE` statements and to follow
 a more elaborate table lifecycle.
 
-## Vitess table lifecycle
+## Vitess Table Lifecycle
 
 The lifecycle offered by Vitess consists of the following stages or some subset of them:
 
@@ -52,7 +52,7 @@ To understand the flow better, consider the following breakdown:
 - `drop`: an actual `DROP TABLE` is imminent
 - _removed_: table is dropped. When using InnoDB and `innodb_file_per_table` this means the `.ibd` data file backing the table is removed, and disk space is reclaimed.
 
-## Lifecycle subsets and configuration
+## Lifecycle Subsets and Configuration
 
 Different environments and users have different requirements and workflows. For example:
 
@@ -71,7 +71,7 @@ In MySQL **8.0.23** and later, table drops do not acquire locks on the InnoDB bu
 - Implicitly skip the `purge` stage, even if defined
 - Implicitly skip the `evac` stage, even if defined
 
-## Stateless flow by table name hints
+## Stateless Flow by Table Name Hints
 
 Vitess does not track the state of the table lifecycle. The process is stateless thanks to an encoding scheme in the table names. Examples:
 
@@ -91,11 +91,11 @@ Starting in Vitess `v20`, the table naming format will change. Tables will be na
 `v19` supports the new naming format, but does not generate any tables in this format. `v20` will generate tables in the new format, and will support the old format. Support for old format will be dropped in `v21` or later.
 {{< /info >}}
 
-## Automated lifecycle
+## Automated Lifecycle
 
 Vitess internally uses the above table lifecycle for [online, managed schema migrations](../../../user-guides/schema-changes/managed-online-schema-changes/). All online strategies: `vitess`, `gh-ost`, and `pt-online-schema-change`, create artifact tables or end with leftover tables: Vitess automatically collects those tables. The artifact or leftover tables are immediate moved to `hold` state. Depending on `vttablet`'s `--table_gc_lifecycle` flag, they may spend time in this state, getting purged, or immediately transitioned to the next state.
 
-## User-facing DROP TABLE lifecycle
+## User-facing DROP TABLE Lifecycle
 
 When using an online `ddl_strategy`, a `DROP TABLE` is a [managed schema migration](../../../user-guides/schema-changes/managed-online-schema-changes/). It is internally replaced by a `RENAME TABLE` statement, renaming it into a `HOLD` state (e.g. `_vt_HOLD_6ace8bcef73211ea87e9f875a4d24e90_20210915120000`). It will then participate in the table lifecycle mechanism. If `table_gc_lifecycle` does not include the `hold` state, the table proceeds to transition to next included state. 
 

--- a/content/en/docs/21.0/user-guides/schema-changes/validating-migrations.md
+++ b/content/en/docs/21.0/user-guides/schema-changes/validating-migrations.md
@@ -37,6 +37,7 @@ mysql> show vitess_migrations like 'a2994c92_f1d4_11ea_afa3_f875a4d24e90' \G
 ```
 
 3. Run the VDiff command. The name of the VReplication workflow is the same as Online DDL's `uuid`.
+
 ```
 vtctldclient VDiff --target-keyspace customer --workflow a2994c92_f1d4_11ea_afa3_f875a4d24e90 Create
 
@@ -44,6 +45,7 @@ VDiff a35b0006-e6d9-416e-bea9-917795dc5bf3 scheduled on target shards, use show 
 ```
 
 4. Monitor VDiff progress/status. 
+
 ```
 vtctldclient VDiff --target-keyspace customer --workflow Show a2994c92_f1d4_11ea_afa3_f875a4d24e90
 
@@ -56,9 +58,11 @@ CompletedAt:  2024-03-26 22:54:31
 
 Use "--format=json" for more detailed output.
 ```
+
 You should see `HasMismatch: false` unless there is a bug in Vitess, in which case please post on Vitess Slack and/or 
 create an issue at `https://github.com/vitessio/vitess/issues`
 
 ## References
+
 * [Online DDL usage](https://vitess.io/docs/user-guides/schema-changes/audit-and-control/)
 * [VDiff](https://vitess.io/docs/reference/vreplication/vdiff/)

--- a/content/en/docs/21.0/user-guides/sql/vexplain.md
+++ b/content/en/docs/21.0/user-guides/sql/vexplain.md
@@ -26,6 +26,7 @@ The output has four columns:
 * Query - the actual query used.
 
 ### Example 1:
+
 ```mysql
 mysql> vexplain queries select * from user where id = 4;
 +------+----------+-------+-----------------------------------------------------------+
@@ -39,6 +40,7 @@ mysql> vexplain queries select * from user where id = 4;
 Here we have a query where the planner can immediately see which shard to send the query to.
 
 ### Example 2:
+
 ```mysql
 mysql> vexplain queries select * from user where lookup = 'apa';
 +------+----------+-------+-------------------------------------------------------------------+
@@ -63,6 +65,7 @@ It does so without actually running any queries - it just plans the given query 
 The output contains a scalar output having a JSON description of the plan that vtgate will use for the query. 
 
 ### Example:
+
 ```mysql
 mysql> vexplain plan select * from corder join commerce.product as prod on corder.sku = prod.sku;
 ```

--- a/content/en/docs/21.0/user-guides/sql/vtexplain-in-bulk.md
+++ b/content/en/docs/21.0/user-guides/sql/vtexplain-in-bulk.md
@@ -27,13 +27,13 @@ To analyze multiple SQL queries and determine how, or if, Vitess executes each s
 1. Run the VTexplain tool and capture the output
 1. Check your output for errors
 
-## 1. Gather the queries from your current MySQL database environment
+## 1. Gather the Queries from Your Current MySQL Database Environment
 
 These queries should be most, if not all, of the queries that are sent to your current MySQL database over an extended period of time. You may need to record your queries for days or weeks depending on the nature of your application(s) and workload. You will need to normalize the queries you will be analyzing. Depending on the scope and complexity of your applications you may have a few hundred to thousands of distinct normalized queries. To obtain normalized queries you can use common MySQL monitoring tools like VividCortex, Monyog or PMM.
 
 It is also possible to use the MySQL [general query log](https://dev.mysql.com/doc/refman/8.0/en/query-log.html) feature to capture raw queries and then normalize it using post-processing.
 
-## 2. Filter out specific queries
+## 2. Filter Out Specific Queries
 
 Remove from your list any unsupported queries or queries from non-application sources. The following are examples of queries to remove are:
 
@@ -61,7 +61,7 @@ cat queries.txt \
  | grep -v mysql > queries_for_vtexplain.txt
 ```
 
-## 3. Populate fake values for your queries
+## 3. Populate Fake Values for Your Queries
 
 Once the queries are normalized in prepared statement style, populate fake values to allow VTexplain to run properly. This is because `vtexplain` operates only on concrete (or un-normalized) queries. Doing this by textual substitution is shown below and typically requires some trial and error. An alternative is to use a MySQL monitoring tool. This tool sometimes has a feature where it can provide one concrete query example for every normalized query form, which is ideal for this purpose.
 
@@ -95,7 +95,7 @@ cat queries.txt \
  | grep -v mysql > queries_for_vtexplain.txt
  ```
 
-## 4. Run the VTexplain tool via a script
+## 4. Run the VTexplain Tool via a Script
 
 In order to analyze every query in your list, create and run a script. The following is an example Python script that assumes a sharded database with 4 shards. You can adjust this script to match your individual requirements.
 
@@ -116,7 +116,7 @@ If you choose to use the single invocation, it would look something like:
 $ vtexplain --schema-file schema.sql --vschema-file vschema.json --shards 4 --sql-file queries_for_vtexplain.txt
 ```
 
-## 5. Add your SQL schema to the output file
+## 5. Add your SQL Schema to the Output File
 
 Add your proposed SQL schema to the file created by the script (e.g. schema.sql). The following is an example SQL schema:
 
@@ -131,7 +131,7 @@ CREATE TABLE `user` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 ```
 
-## 6. Add your VSchema
+## 6. Add Your VSchema
 
 Add your VSchema to the file created by the script: in this example, the file is named `schema.json`. The following is an example VSchema to match the example SQL schema above.
 
@@ -160,7 +160,7 @@ $ cat vschema.json
 ```
 Note that unlike the VSchema used in Vitess, e.g. in `vtctldclient GetVSchema` and `vtctldclient ApplyVSchema`, the format required by `vtexplain` differs slightly. There is an extra level of JSON objects at the top-level of the JSON format to allow you to have a single file that represents the VSchema for multiple Vitess keyspaces. In the above example, there is just a single keyspace called `ks1`.
 
-## 7. Run the VTexplain tool and capture the output
+## 7. Run the VTexplain Tool and Capture the Output
 
 This step will generate the output you need to analyze to determine what queries may have issues with your proposed VSchema. It may take a long time to finish if you have a number of queries.
 
@@ -168,11 +168,11 @@ This step will generate the output you need to analyze to determine what queries
 $ sh -x run_vtexplain.sh 2> vtexplain.output
 ```
 
-## 8. Check your output
+## 8. Check Your Output
 
 Once you have your full output in vtexplain.output, use `grep` to search for the string "ERROR" to review any issues that VTExplain found.
 
-### Example: Scattered across shards
+### Example: Scattered Across Shards
 
 In the following example, VTGate scatters the example query across both shards, and then aggregates the query results.
 
@@ -194,7 +194,7 @@ This is not an error, but illustrates a few things about the query:
  * The phases of the scatter operation will occur in parallel. This is because the number `1` on the left-hand-side of the output indicates the ordering of the operations in time. The same number indicates parallel processing.
  * The implicit Vitess row limit of 10000 rows is also seen, even though that was not present in the original query.
 
-### Example: Query returns an error
+### Example: Query Returns an Error
 
 The following query produces an error because Vitess does not support the `AVG` function for scatter queries across multiple shards.
 
@@ -203,7 +203,7 @@ $ vtexplain --schema-file schema.sql --vschema-file vschema.json --shards 4 --sq
 ERROR: vtexplain execute error in 'SELECT AVG(balance) FROM user': unsupported: in scatter query: complex aggregate expression
 ```
 
-### Example: Targeting a single shard
+### Example: Targeting a Single Shard
 
 The following query only targets a single shard because the query supplies the sharding key.
 

--- a/content/en/docs/21.0/user-guides/sql/vtexplain.md
+++ b/content/en/docs/21.0/user-guides/sql/vtexplain.md
@@ -27,7 +27,7 @@ To successfully analyze your SQL queries and determine how Vitess executes each 
 
 If you have a large number of queries you want to analyze for issues, based on a Vschema you’ve created for your database, you can read through a detailed scripted example [here](../vtexplain-in-bulk).
 
-## 1. Identify a SQL schema for tables in the statement
+## 1. Identify a SQL schema for Tables in the Statement
 
 In order to explain a statement, first identify the SQL schema for the tables that the statement uses. This includes tables that a query targets and tables that a DML statement modifies.
 
@@ -49,11 +49,11 @@ CREATE TABLE users_name_idx(
 );
 ```
 
-## 2. Identify a VSchema for the statement's source tables
+## 2. Identify a VSchema for the Statement's Source Tables
 
 Next, identify a [VSchema](../../../concepts/vschema) that contains the [Vindexes](../../../reference/features/vindexes) for the tables in the statement.
 
-### The VSchema must use a keyspace name.
+### The VSchema must Use a Keyspace Name.
 
 VTExplain requires a keyspace name for each keyspace in an input VSchema:
 
@@ -125,11 +125,11 @@ The following example VSchema defines a single keyspace `mainkeyspace` and three
 }
 ```
 
-## 3. Run the VTExplain tool
+## 3. Run the VTExplain Tool
 
 To explain a query, pass the SQL schema and VSchema files as arguments to the `VTExplain` command.
 
-### Example: Explaining a SELECT query
+### Example: Explaining a SELECT Query
 
 In the following example, the `VTExplain` command takes a `SELECT` query and returns the sequence of queries that Vitess runs in order to execute the query:
 
@@ -159,7 +159,7 @@ In the example above, the output of `VTExplain` shows the sequence of queries th
 
 In this example, each query has sequence number `1`, which shows that Vitess executes these in parallel. Vitess automatically adds the `LIMIT 10001` clause to protect against large results.
 
-### Example: Explaining an INSERT query
+### Example: Explaining an INSERT Query
 
 In the following example, the `VTExplain` command takes an `INSERT` query and returns the sequence of queries that Vitess runs in order to execute the query:
 
@@ -186,7 +186,7 @@ The example above shows how Vitess handles an insert into a table with a seconda
 * At sequence number `3`, the first transaction commits.
 * At sequence number `4`, the second transaction commits.
 
-### Example: Explaining an uneven keyspace
+### Example: Explaining an Uneven Keyspace
 
 In previous examples, we used the `--shards` flag to set up an evenly-sharded keyspace, where each shard covers the same fraction of the keyrange.
 `VTExplain` also supports receiving a JSON mapping of shard ranges to see how Vitess would handle a query against an arbitrarly-sharded keyspace.
@@ -302,6 +302,6 @@ SELECT * FROM users WHERE id IN (10, 17, 42, 1000)
 ```
 
 
-## See also
+## See Also
 
 * For detailed configuration options for VTExplain, see the [VTExplain syntax reference](../../../reference/programs/vtexplain).

--- a/content/en/docs/21.0/user-guides/vschema-guide/advanced-vschema.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/advanced-vschema.md
@@ -16,7 +16,7 @@ In both cases the leading column is the region or tenant, and is used to form th
 
 Please refer to [Region-based Sharding](../../configuration-advanced/region-sharding) for an example on how to use the `region_json` vindex and [Subsharding Vindex](../subsharding-vindex) for the more generic multicol vindex.
 
-#### Alternate approach
+#### Alternate Approach
 
 You have the option to pre-combine the region and id bits into a single column and use that as an input for a single column vindex. This approach achieves the same goals as a multi-column vindex.
 

--- a/content/en/docs/21.0/user-guides/vschema-guide/foreign-keys.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/foreign-keys.md
@@ -37,7 +37,7 @@ For more details on what operations Vitess performs for each type of DML, please
 - Some query syntaxes like `REPLACE INTO` and `INSERT INTO ... ON DUPLICATE KEY UPDATE` aren't supported.
 - Cyclic foreign keys are rejected by Vitess.
 
-#### Unsupported cyclic foreign keys
+#### Unsupported Cyclic Foreign Keys
 
 In this foreign key mode, Vitess limits support for certain schema patterns to prevent scenarios where the planner might enter an endless loop.
 
@@ -52,7 +52,8 @@ Once this graph is assembled, the schema is considered unacceptable if a cycle i
 
 To better clarify, here are some illustrative examples demonstrating unacceptable configurations and pointers on how to fix them:
 
-Example 1: Consider the following schema -
+**Example 1:** Consider the following schema:
+
 ```sql
 CREATE TABLE `employee` (
 	`id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -64,7 +65,7 @@ CREATE TABLE `employee` (
   CHARSET utf8mb4,
   COLLATE utf8mb4_0900_ai_ci;
 ```
-Because of the `ON DELETE CASCADE` in the foreign key, we'll end up with a graph like so -
+Because of the `ON DELETE CASCADE` in the foreign key, we'll end up with a graph like so:
 
 ```mermaid
 flowchart TD
@@ -74,7 +75,7 @@ flowchart TD
 
 To fix the schema, we should change the reference action of the foreign key. Any other action other than `ON DELETE CASCADE` will prevent cycles.
 
-Example 2: A similar situation can arise in a multi table schema as well.
+**Example 2:** A similar situation can arise in a multi table schema as well:
 
 ```sql
 CREATE TABLE `One` (
@@ -98,7 +99,7 @@ CREATE TABLE `Two` (
   COLLATE utf8mb4_0900_ai_ci;
 ```
 
-Because of the `on delete cascade` in the foreign key, we'll end up with a graph like so -
+Because of the `on delete cascade` in the foreign key, we'll end up with a graph like so:
 
 ```mermaid
 flowchart TD
@@ -118,7 +119,8 @@ flowchart TD
 
 The fix is again the same, wherein we need to change the reference action.
 
-Example 3: Consider the following schema - 
+**Example 3:** Consider the following schema:
+
 ```sql
 CREATE TABLE `t1` (
     `id` bigint unsigned NOT NULL AUTO_INCREMENT,
@@ -148,7 +150,7 @@ CHARSET utf8mb4,
 COLLATE utf8mb4_0900_ai_ci;
 ```
 
-The constructed graph looks like so - 
+The constructed graph looks like so:
 
 ```mermaid
 flowchart TD

--- a/content/en/docs/21.0/user-guides/vschema-guide/sharding-guidelines.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/sharding-guidelines.md
@@ -58,7 +58,7 @@ Vitess now has support for [multi-column Vindexes](../advanced-vschema/#multi-co
 
 The Vitess multi-column Vindex feature also allows you to locate data associated with regions in different geographical locations. For more details, see [Region-based Sharding](../../configuration-advanced/region-sharding).
 
-### Many-to-Many relationships
+### Many-to-Many Relationships
 
 Sharding works well only if the relationship between data is hierarchical (one-to-one or one-to-many). If a table has foreign keys into multiple other tables, you have to choose one based on the strongest relationship and group the rows by that foreign key. The rest of the relationships will incur cross-shard overheads.
 

--- a/content/en/docs/21.0/user-guides/vschema-guide/shared-vindexes.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/shared-vindexes.md
@@ -157,7 +157,7 @@ Foreign key constraints across shards or keyspaces are not supported in Vitess. 
 
 A more detailed analysis of foreign keys in Vitess can be found on the [foreign keys](../foreign-keys) page.
 
-### Many-to-Many relationships
+### Many-to-Many Relationships
 
 In the case where a table has relationships with multiple other tables, you can only choose one of those relationships for shard grouping. All other relationships will end up being cross-shard, and will incur cross-shard penalties.
 

--- a/content/en/docs/21.0/user-guides/vschema-guide/subsharding-vindex.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/subsharding-vindex.md
@@ -12,7 +12,7 @@ be routed to a single shard.  If an ordered subset of columns are provided,
 starting with the first column in the vindex, then the query can usually be
 routed to a subset of shards instead of all shards.
 
-### Use cases
+### Use Cases
 
 A common use case for a subsharding vindex is when a given entity’s data fits
 on more than one shard (e.g a large tenant in a SaaS scenario) and there is
@@ -25,11 +25,13 @@ region should reside within a subset of shards which are co-located in that
 region.
 
 ### Prerequisite
+
 The subsharding vindex only works with Gen4 query planner.
 
 ### Usage
 
 This vindex is registered as `multicol` vindex.
+
 It takes 3 parameters as input:
 
 1. `column_count` - the number of columns provided for using the vindex.
@@ -62,7 +64,9 @@ Example usage in VSchema:
   }
 }
 ```
+
 `column_count` is a required parameter.
+
 A maximum of 8 columns can be used in this vindex i.e. `column_count <= 8`
 
 `column_vindex` should contain the vindex names in a comma-separated list. It should be less than or equal to column_count.
@@ -94,7 +98,7 @@ keyspace_id:
 `column_bytes` should contain the number of bytes for each column in a comma-separated list. The numbers should add up to 8.
 If the number of bytes is not provided for all columns, they are inferred by assigning equal numbers to the remaining unassigned columns.
 
-Example 1:
+**Example 1:**
 
 ```
 Given:
@@ -115,13 +119,15 @@ col 4 -> 1
 col 5 -> 1
 ```
 
-Example 2:
+**Example 2:**
+
 ```
 given: 3 columns, 8 bytes
 output: c1 -> 3, c2 -> 3, c3 -> 2
 ```
 
-Example 3:
+**Example 3:**
+
 ```
 given: 3 columns, first column is 1 byte.
 output: c1 -> 1, c2 -> 4, c3 -> 3
@@ -140,7 +146,6 @@ The Vindexes that can be used in a subsharding vindex by implementing the requir
 * `unicode_loose_md5`
 * `unicode_loose_xxhash`
 * `xxhash`
-
 
 ### Example
 

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -40,7 +40,7 @@ nvm use 16.13.0
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
 
-### Packages from CentOS repos
+### Packages from CentOS Repos
 
 First install the MySQL repository from Oracle:
 
@@ -101,7 +101,7 @@ You can skip this step by setting the `NOVTADMINBUILD` environment variable.
 NOVTADMINBUILD=1 make build
 ```
 
-## Testing your Binaries
+## Testing our Binaries
 
 The unit tests require the following additional packages:
 
@@ -142,4 +142,3 @@ mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
 E1027 18:28:23.464780   19483 mysqld.go:734] mysqld --initialize-insecure failed: /usr/sbin/mysqld: exit status 1, output: mysqld: [ERROR] Failed to open required defaults file: /home/morgo/vitess/vtdataroot/vt_0000000101/my.cnf
 mysqld: [ERROR] Fatal error in defaults handling. Program aborted!
 ```
-

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -39,6 +39,7 @@ nvm use 16.13.0
 ```
 
 See the [vtadmin README](https://github.com/vitessio/vitess/blob/main/web/vtadmin/README.md) for more details.
+
 ### Packages from apt repos
 
 Install dependencies required to build and run Vitess:
@@ -194,4 +195,3 @@ If you use an IDE to run these tests, you need to set `VTROOT` previously. For e
     "VTROOT": "<path to my vitess checkout>"
 }
 ```
-

--- a/content/en/docs/contributing/code-reviews.md
+++ b/content/en/docs/contributing/code-reviews.md
@@ -44,7 +44,7 @@ We use unit tests both to test the code and to describe it for other developers.
 They must cover all the important use cases of the feature.
 * A separate pull request into `vitessio/website` that updates the documentation is required if the feature changes or adds to existing behavior.
 
-### Bug fixes
+### Bug Fixes
 
 If you are creating a PR to fix a bug, make sure to create an end-to-end test that fails without your change.
 This is the important reproduction case that will make sure this particular bug does not show up again, and that clearly shows on your PR what bug you are fixing.

--- a/content/en/docs/contributing/github-workflow.md
+++ b/content/en/docs/contributing/github-workflow.md
@@ -87,7 +87,7 @@ test` from the root of the Git tree.
 If you haven't installed all dependencies for `make test`, you can rely on the CI test results as well.
 These results will be present on your pull request.
 
-## Committing your work
+## Committing Your Work
 
 When running `git commit` use the `-s` option to add a Signed-off-by line.
 This is needed for [the Developer Certificate of Origin](https://github.com/apps/dco).

--- a/content/en/docs/contributing/pr-convention.md
+++ b/content/en/docs/contributing/pr-convention.md
@@ -31,7 +31,7 @@ The suggested solution would be creating general guidelines for this naming conv
 - Should be capitalized and written in imperative present tense
 - Not end with a period
 
-#### Consists of three parts:
+#### Consists of Three Parts:
 
 * Title: Short informative summary of the pull request
 * #[Issue_ID]


### PR DESCRIPTION
I have noticed in most headline `Title Case` is used. However, in some cases `Title Case` was not used. This PR implements a `Title Case` capitalization update across various header in the documentation to enhance readability and consistency in documentation headers.

While making the changes, I didnt change the case for technical terms. 