### PR TITLE
Fix "apt install" command for Debian

### DIFF
--- a/content/en/docs/20.0/get-started/local.md
+++ b/content/en/docs/20.0/get-started/local.md
@@ -19,7 +19,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
-sudo apt install -y default-mysql-server default-mysql-client etcd curl
+sudo apt install -y default-mysql-server default-mysql-client etcd-server etcd-client curl
 
 # Yum based
 sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm

--- a/content/en/docs/21.0/get-started/local.md
+++ b/content/en/docs/21.0/get-started/local.md
@@ -19,7 +19,7 @@ Vitess supports the databases listed [here](../../overview/supported-databases/)
 sudo apt install -y mysql-server etcd-server etcd-client curl
 
 # Debian
-sudo apt install -y default-mysql-server default-mysql-client etcd curl
+sudo apt install -y default-mysql-server default-mysql-client etcd-server etcd-client curl
 
 # Yum based
 sudo yum -y localinstall https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm


### PR DESCRIPTION
The etcd package is not available in the bookworm repositories (https://packages.debian.org/bullseye/etcd).

Related: https://github.com/vitessio/website/issues/1738

---

I only updated the docs for v20 and v21, should I also apply the changes to older versions?