### PR TITLE
Documentation for https://github.com/vitessio/vitess/pull/16618

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://vitess.io"
 canonifyurls = true
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 enableGitInfo = true
 googleAnalytics = "G-JWT03RNV4P"
 enableRobotsTXT = true

--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = "https://vitess.io"
 canonifyurls = true
-disableKinds = ["taxonomy"]
+disableKinds = ["taxonomy", "taxonomyTerm"]
 enableGitInfo = true
 googleAnalytics = "G-JWT03RNV4P"
 enableRobotsTXT = true

--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL
 
@@ -28,7 +28,7 @@ Operates on online DDL (schema migrations).
 
 * [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 * [vtctldclient OnlineDDL cancel](./vtctldclient_onlineddl_cancel/)	 - Cancel one or all migrations, terminating any running ones as needed.
-* [vtctldclient OnlineDDL cleanup](./vtctldclient_onlineddl_cleanup/)	 - Mark a given schema migration ready for artifact cleanup.
+* [vtctldclient OnlineDDL cleanup](./vtctldclient_onlineddl_cleanup/)	 - Mark a given schema migration, or all complete/failed/cancelled migrations, ready for artifact cleanup.
 * [vtctldclient OnlineDDL complete](./vtctldclient_onlineddl_complete/)	 - Complete one or all migrations executed with --postpone-completion
 * [vtctldclient OnlineDDL force-cutover](./vtctldclient_onlineddl_force-cutover/)	 - Mark a given schema migration, or all pending migrations, for forced cut over.
 * [vtctldclient OnlineDDL launch](./vtctldclient_onlineddl_launch/)	 - Launch one or all migrations executed with --postpone-launch

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,14 +1,14 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL cleanup
 
-Mark a given schema migration ready for artifact cleanup.
+Mark a given schema migration, or all complete/failed/cancelled migrations, ready for artifact cleanup.
 
 ```
-vtctldclient OnlineDDL cleanup <keyspace> <uuid>
+vtctldclient OnlineDDL cleanup <keyspace> <uuid|all>
 ```
 
 ### Examples

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -14,6 +14,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ### Options
 
 ```
+      --allow-cross-cell-promotion           Allow cross cell promotion
       --avoid-primary string                 Alias of a tablet that should not be the primary; i.e. "reparent to any other tablet if this one is the primary".
   -h, --help                                 help for PlannedReparentShard
       --new-primary string                   Alias of a tablet that should be the new primary.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SetShardTabletControl
 
@@ -32,11 +32,11 @@ vtctldclient SetShardTabletControl [--cells=c1,c2...] [--denied-tables=t1,t2,...
 ### Options
 
 ```
-  -c, --cells strings           Specifies a comma-separated list of cells to update.
-      --denied-tables strings   Specifies a comma-separated list of tables to add to the denylist (for MoveTables). Each table name is either an exact match, or a regular expression of the form '/regexp/'.
-      --disable-query-service   Sets the DisableQueryService flag in the specified cells. This flag requires --denied-tables and --remove to be unset; if either is set, this flag is ignored.
+  -c, --cells strings           Specifies a comma-separated list of cells to update (all cells will be used by default).
+      --denied-tables strings   Specifies a comma-separated list of tables to add to the DeniedTables list, or remove from the list if --remove is also specified, in the Shard records (MoveTables). Each table name is either an exact match, or a regular expression of the form '/regexp/'.
+      --disable-query-service   Adds or removes the DisableQueryService field in the SrvKeyspace record (Reshard) for the specified cells (using all cells by deefault). This flag requires --denied-tables and --remove to be unset; if either is set, this flag is ignored.
   -h, --help                    help for SetShardTabletControl
-  -r, --remove                  Removes the specified cells for MoveTables operations.
+  -r, --remove                  Removes the TabletControl field and its DeniedTables entries, or if specified with --denied-tables then only remove the specified tables from the DeniedTables list, in the Shard records (MoveTables) in the specified cells (using all cells by default).
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,23 +1,21 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient UpdateThrottlerConfig
 
 Update the tablet throttler configuration for all tablets in the given keyspace (across all cells)
 
 ```
-vtctldclient UpdateThrottlerConfig [--enable|--disable] [--threshold=<float64>] [--custom-query=<query>] [--check-as-check-self|--check-as-check-shard] [--throttle-app|unthrottle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] <keyspace>
+vtctldclient UpdateThrottlerConfig [--enable|--disable] [--metric-name=<name>] [--threshold=<float64>] [--custom-query=<query>] [--throttle-app|unthrottle-app=<name>] [--throttle-app-ratio=<float, range [0..1]>] [--throttle-app-duration=<duration>] [--throttle-app-exempt=<bool>] [--app-name=<name> --app-metrics=<metrics>] <keyspace>
 ```
 
 ### Options
 
 ```
-      --app-metrics strings              metrics to be used when checking the throttler for the app (requires --app-name). Empty to restore to default metrics
+      --app-metrics strings              metrics to be used when checking the throttler for the app (requires --app-name). Empty to restore to default metrics. Example: --app-metrics=lag,custom,shard/loadavg
       --app-name string                  app name for which to assign metrics (requires --app-metrics)
-      --check-as-check-self              /throttler/check requests behave as is /throttler/check-self was called
-      --check-as-check-shard             use standard behavior for /throttler/check requests
       --custom-query string              custom throttler check query
       --disable                          Disable the throttler
       --enable                           Enable the throttler

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff create
 
@@ -15,7 +15,7 @@ vtctldclient VDiff create
 
 ```
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create
-vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002
+vtctldclient --server :15999 vdiff --workflow c2c --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002 --source-cells zone1 --tablet-types "rdonly,replica" --target-cells zone1 --update-table-stats --max-report-sample-rows 1000 --wait --wait-update-interval 5s --auto-retry --max-diff-duration 1h --row-diff-column-truncate-at 0
 ```
 
 ### Options

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -15,7 +15,7 @@ vtctldclient VDiff create
 
 ```
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer create
-vtctldclient --server :15999 vdiff --workflow c2c --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002 --source-cells zone1 --tablet-types "rdonly,replica" --target-cells zone1 --update-table-stats --max-report-sample-rows 1000 --wait --wait-update-interval 5s --auto-retry --max-diff-duration 1h --row-diff-column-truncate-at 0
+vtctldclient --server :15999 vdiff --workflow c2c --target-keyspace customer create b3f59678-5241-11ee-be56-0242ac120002 --source-cells zone1 --tablet-types "rdonly,replica" --target-cells zone1 --update-table-stats --max-report-sample-rows 1000 --wait --wait-update-interval 5s --max-diff-duration 1h --row-diff-column-truncate-at 0
 ```
 
 ### Options

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff create
 
@@ -30,6 +30,7 @@ vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --targe
       --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --max-report-sample-rows int                Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks (default 10)
       --only-pks                                  When reporting missing rows, only show primary keys in the report.
+      --row-diff-column-truncate-at int           When showing row differences, truncate the non Primary Key column values to this length. A value less than 1 means do not truncate. (default 128)
       --source-cells strings                      The source cell(s) to compare from; default is any available cell.
       --tables strings                            Only run vdiff for these tables in the workflow.
       --tablet-types strings                      Tablet types to use on the source and target.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff show
 
@@ -14,8 +14,8 @@ vtctldclient VDiff show
 ### Examples
 
 ```
-vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer show last
-vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer show a037a9e2-5628-11ee-8c99-0242ac120002
+vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer show last --verbose --format json
+vtctldclient --server :15999 vdiff --workflow commerce2customer --target-keyspace customer show a037a9e2-5628-11ee-8c99-0242ac120002
 vtctldclient --server localhost:15999 vdiff --workflow commerce2customer --target-keyspace customer show all
 ```
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 7e8f008834c0278b8df733d606940a629b67a9d9
+commit: 4bc3b998941037e0446f5c0899587e4093d79f57
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: cd0c2b594b2d5178a9c8ac081eaee7d1b7eef28a
+commit: 7e8f008834c0278b8df733d606940a629b67a9d9
 ---
 ## vtctldclient Workflow update
 

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{ $inServerMode := hugo.IsServer }}
+{{ $inServerMode := site.IsServer }}
 {{ $style        := "sass/style.sass" }}
 {{ $target       := "css/style.css" }}
 {{ $includes     := (slice "node_modules") }}

--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -1,4 +1,4 @@
-{{ $inServerMode := site.IsServer }}
+{{ $inServerMode := hugo.IsServer }}
 {{ $style        := "sass/style.sass" }}
 {{ $target       := "css/style.css" }}
 {{ $includes     := (slice "node_modules") }}


### PR DESCRIPTION
This rebuilds the vtctldclient generated docs and includes the changes from: https://github.com/vitessio/vitess/pull/16618

PR specific changes: 
  - File: `content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md`
  - Preview: https://deploy-preview-1831--vitess.netlify.app/docs/21.0/reference/programs/vtctldclient/vtctldclient_vdiff/vtctldclient_vdiff_create/