### PR TITLE
Documentation for MySQL Shell backup engine

### DIFF
--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -141,7 +141,7 @@ __Optional flags:__
 	* you can control how many threads and other options with this flag. See the [MySQL docs](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-shell-utilities-dump-instance-schema.html) for other 
 	options
 * `--mysql-shell-load-flags="{\"updateGtidSet\": \"replace\", \"progressFile\": \"\", \"skipBinlog\": true}"`
-	* `updateGtidSet` must be set to `true` so MySQL Shell updates the executed GTID at the 
+	* `updateGtidSet` must be set to `"replace"` so MySQL Shell updates the executed GTID at the 
 	end of the restore
 	* `progressFile` must be empty indicate we are starting a new backup and not continuing an
 	existing one

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -165,9 +165,9 @@ All databases will be backed up, with the exception of `information_schema`, `my
 #### Users
 Since user grants are stored in the `mysql` database, they are not backed up like the other databases. MySQL Shell works around that saving users separately and allow the user to pass the `loadUsers: true` option during the load process to restore users to the state they were during the backup. 
 
-Internal users (`mysql.sys@localhost`, `mysql.session@localhost`, `mysql.infoschema@localhost`) are not restored, as well as the current user logged in to MySQL. You might as well have issue restoring `root` if the `vt_dba` user doesn't have the right permissions, so that's why by default Vitess also excludes it.
+Internal users (`mysql.sys@localhost`, `mysql.session@localhost`, `mysql.infoschema@localhost`) are not restored, as well as the current user logged in to MySQL. It is also possible to exclude some users from being imported by using adjusting your `--mysql-shell-load-flags` if necessary.
 
-Because MySQL Shell will fail the restore if any users already exist, Vitess will drop all users in MySQL (except the ones noted above) before the restore if you specify `loadUsers: true`.
+Because MySQL Shell will fail the restore if any user already exists, Vitess will drop all users in MySQL (except the ones noted above) before the restore if you specify `loadUsers: true`.
 
 ## Create a full backup with vtctl
 

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/creating-a-backup.md
@@ -165,7 +165,7 @@ All databases will be backed up, with the exception of `information_schema`, `my
 #### Users
 Since user grants are stored in the `mysql` database, they are not backed up like the other databases. MySQL Shell works around that saving users separately and allow the user to pass the `loadUsers: true` option during the load process to restore users to the state they were during the backup. 
 
-Internal users (`mysql.sys@localhost`, `mysql.session@localhost`, `mysql.infoschema@localhost`) are not restored, as well as the current user logged in to MySQL. You might as well have issue restoring `root` if the `vt_dba` user doesn't have the right permissions, so that why by default Vitess also excludes it.
+Internal users (`mysql.sys@localhost`, `mysql.session@localhost`, `mysql.infoschema@localhost`) are not restored, as well as the current user logged in to MySQL. You might as well have issue restoring `root` if the `vt_dba` user doesn't have the right permissions, so that's why by default Vitess also excludes it.
 
 Because MySQL Shell will fail the restore if any users already exist, Vitess will drop all users in MySQL (except the ones noted above) before the restore if you specify `loadUsers: true`.
 

--- a/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/overview.md
+++ b/content/en/docs/21.0/user-guides/operating-vitess/backup-and-restore/overview.md
@@ -25,6 +25,7 @@ The engine is the techology used for generating the backup. Currently Vitess has
 
 * Builtin: Shutdown an instance and copy all the database files (default)
 * XtraBackup: An online backup using Percona's [XtraBackup](https://www.percona.com/software/mysql-database/percona-xtrabackup)
+* MySQL Shell: a logical backup engine using the upstream [mysqlsh](https://dev.mysql.com/doc/mysql-shell/8.0/en/) dump/load tool (EXPERIMENTAL)
 
 ### Backup types
 


### PR DESCRIPTION
This PR adds the documentation needed for the new MySQL Shell Backup engine that is being added in https://github.com/vitessio/vitess/pull/16295