### PR TITLE
Correct createlookupvindex examples

### DIFF
--- a/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -643,7 +643,7 @@ mysql> vexplain select * from corder where sku = "Product_1";
 </br>
 
 As expected, we can see it is not scattering anymore, which it would have
-before we executed the `CreateLookupVindex` command.
+before we executed the `LookupVindex create` command.
 
 Lastly, let's ensure that the lookup Vindex is being updated appropriately
 when we insert and delete rows:

--- a/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -193,7 +193,7 @@ any schema to create as it will do it automatically. Now, let us
 actually execute the `LookupVindex create` command:
 
 ```bash
-vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main create --keyspace main --type consistent_lookup_unique --table-owner customer --table-owner-columns=id --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns=sku --tablet-types=PRIMARY
 ```
 
 </br>
@@ -234,105 +234,211 @@ Now we can look what happened in greater detail:
 
 Lets observe the VReplication streams that got created using the `show` sub-command.
 
-{{< info >}}
-The created vreplication workflow will have a generated name of `<target_table_name>_vdx`.
-So in our example here: `corder_lookup_vdx`.
-{{< /info >}}
-
 ```json
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main show --include-logs=false
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer show --compact
 {
   "workflows": [
     {
-      "name": "customer_region_lookup",
+      "name": "corder_lookup",
       "source": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
       "target": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
-      "max_v_replication_lag": "0",
       "shard_streams": {
-        "0/zone1-0000000100": {
+        "-80/zone1-0000000301": {
           "streams": [
             {
-              "id": "1",
-              "shard": "0",
+              "id": "2",
+              "shard": "-80",
               "tablet": {
                 "cell": "zone1",
-                "uid": 100
+                "uid": 301
               },
               "binlog_source": {
-                "keyspace": "main",
-                "shard": "0",
-                "tablet_type": "UNKNOWN",
-                "key_range": null,
-                "tables": [],
+                "keyspace": "customer",
+                "shard": "-80",
                 "filter": {
                   "rules": [
                     {
-                      "match": "customer_region_lookup",
-                      "filter": "select id as id, keyspace_id() as keyspace_id from customer where in_keyrange(id, 'main.xxhash', '-') group by id, keyspace_id",
-                      "convert_enum_to_text": {},
-                      "convert_charset": {},
-                      "source_unique_key_columns": "",
-                      "target_unique_key_columns": "",
-                      "source_unique_key_target_columns": "",
-                      "convert_int_to_enum": {}
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
                     }
-                  ],
-                  "field_event_mode": "ERR_ON_MISMATCH",
-                  "workflow_type": "0",
-                  "workflow_name": ""
-                },
-                "on_ddl": "IGNORE",
-                "external_mysql": "",
-                "stop_after_copy": false,
-                "external_cluster": "",
-                "source_time_zone": "",
-                "target_time_zone": ""
+                  ]
+                }
               },
-              "position": "63c84d28-6888-11ee-93b0-81b2fbd12545:1-63",
-              "stop_position": "",
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
               "state": "Running",
-              "db_name": "vt_main",
+              "db_name": "vt_customer",
               "transaction_timestamp": {
-                "seconds": "1697064644",
-                "nanoseconds": 0
+                "seconds": "1726847304"
               },
               "time_updated": {
-                "seconds": "1697064646",
-                "nanoseconds": 0
+                "seconds": "1726847306"
               },
-              "message": "",
-              "copy_states": [],
-              "logs": [],
-              "log_fetch_error": "",
-              "tags": [],
-              "rows_copied": "0",
+              "tags": [
+                ""
+              ],
               "throttler_status": {
-                "component_throttled": "",
-                "time_throttled": {
-                  "seconds": "0",
-                  "nanoseconds": 0
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "-80",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 301
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
+                    }
+                  ]
                 }
-              }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
             }
           ],
-          "tablet_controls": [],
+          "is_primary_serving": true
+        },
+        "80-/zone1-0000000401": {
+          "streams": [
+            {
+              "id": "2",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "-80",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "4",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "1",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            }
+          ],
           "is_primary_serving": true
         }
       },
       "workflow_type": "CreateLookupIndex",
       "workflow_sub_type": "None",
-      "max_v_replication_transaction_lag": "0",
-      "defer_secondary_keys": false
+      "options": {}
     }
   ]
 }
@@ -399,8 +505,8 @@ the VReplication streams and also clear the `write_only` flag from the
 Vindex indicating that it is *not* backfilling anymore.
 
 ```bash
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main externalize
-LookupVindex customer_region_lookup has been externalized and the customer_region_lookup VReplication workflow has been deleted
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer externalize
+LookupVindex corder_lookup has been externalized and the corder_lookup VReplication workflow has been deleted
 ```
 
 </br>

--- a/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -93,7 +93,7 @@ If we look at the [VSchema](../../../reference/features/vschema/) for the
 `customer_id` column:
 
 ```json
-$ vtctldclient GetVSchema customer
+$ vtctldclient --server localhost:15999 GetVSchema customer
 {
   "sharded": true,
   "vindexes": {

--- a/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
@@ -109,7 +109,7 @@ Now that we have some data in our unsharded `main` keyspace, let's go ahead and 
 for resharding. The initial vschema is unsharded and simply lists the customer table:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server localhost:15999 GetVSchema main
 {
   "sharded": false,
   "vindexes": {},
@@ -156,7 +156,7 @@ Now if we look at the `main` keyspace's vschema again we can see that it now inc
 a lookup vindex called `customer_region_lookup`:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server=localhost:15999 GetVSchema main --compact
 {
   "sharded": true,
   "vindexes": {
@@ -164,31 +164,27 @@ $ vtctldclient GetVSchema main
       "type": "consistent_lookup_unique",
       "params": {
         "from": "id",
-        "table": "main.customer_lookup",
+        "ignore_nulls": "false",
+        "table": "main.customer_region_lookup",
         "to": "keyspace_id"
       },
       "owner": "customer"
-    },
-    "hash": {
-      "type": "hash",
-      "params": {},
-      "owner": ""
     },
     "region_vdx": {
       "type": "region_json",
       "params": {
         "region_bytes": "1",
         "region_map": "./countries.json"
-      },
-      "owner": ""
+      }
+    },
+    "hash": {
+      "type": "hash"
     }
   },
   "tables": {
     "customer": {
-      "type": "",
       "column_vindexes": [
         {
-          "column": "",
           "name": "region_vdx",
           "columns": [
             "id",
@@ -196,34 +192,22 @@ $ vtctldclient GetVSchema main
           ]
         },
         {
-          "column": "id",
           "name": "customer_region_lookup",
-          "columns": []
+          "columns": [
+            "id"
+          ]
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     },
-    "customer_lookup": {
-      "type": "",
+    "customer_region_lookup": {
       "column_vindexes": [
         {
           "column": "id",
-          "name": "hash",
-          "columns": []
+          "name": "hash"
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     }
-  },
-  "require_explicit_routing": false
+  }
 }
 ```
 
@@ -293,7 +277,7 @@ Now we have tablets for our original unsharded `main` keyspace — shard `0` —
 we'll be using when we reshard the `main` keyspace:
 
 ```bash
-$ vtctldclient GetTablets --keyspace=main
+$ vtctldclient --server localhost:15999 GetTablets --keyspace=main
 zone1-0000000100 main 0 primary localhost:15100 localhost:17100 [] 2023-01-24T04:31:08Z
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
@@ -322,7 +306,7 @@ Now that our new tablets are up, we can go ahead with the resharding:
 This script executes one command:
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
 ```
 
 </br>
@@ -338,10 +322,10 @@ We can check the correctness of the copy using the [`VDiff` command](../../../re
 and the `<keyspace>.<workflow>` name we used for `Reshard` command above:
 
 ```bash
-$ vtctldclient VDiff --target-keyspace main --workflow main2regions create
+$ vtctldclient --server localhost:15999 VDiff --target-keyspace main --workflow main2regions create
 VDiff 044e8da0-9ba4-11ed-8bc7-920702940ee0 scheduled on target shards, use show to view progress
 
-$ vtctldclient VDiff --format=json --target-keyspace main --workflow main2regions show last
+$ vtctldclient --server localhost:15999 VDiff --format=json --target-keyspace main --workflow main2regions show last
 {
 	"Workflow": "main2regions",
 	"Keyspace": "main",
@@ -361,7 +345,7 @@ We can take a look at the VReplication workflow's status using the
 [`show` action](../../../reference/programs/vtctldclient/vtctldclient_reshard/vtctldclient_reshard_show/):
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions show
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions show
 ```
 
 </br>
@@ -476,7 +460,7 @@ All we have now is the sharded `main` keyspace and the original unsharded `main`
 longer exists:
 
 ```bash
-$ vtctldclient GetTablets
+$ vtctldclient --server localhost:15999 GetTablets
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
 zone1-0000000400 main 80-c0 primary localhost:15400 localhost:17400 [] 2023-01-24T04:45:38Z

--- a/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,41 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`CreateLookupVindex` command](../../migration/move-tables/) with the definition found in the
-`lookup_vindex.json` file.
-
-That file is where we both define the [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex)
-and associate it with the `customer` table in the `main` keyspace:
-
-```json
-$ cat ./lookup_vindex.json
-{
-  "sharded": true,
-  "vindexes": {
-    "customer_region_lookup": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "main.customer_lookup",
-        "from": "id",
-        "to": "keyspace_id"
-      },
-      "owner": "customer"
-    }
-  },
-  "tables": {
-    "customer": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "customer_region_lookup"
-        }
-      ]
-    }
-  }
-}
-```
-
-</br>
+[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:
@@ -264,7 +230,7 @@ $ vtctldclient GetVSchema main
 </br>
 
 Notice that the vschema shows a `hash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
-the lookup table. This is automatically created by the `CreateLookupVindex` workflow, along with the 
+the lookup table. This is automatically created by the `LookupVindex` workflow, along with the
 backing table needed to hold the vindex and populating it with the correct rows (for additional details on this
 command see [the associated user-guide](../createlookupvindex/)). We can see that by checking our `main`
 database/keyspace again:

--- a/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,7 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
+[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:

--- a/content/en/docs/18.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/18.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -39,76 +39,22 @@ To create such a lookup vindex on a real Vitess cluster, you can use the followi
 
 *Continued from [Unique Lookup Vindex Page](../unique-lookup)*
 
-Save the following json into a file, say `corder_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "corder_keyspace_idx": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "product.corder_keyspace_idx",
-        "from": "corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-          "column": "corder_id",
-          "name": "corder_keyspace_idx"
-      }],
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name corder_keyspace --table-keyspace product create --keyspace product --type consistent_lookup_unique --table-owner corder --table-owner-columns corder_id --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat corder_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace` knowing that it is sharded.
 
 #### Non-unique Lookup Vindex Example
 
 *Continued from [Non-unique Lookup Vindex Page](../non-unique-lookup)*
 
-Save the following json into a file, say `oname_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "oname_keyspace_idx": {
-      "type": "consistent_lookup",
-      "params": {
-        "table": "customer.oname_keyspace_idx",
-        "from": "oname,corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-        "columns": ["oname", "corder_id"],
-        "name": "oname_keyspace_idx"
-      }]
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name oname_keyspace --table-keyspace customer create --keyspace customer --type consistent_lookup --table-owner corder --table-owner-columns 'oname,corder_id' --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat oname_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace` knowing that it is sharded.

--- a/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -643,7 +643,7 @@ mysql> vexplain select * from corder where sku = "Product_1";
 </br>
 
 As expected, we can see it is not scattering anymore, which it would have
-before we executed the `CreateLookupVindex` command.
+before we executed the `LookupVindex create` command.
 
 Lastly, let's ensure that the lookup Vindex is being updated appropriately
 when we insert and delete rows:

--- a/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -193,7 +193,7 @@ any schema to create as it will do it automatically. Now, let us
 actually execute the `LookupVindex create` command:
 
 ```bash
-vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main create --keyspace main --type consistent_lookup_unique --table-owner customer --table-owner-columns=id --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns=sku --tablet-types=PRIMARY
 ```
 
 </br>
@@ -234,105 +234,211 @@ Now we can look what happened in greater detail:
 
 Lets observe the VReplication streams that got created using the `show` sub-command.
 
-{{< info >}}
-The created vreplication workflow will have a generated name of `<target_table_name>_vdx`.
-So in our example here: `corder_lookup_vdx`.
-{{< /info >}}
-
 ```json
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main show --include-logs=false
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer show --compact
 {
   "workflows": [
     {
-      "name": "customer_region_lookup",
+      "name": "corder_lookup",
       "source": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
       "target": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
-      "max_v_replication_lag": "0",
       "shard_streams": {
-        "0/zone1-0000000100": {
+        "-80/zone1-0000000301": {
           "streams": [
             {
-              "id": "1",
-              "shard": "0",
+              "id": "2",
+              "shard": "-80",
               "tablet": {
                 "cell": "zone1",
-                "uid": 100
+                "uid": 301
               },
               "binlog_source": {
-                "keyspace": "main",
-                "shard": "0",
-                "tablet_type": "UNKNOWN",
-                "key_range": null,
-                "tables": [],
+                "keyspace": "customer",
+                "shard": "-80",
                 "filter": {
                   "rules": [
                     {
-                      "match": "customer_region_lookup",
-                      "filter": "select id as id, keyspace_id() as keyspace_id from customer where in_keyrange(id, 'main.xxhash', '-') group by id, keyspace_id",
-                      "convert_enum_to_text": {},
-                      "convert_charset": {},
-                      "source_unique_key_columns": "",
-                      "target_unique_key_columns": "",
-                      "source_unique_key_target_columns": "",
-                      "convert_int_to_enum": {}
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
                     }
-                  ],
-                  "field_event_mode": "ERR_ON_MISMATCH",
-                  "workflow_type": "0",
-                  "workflow_name": ""
-                },
-                "on_ddl": "IGNORE",
-                "external_mysql": "",
-                "stop_after_copy": false,
-                "external_cluster": "",
-                "source_time_zone": "",
-                "target_time_zone": ""
+                  ]
+                }
               },
-              "position": "63c84d28-6888-11ee-93b0-81b2fbd12545:1-63",
-              "stop_position": "",
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
               "state": "Running",
-              "db_name": "vt_main",
+              "db_name": "vt_customer",
               "transaction_timestamp": {
-                "seconds": "1697064644",
-                "nanoseconds": 0
+                "seconds": "1726847304"
               },
               "time_updated": {
-                "seconds": "1697064646",
-                "nanoseconds": 0
+                "seconds": "1726847306"
               },
-              "message": "",
-              "copy_states": [],
-              "logs": [],
-              "log_fetch_error": "",
-              "tags": [],
-              "rows_copied": "0",
+              "tags": [
+                ""
+              ],
               "throttler_status": {
-                "component_throttled": "",
-                "time_throttled": {
-                  "seconds": "0",
-                  "nanoseconds": 0
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "-80",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 301
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
+                    }
+                  ]
                 }
-              }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
             }
           ],
-          "tablet_controls": [],
+          "is_primary_serving": true
+        },
+        "80-/zone1-0000000401": {
+          "streams": [
+            {
+              "id": "2",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "-80",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "4",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "1",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            }
+          ],
           "is_primary_serving": true
         }
       },
       "workflow_type": "CreateLookupIndex",
       "workflow_sub_type": "None",
-      "max_v_replication_transaction_lag": "0",
-      "defer_secondary_keys": false
+      "options": {}
     }
   ]
 }
@@ -399,8 +505,8 @@ the VReplication streams and also clear the `write_only` flag from the
 Vindex indicating that it is *not* backfilling anymore.
 
 ```bash
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main externalize
-LookupVindex customer_region_lookup has been externalized and the customer_region_lookup VReplication workflow has been deleted
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer externalize
+LookupVindex corder_lookup has been externalized and the corder_lookup VReplication workflow has been deleted
 ```
 
 </br>

--- a/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -93,7 +93,7 @@ If we look at the [VSchema](../../../reference/features/vschema/) for the
 `customer_id` column:
 
 ```json
-$ vtctldclient GetVSchema customer
+$ vtctldclient --server localhost:15999 GetVSchema customer
 {
   "sharded": true,
   "vindexes": {

--- a/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
@@ -109,7 +109,7 @@ Now that we have some data in our unsharded `main` keyspace, let's go ahead and 
 for resharding. The initial vschema is unsharded and simply lists the customer table:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server localhost:15999 GetVSchema main
 {
   "sharded": false,
   "vindexes": {},
@@ -156,7 +156,7 @@ Now if we look at the `main` keyspace's vschema again we can see that it now inc
 a lookup vindex called `customer_region_lookup`:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server=localhost:15999 GetVSchema main --compact
 {
   "sharded": true,
   "vindexes": {
@@ -164,31 +164,27 @@ $ vtctldclient GetVSchema main
       "type": "consistent_lookup_unique",
       "params": {
         "from": "id",
-        "table": "main.customer_lookup",
+        "ignore_nulls": "false",
+        "table": "main.customer_region_lookup",
         "to": "keyspace_id"
       },
       "owner": "customer"
-    },
-    "hash": {
-      "type": "hash",
-      "params": {},
-      "owner": ""
     },
     "region_vdx": {
       "type": "region_json",
       "params": {
         "region_bytes": "1",
         "region_map": "./countries.json"
-      },
-      "owner": ""
+      }
+    },
+    "hash": {
+      "type": "hash"
     }
   },
   "tables": {
     "customer": {
-      "type": "",
       "column_vindexes": [
         {
-          "column": "",
           "name": "region_vdx",
           "columns": [
             "id",
@@ -196,34 +192,22 @@ $ vtctldclient GetVSchema main
           ]
         },
         {
-          "column": "id",
           "name": "customer_region_lookup",
-          "columns": []
+          "columns": [
+            "id"
+          ]
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     },
-    "customer_lookup": {
-      "type": "",
+    "customer_region_lookup": {
       "column_vindexes": [
         {
           "column": "id",
-          "name": "hash",
-          "columns": []
+          "name": "hash"
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     }
-  },
-  "require_explicit_routing": false
+  }
 }
 ```
 
@@ -293,7 +277,7 @@ Now we have tablets for our original unsharded `main` keyspace — shard `0` —
 we'll be using when we reshard the `main` keyspace:
 
 ```bash
-$ vtctldclient GetTablets --keyspace=main
+$ vtctldclient --server localhost:15999 GetTablets --keyspace=main
 zone1-0000000100 main 0 primary localhost:15100 localhost:17100 [] 2023-01-24T04:31:08Z
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
@@ -322,7 +306,7 @@ Now that our new tablets are up, we can go ahead with the resharding:
 This script executes one command:
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
 ```
 
 </br>
@@ -338,10 +322,10 @@ We can check the correctness of the copy using the [`VDiff` command](../../../re
 and the `<keyspace>.<workflow>` name we used for `Reshard` command above:
 
 ```bash
-$ vtctldclient VDiff --target-keyspace main --workflow main2regions create
+$ vtctldclient --server localhost:15999 VDiff --target-keyspace main --workflow main2regions create
 VDiff 044e8da0-9ba4-11ed-8bc7-920702940ee0 scheduled on target shards, use show to view progress
 
-$ vtctldclient VDiff --format=json --target-keyspace main --workflow main2regions show last
+$ vtctldclient --server localhost:15999 VDiff --format=json --target-keyspace main --workflow main2regions show last
 {
 	"Workflow": "main2regions",
 	"Keyspace": "main",
@@ -361,7 +345,7 @@ We can take a look at the VReplication workflow's status using the
 [`show` action](../../../reference/programs/vtctldclient/vtctldclient_reshard/vtctldclient_reshard_show/):
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions show
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions show
 ```
 
 </br>
@@ -476,7 +460,7 @@ All we have now is the sharded `main` keyspace and the original unsharded `main`
 longer exists:
 
 ```bash
-$ vtctldclient GetTablets
+$ vtctldclient --server localhost:15999 GetTablets
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
 zone1-0000000400 main 80-c0 primary localhost:15400 localhost:17400 [] 2023-01-24T04:45:38Z

--- a/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,41 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`CreateLookupVindex` command](../../migration/move-tables/) with the definition found in the
-`lookup_vindex.json` file.
-
-That file is where we both define the [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex)
-and associate it with the `customer` table in the `main` keyspace:
-
-```json
-$ cat ./lookup_vindex.json
-{
-  "sharded": true,
-  "vindexes": {
-    "customer_region_lookup": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "main.customer_lookup",
-        "from": "id",
-        "to": "keyspace_id"
-      },
-      "owner": "customer"
-    }
-  },
-  "tables": {
-    "customer": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "customer_region_lookup"
-        }
-      ]
-    }
-  }
-}
-```
-
-</br>
+[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:
@@ -264,7 +230,7 @@ $ vtctldclient GetVSchema main
 </br>
 
 Notice that the vschema shows a `hash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
-the lookup table. This is automatically created by the `CreateLookupVindex` workflow, along with the 
+the lookup table. This is automatically created by the `LookupVindex` workflow, along with the
 backing table needed to hold the vindex and populating it with the correct rows (for additional details on this
 command see [the associated user-guide](../createlookupvindex/)). We can see that by checking our `main`
 database/keyspace again:

--- a/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,7 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
+[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:

--- a/content/en/docs/19.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/19.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -39,76 +39,22 @@ To create such a lookup vindex on a real Vitess cluster, you can use the followi
 
 *Continued from [Unique Lookup Vindex Page](../unique-lookup)*
 
-Save the following json into a file, say `corder_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "corder_keyspace_idx": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "product.corder_keyspace_idx",
-        "from": "corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-          "column": "corder_id",
-          "name": "corder_keyspace_idx"
-      }],
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name corder_keyspace --table-keyspace product create --keyspace product --type consistent_lookup_unique --table-owner corder --table-owner-columns corder_id --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat corder_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace` knowing that it is sharded.
 
 #### Non-unique Lookup Vindex Example
 
 *Continued from [Non-unique Lookup Vindex Page](../non-unique-lookup)*
 
-Save the following json into a file, say `oname_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "oname_keyspace_idx": {
-      "type": "consistent_lookup",
-      "params": {
-        "table": "customer.oname_keyspace_idx",
-        "from": "oname,corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-        "columns": ["oname", "corder_id"],
-        "name": "oname_keyspace_idx"
-      }]
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name oname_keyspace --table-keyspace customer create --keyspace customer --type consistent_lookup --table-owner corder --table-owner-columns 'oname,corder_id' --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat oname_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace` knowing that it is sharded.

--- a/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -643,7 +643,7 @@ mysql> vexplain select * from corder where sku = "Product_1";
 </br>
 
 As expected, we can see it is not scattering anymore, which it would have
-before we executed the `CreateLookupVindex` command.
+before we executed the `LookupVindex create` command.
 
 Lastly, let's ensure that the lookup Vindex is being updated appropriately
 when we insert and delete rows:

--- a/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -193,7 +193,7 @@ any schema to create as it will do it automatically. Now, let us
 actually execute the `LookupVindex create` command:
 
 ```bash
-vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main create --keyspace main --type consistent_lookup_unique --table-owner customer --table-owner-columns=id --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns=sku --tablet-types=PRIMARY
 ```
 
 </br>
@@ -234,105 +234,211 @@ Now we can look what happened in greater detail:
 
 Lets observe the VReplication streams that got created using the `show` sub-command.
 
-{{< info >}}
-The created vreplication workflow will have a generated name of `<target_table_name>_vdx`.
-So in our example here: `corder_lookup_vdx`.
-{{< /info >}}
-
 ```json
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main show --include-logs=false
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer show --compact
 {
   "workflows": [
     {
-      "name": "customer_region_lookup",
+      "name": "corder_lookup",
       "source": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
       "target": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
-      "max_v_replication_lag": "0",
       "shard_streams": {
-        "0/zone1-0000000100": {
+        "-80/zone1-0000000301": {
           "streams": [
             {
-              "id": "1",
-              "shard": "0",
+              "id": "2",
+              "shard": "-80",
               "tablet": {
                 "cell": "zone1",
-                "uid": 100
+                "uid": 301
               },
               "binlog_source": {
-                "keyspace": "main",
-                "shard": "0",
-                "tablet_type": "UNKNOWN",
-                "key_range": null,
-                "tables": [],
+                "keyspace": "customer",
+                "shard": "-80",
                 "filter": {
                   "rules": [
                     {
-                      "match": "customer_region_lookup",
-                      "filter": "select id as id, keyspace_id() as keyspace_id from customer where in_keyrange(id, 'main.xxhash', '-') group by id, keyspace_id",
-                      "convert_enum_to_text": {},
-                      "convert_charset": {},
-                      "source_unique_key_columns": "",
-                      "target_unique_key_columns": "",
-                      "source_unique_key_target_columns": "",
-                      "convert_int_to_enum": {}
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
                     }
-                  ],
-                  "field_event_mode": "ERR_ON_MISMATCH",
-                  "workflow_type": "0",
-                  "workflow_name": ""
-                },
-                "on_ddl": "IGNORE",
-                "external_mysql": "",
-                "stop_after_copy": false,
-                "external_cluster": "",
-                "source_time_zone": "",
-                "target_time_zone": ""
+                  ]
+                }
               },
-              "position": "63c84d28-6888-11ee-93b0-81b2fbd12545:1-63",
-              "stop_position": "",
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
               "state": "Running",
-              "db_name": "vt_main",
+              "db_name": "vt_customer",
               "transaction_timestamp": {
-                "seconds": "1697064644",
-                "nanoseconds": 0
+                "seconds": "1726847304"
               },
               "time_updated": {
-                "seconds": "1697064646",
-                "nanoseconds": 0
+                "seconds": "1726847306"
               },
-              "message": "",
-              "copy_states": [],
-              "logs": [],
-              "log_fetch_error": "",
-              "tags": [],
-              "rows_copied": "0",
+              "tags": [
+                ""
+              ],
               "throttler_status": {
-                "component_throttled": "",
-                "time_throttled": {
-                  "seconds": "0",
-                  "nanoseconds": 0
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "-80",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 301
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '-80') group by sku, keyspace_id"
+                    }
+                  ]
                 }
-              }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
             }
           ],
-          "tablet_controls": [],
+          "is_primary_serving": true
+        },
+        "80-/zone1-0000000401": {
+          "streams": [
+            {
+              "id": "2",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "-80",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "4",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.binary_md5', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "1",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            }
+          ],
           "is_primary_serving": true
         }
       },
       "workflow_type": "CreateLookupIndex",
       "workflow_sub_type": "None",
-      "max_v_replication_transaction_lag": "0",
-      "defer_secondary_keys": false
+      "options": {}
     }
   ]
 }
@@ -399,8 +505,8 @@ the VReplication streams and also clear the `write_only` flag from the
 Vindex indicating that it is *not* backfilling anymore.
 
 ```bash
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main externalize
-LookupVindex customer_region_lookup has been externalized and the customer_region_lookup VReplication workflow has been deleted
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer externalize
+LookupVindex corder_lookup has been externalized and the corder_lookup VReplication workflow has been deleted
 ```
 
 </br>

--- a/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -93,7 +93,7 @@ If we look at the [VSchema](../../../reference/features/vschema/) for the
 `customer_id` column:
 
 ```json
-$ vtctldclient GetVSchema customer
+$ vtctldclient --server localhost:15999 GetVSchema customer
 {
   "sharded": true,
   "vindexes": {

--- a/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
@@ -109,7 +109,7 @@ Now that we have some data in our unsharded `main` keyspace, let's go ahead and 
 for resharding. The initial vschema is unsharded and simply lists the customer table:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server localhost:15999 GetVSchema main
 {
   "sharded": false,
   "vindexes": {},
@@ -156,7 +156,7 @@ Now if we look at the `main` keyspace's vschema again we can see that it now inc
 a lookup vindex called `customer_region_lookup`:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server=localhost:15999 GetVSchema main --compact
 {
   "sharded": true,
   "vindexes": {
@@ -164,31 +164,27 @@ $ vtctldclient GetVSchema main
       "type": "consistent_lookup_unique",
       "params": {
         "from": "id",
-        "table": "main.customer_lookup",
+        "ignore_nulls": "false",
+        "table": "main.customer_region_lookup",
         "to": "keyspace_id"
       },
       "owner": "customer"
-    },
-    "hash": {
-      "type": "hash",
-      "params": {},
-      "owner": ""
     },
     "region_vdx": {
       "type": "region_json",
       "params": {
         "region_bytes": "1",
         "region_map": "./countries.json"
-      },
-      "owner": ""
+      }
+    },
+    "hash": {
+      "type": "hash"
     }
   },
   "tables": {
     "customer": {
-      "type": "",
       "column_vindexes": [
         {
-          "column": "",
           "name": "region_vdx",
           "columns": [
             "id",
@@ -196,34 +192,22 @@ $ vtctldclient GetVSchema main
           ]
         },
         {
-          "column": "id",
           "name": "customer_region_lookup",
-          "columns": []
+          "columns": [
+            "id"
+          ]
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     },
-    "customer_lookup": {
-      "type": "",
+    "customer_region_lookup": {
       "column_vindexes": [
         {
           "column": "id",
-          "name": "hash",
-          "columns": []
+          "name": "hash"
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     }
-  },
-  "require_explicit_routing": false
+  }
 }
 ```
 
@@ -293,7 +277,7 @@ Now we have tablets for our original unsharded `main` keyspace — shard `0` —
 we'll be using when we reshard the `main` keyspace:
 
 ```bash
-$ vtctldclient GetTablets --keyspace=main
+$ vtctldclient --server localhost:15999 GetTablets --keyspace=main
 zone1-0000000100 main 0 primary localhost:15100 localhost:17100 [] 2023-01-24T04:31:08Z
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
@@ -322,7 +306,7 @@ Now that our new tablets are up, we can go ahead with the resharding:
 This script executes one command:
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
 ```
 
 </br>
@@ -338,10 +322,10 @@ We can check the correctness of the copy using the [`VDiff` command](../../../re
 and the `<keyspace>.<workflow>` name we used for `Reshard` command above:
 
 ```bash
-$ vtctldclient VDiff --target-keyspace main --workflow main2regions create
+$ vtctldclient --server localhost:15999 VDiff --target-keyspace main --workflow main2regions create
 VDiff 044e8da0-9ba4-11ed-8bc7-920702940ee0 scheduled on target shards, use show to view progress
 
-$ vtctldclient VDiff --format=json --target-keyspace main --workflow main2regions show last
+$ vtctldclient --server localhost:15999 VDiff --format=json --target-keyspace main --workflow main2regions show last
 {
 	"Workflow": "main2regions",
 	"Keyspace": "main",
@@ -361,7 +345,7 @@ We can take a look at the VReplication workflow's status using the
 [`show` action](../../../reference/programs/vtctldclient/vtctldclient_reshard/vtctldclient_reshard_show/):
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions show
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions show
 ```
 
 </br>
@@ -476,7 +460,7 @@ All we have now is the sharded `main` keyspace and the original unsharded `main`
 longer exists:
 
 ```bash
-$ vtctldclient GetTablets
+$ vtctldclient --server localhost:15999 GetTablets
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
 zone1-0000000400 main 80-c0 primary localhost:15400 localhost:17400 [] 2023-01-24T04:45:38Z

--- a/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,41 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`CreateLookupVindex` command](../../migration/move-tables/) with the definition found in the
-`lookup_vindex.json` file.
-
-That file is where we both define the [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex)
-and associate it with the `customer` table in the `main` keyspace:
-
-```json
-$ cat ./lookup_vindex.json
-{
-  "sharded": true,
-  "vindexes": {
-    "customer_region_lookup": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "main.customer_lookup",
-        "from": "id",
-        "to": "keyspace_id"
-      },
-      "owner": "customer"
-    }
-  },
-  "tables": {
-    "customer": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "customer_region_lookup"
-        }
-      ]
-    }
-  }
-}
-```
-
-</br>
+[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:
@@ -264,7 +230,7 @@ $ vtctldclient GetVSchema main
 </br>
 
 Notice that the vschema shows a `hash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
-the lookup table. This is automatically created by the `CreateLookupVindex` workflow, along with the 
+the lookup table. This is automatically created by the `LookupVindex` workflow, along with the
 backing table needed to hold the vindex and populating it with the correct rows (for additional details on this
 command see [the associated user-guide](../createlookupvindex/)). We can see that by checking our `main`
 database/keyspace again:

--- a/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,7 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
+[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:

--- a/content/en/docs/20.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/20.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -39,76 +39,22 @@ To create such a lookup vindex on a real Vitess cluster, you can use the followi
 
 *Continued from [Unique Lookup Vindex Page](../unique-lookup)*
 
-Save the following json into a file, say `corder_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "corder_keyspace_idx": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "product.corder_keyspace_idx",
-        "from": "corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-          "column": "corder_id",
-          "name": "corder_keyspace_idx"
-      }],
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name corder_keyspace --table-keyspace product create --keyspace product --type consistent_lookup_unique --table-owner corder --table-owner-columns corder_id --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat corder_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace` knowing that it is sharded.
 
 #### Non-unique Lookup Vindex Example
 
 *Continued from [Non-unique Lookup Vindex Page](../non-unique-lookup)*
 
-Save the following json into a file, say `oname_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "oname_keyspace_idx": {
-      "type": "consistent_lookup",
-      "params": {
-        "table": "customer.oname_keyspace_idx",
-        "from": "oname,corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-        "columns": ["oname", "corder_id"],
-        "name": "oname_keyspace_idx"
-      }]
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name oname_keyspace --table-keyspace customer create --keyspace customer --type consistent_lookup --table-owner corder --table-owner-columns 'oname,corder_id' --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat oname_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace` knowing that it is sharded.

--- a/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -643,7 +643,7 @@ mysql> vexplain select * from corder where sku = "Product_1";
 </br>
 
 As expected, we can see it is not scattering anymore, which it would have
-before we executed the `CreateLookupVindex` command.
+before we executed the `LookupVindex create` command.
 
 Lastly, let's ensure that the lookup Vindex is being updated appropriately
 when we insert and delete rows:

--- a/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -193,7 +193,7 @@ any schema to create as it will do it automatically. Now, let us
 actually execute the `LookupVindex create` command:
 
 ```bash
-vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main create --keyspace main --type consistent_lookup_unique --table-owner customer --table-owner-columns=id --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer create --keyspace customer --type consistent_lookup_unique --table-owner corder --table-owner-columns=sku --tablet-types=PRIMARY
 ```
 
 </br>
@@ -234,105 +234,211 @@ Now we can look what happened in greater detail:
 
 Lets observe the VReplication streams that got created using the `show` sub-command.
 
-{{< info >}}
-The created vreplication workflow will have a generated name of `<target_table_name>_vdx`.
-So in our example here: `corder_lookup_vdx`.
-{{< /info >}}
-
 ```json
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main show --include-logs=false
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer show --compact
 {
   "workflows": [
     {
-      "name": "customer_region_lookup",
+      "name": "corder_lookup",
       "source": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
       "target": {
-        "keyspace": "main",
+        "keyspace": "customer",
         "shards": [
-          "0"
+          "-80",
+          "80-"
         ]
       },
-      "max_v_replication_lag": "0",
       "shard_streams": {
-        "0/zone1-0000000100": {
+        "-80/zone1-0000000301": {
           "streams": [
             {
-              "id": "1",
-              "shard": "0",
+              "id": "2",
+              "shard": "-80",
               "tablet": {
                 "cell": "zone1",
-                "uid": 100
+                "uid": 301
               },
               "binlog_source": {
-                "keyspace": "main",
-                "shard": "0",
-                "tablet_type": "UNKNOWN",
-                "key_range": null,
-                "tables": [],
+                "keyspace": "customer",
+                "shard": "-80",
                 "filter": {
                   "rules": [
                     {
-                      "match": "customer_region_lookup",
-                      "filter": "select id as id, keyspace_id() as keyspace_id from customer where in_keyrange(id, 'main.xxhash', '-') group by id, keyspace_id",
-                      "convert_enum_to_text": {},
-                      "convert_charset": {},
-                      "source_unique_key_columns": "",
-                      "target_unique_key_columns": "",
-                      "source_unique_key_target_columns": "",
-                      "convert_int_to_enum": {}
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.xxhash', '-80') group by sku, keyspace_id"
                     }
-                  ],
-                  "field_event_mode": "ERR_ON_MISMATCH",
-                  "workflow_type": "0",
-                  "workflow_name": ""
-                },
-                "on_ddl": "IGNORE",
-                "external_mysql": "",
-                "stop_after_copy": false,
-                "external_cluster": "",
-                "source_time_zone": "",
-                "target_time_zone": ""
+                  ]
+                }
               },
-              "position": "63c84d28-6888-11ee-93b0-81b2fbd12545:1-63",
-              "stop_position": "",
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
               "state": "Running",
-              "db_name": "vt_main",
+              "db_name": "vt_customer",
               "transaction_timestamp": {
-                "seconds": "1697064644",
-                "nanoseconds": 0
+                "seconds": "1726847304"
               },
               "time_updated": {
-                "seconds": "1697064646",
-                "nanoseconds": 0
+                "seconds": "1726847306"
               },
-              "message": "",
-              "copy_states": [],
-              "logs": [],
-              "log_fetch_error": "",
-              "tags": [],
-              "rows_copied": "0",
+              "tags": [
+                ""
+              ],
               "throttler_status": {
-                "component_throttled": "",
-                "time_throttled": {
-                  "seconds": "0",
-                  "nanoseconds": 0
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "-80",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 301
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.xxhash', '-80') group by sku, keyspace_id"
+                    }
+                  ]
                 }
-              }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
             }
           ],
-          "tablet_controls": [],
+          "is_primary_serving": true
+        },
+        "80-/zone1-0000000401": {
+          "streams": [
+            {
+              "id": "2",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "-80",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.xxhash', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "34cf0c58-7766-11ef-b70b-17a4f2cf39af:1-1838",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "4",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            },
+            {
+              "id": "3",
+              "shard": "80-",
+              "tablet": {
+                "cell": "zone1",
+                "uid": 401
+              },
+              "binlog_source": {
+                "keyspace": "customer",
+                "shard": "80-",
+                "filter": {
+                  "rules": [
+                    {
+                      "match": "corder_lookup",
+                      "filter": "select sku as sku, keyspace_id() as keyspace_id from corder where in_keyrange(sku, 'customer.xxhash', '80-') group by sku, keyspace_id"
+                    }
+                  ]
+                }
+              },
+              "position": "3b54ffe2-7766-11ef-930d-f41db225a1b8:1-1841",
+              "state": "Running",
+              "db_name": "vt_customer",
+              "transaction_timestamp": {
+                "seconds": "1726847304"
+              },
+              "time_updated": {
+                "seconds": "1726847306"
+              },
+              "tags": [
+                ""
+              ],
+              "rows_copied": "1",
+              "throttler_status": {
+                "time_throttled": {}
+              },
+              "tablet_types": [
+                "REPLICA",
+                "PRIMARY"
+              ],
+              "cells": [
+                "zone1"
+              ]
+            }
+          ],
           "is_primary_serving": true
         }
       },
       "workflow_type": "CreateLookupIndex",
       "workflow_sub_type": "None",
-      "max_v_replication_transaction_lag": "0",
-      "defer_secondary_keys": false
+      "options": {}
     }
   ]
 }
@@ -399,8 +505,8 @@ the VReplication streams and also clear the `write_only` flag from the
 Vindex indicating that it is *not* backfilling anymore.
 
 ```bash
-$ vtctldclient --server localhost:15999 LookupVindex --name customer_region_lookup --table-keyspace main externalize
-LookupVindex customer_region_lookup has been externalized and the customer_region_lookup VReplication workflow has been deleted
+$ vtctldclient --server localhost:15999 LookupVindex --name corder_lookup --table-keyspace customer externalize
+LookupVindex corder_lookup has been externalized and the corder_lookup VReplication workflow has been deleted
 ```
 
 </br>

--- a/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/createlookupvindex.md
@@ -93,7 +93,7 @@ If we look at the [VSchema](../../../reference/features/vschema/) for the
 `customer_id` column:
 
 ```json
-$ vtctldclient GetVSchema customer
+$ vtctldclient --server localhost:15999 GetVSchema customer
 {
   "sharded": true,
   "vindexes": {

--- a/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,41 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`CreateLookupVindex` command](../../migration/move-tables/) with the definition found in the
-`lookup_vindex.json` file.
-
-That file is where we both define the [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex)
-and associate it with the `customer` table in the `main` keyspace:
-
-```json
-$ cat ./lookup_vindex.json
-{
-  "sharded": true,
-  "vindexes": {
-    "customer_region_lookup": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "main.customer_lookup",
-        "from": "id",
-        "to": "keyspace_id"
-      },
-      "owner": "customer"
-    }
-  },
-  "tables": {
-    "customer": {
-      "column_vindexes": [
-        {
-          "column": "id",
-          "name": "customer_region_lookup"
-        }
-      ]
-    }
-  }
-}
-```
-
-</br>
+[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:
@@ -264,7 +230,7 @@ $ vtctldclient GetVSchema main
 </br>
 
 Notice that the vschema shows a `hash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
-the lookup table. This is automatically created by the `CreateLookupVindex` workflow, along with the 
+the lookup table. This is automatically created by the `LookupVindex` workflow, along with the
 backing table needed to hold the vindex and populating it with the correct rows (for additional details on this
 command see [the associated user-guide](../createlookupvindex/)). We can see that by checking our `main`
 database/keyspace again:

--- a/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
@@ -150,7 +150,7 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
+[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:

--- a/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/region-sharding.md
@@ -109,7 +109,7 @@ Now that we have some data in our unsharded `main` keyspace, let's go ahead and 
 for resharding. The initial vschema is unsharded and simply lists the customer table:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server localhost:15999 GetVSchema main
 {
   "sharded": false,
   "vindexes": {},
@@ -150,13 +150,13 @@ We then run the 201 script:
 
 That script creates our sharded vschema as defined in the `main_vschema_sharded.json` file and it
 creates a [lookup vindex](../../../reference/features/vindexes/#functional-and-lookup-vindex) using the
-[`LookupVindex create` command](../../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
+[`LookupVindex create` command](../../reference/programs/vtctldclient/vtctldclient_lookupvindex/vtctldclient_lookupvindex_create/).
 
 Now if we look at the `main` keyspace's vschema again we can see that it now includes the `region_vdx` vindex and
 a lookup vindex called `customer_region_lookup`:
 
 ```json
-$ vtctldclient GetVSchema main
+$ vtctldclient --server=localhost:15999 GetVSchema main --compact
 {
   "sharded": true,
   "vindexes": {
@@ -164,31 +164,27 @@ $ vtctldclient GetVSchema main
       "type": "consistent_lookup_unique",
       "params": {
         "from": "id",
-        "table": "main.customer_lookup",
+        "ignore_nulls": "false",
+        "table": "main.customer_region_lookup",
         "to": "keyspace_id"
       },
       "owner": "customer"
-    },
-    "hash": {
-      "type": "hash",
-      "params": {},
-      "owner": ""
     },
     "region_vdx": {
       "type": "region_json",
       "params": {
         "region_bytes": "1",
         "region_map": "./countries.json"
-      },
-      "owner": ""
+      }
+    },
+    "xxhash": {
+      "type": "xxhash"
     }
   },
   "tables": {
     "customer": {
-      "type": "",
       "column_vindexes": [
         {
-          "column": "",
           "name": "region_vdx",
           "columns": [
             "id",
@@ -196,40 +192,28 @@ $ vtctldclient GetVSchema main
           ]
         },
         {
-          "column": "id",
           "name": "customer_region_lookup",
-          "columns": []
+          "columns": [
+            "id"
+          ]
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     },
-    "customer_lookup": {
-      "type": "",
+    "customer_region_lookup": {
       "column_vindexes": [
         {
           "column": "id",
-          "name": "hash",
-          "columns": []
+          "name": "xxhash"
         }
-      ],
-      "auto_increment": null,
-      "columns": [],
-      "pinned": "",
-      "column_list_authoritative": false,
-      "source": ""
+      ]
     }
-  },
-  "require_explicit_routing": false
+  }
 }
 ```
 
 </br>
 
-Notice that the vschema shows a `hash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
+Notice that the vschema shows a `xxhash` [vindex type](../../../reference/features/vindexes/#predefined-vindexes) for
 the lookup table. This is automatically created by the `LookupVindex` workflow, along with the
 backing table needed to hold the vindex and populating it with the correct rows (for additional details on this
 command see [the associated user-guide](../createlookupvindex/)). We can see that by checking our `main`
@@ -293,7 +277,7 @@ Now we have tablets for our original unsharded `main` keyspace — shard `0` —
 we'll be using when we reshard the `main` keyspace:
 
 ```bash
-$ vtctldclient GetTablets --keyspace=main
+$ vtctldclient --server localhost:15999 GetTablets --keyspace=main
 zone1-0000000100 main 0 primary localhost:15100 localhost:17100 [] 2023-01-24T04:31:08Z
 zone1-0000000200 main -40 primary localhost:15200 localhost:17200 [] 2023-01-24T04:45:38Z
 zone1-0000000300 main 40-80 primary localhost:15300 localhost:17300 [] 2023-01-24T04:45:38Z
@@ -322,7 +306,7 @@ Now that our new tablets are up, we can go ahead with the resharding:
 This script executes one command:
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions create --source-shards '0' --target-shards '-40,40-80,80-c0,c0-' --tablet-types=PRIMARY
 ```
 
 </br>
@@ -338,10 +322,10 @@ We can check the correctness of the copy using the [`VDiff` command](../../../re
 and the `<keyspace>.<workflow>` name we used for `Reshard` command above:
 
 ```bash
-$ vtctldclient VDiff --target-keyspace main --workflow main2regions create
+$ vtctldclient --server localhost:15999 VDiff --target-keyspace main --workflow main2regions create
 VDiff 044e8da0-9ba4-11ed-8bc7-920702940ee0 scheduled on target shards, use show to view progress
 
-$ vtctldclient VDiff --format=json --target-keyspace main --workflow main2regions show last
+$ vtctldclient --server localhost:15999 VDiff --format=json --target-keyspace main --workflow main2regions show last
 {
 	"Workflow": "main2regions",
 	"Keyspace": "main",
@@ -361,7 +345,7 @@ We can take a look at the VReplication workflow's status using the
 [`show` action](../../../reference/programs/vtctldclient/vtctldclient_reshard/vtctldclient_reshard_show/):
 
 ```bash
-vtctldclient Reshard --target-keyspace main --workflow main2regions show
+vtctldclient --server localhost:15999 Reshard --target-keyspace main --workflow main2regions show
 ```
 
 </br>
@@ -427,7 +411,7 @@ You can see that only data from US and Canada exists in the `customer` table in 
 other shards — `40-80`, `80-c0`, and `c0-` — you will see that each shard contains 4 rows in `customer` table.
 
 The lookup table, however, has a different number of rows per shard. This is because we are using a
-[`hash` vindex type](../../../reference/features/vindexes/#predefined-vindexes) to shard the lookup table
+[`xxhash` vindex type](../../../reference/features/vindexes/#predefined-vindexes) to shard the lookup table
 which means that it is distributed differently from the `customer` table. We can see an example of this if we
 look at the next shard, `40-80`:
 

--- a/content/en/docs/21.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/21.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -39,76 +39,22 @@ To create such a lookup vindex on a real Vitess cluster, you can use the followi
 
 *Continued from [Unique Lookup Vindex Page](../unique-lookup)*
 
-Save the following json into a file, say `corder_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "corder_keyspace_idx": {
-      "type": "consistent_lookup_unique",
-      "params": {
-        "table": "product.corder_keyspace_idx",
-        "from": "corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-          "column": "corder_id",
-          "name": "corder_keyspace_idx"
-      }],
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name corder_keyspace --table-keyspace product create --keyspace product --type consistent_lookup_unique --table-owner corder --table-owner-columns corder_id --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat corder_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `corder_keyspace` knowing that it is sharded.
 
 #### Non-unique Lookup Vindex Example
 
 *Continued from [Non-unique Lookup Vindex Page](../non-unique-lookup)*
 
-Save the following json into a file, say `oname_keyspace_idx.json`:
+Issue the `vtctldclient` command:
 
-```json
-{
-  "sharded": true,
-  "vindexes": {
-    "oname_keyspace_idx": {
-      "type": "consistent_lookup",
-      "params": {
-        "table": "customer.oname_keyspace_idx",
-        "from": "oname,corder_id",
-        "to": "keyspace_id"
-      },
-      "owner": "corder"
-    }
-  },
-  "tables": {
-    "corder": {
-      "column_vindexes": [{
-        "columns": ["oname", "corder_id"],
-        "name": "oname_keyspace_idx"
-      }]
-    }
-  }
-}
+```bash
+vtctldclient --server localhost:15999 LookupVindex --name oname_keyspace --table-keyspace customer create --keyspace customer --type consistent_lookup --table-owner corder --table-owner-columns 'oname,corder_id' --tablet-types=PRIMARY
 ```
 
-And issue the vtctldclient command:
-
-```sh
-$ vtctldclient --server <vtctld_grpc_address> CreateLookupVindex -- --tablet_types=REPLICA customer "$(cat oname_keyspace_idx.json)"
-```
-
-The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace_idx` knowing that it is sharded.
+The workflow will automatically create the necessary Primary Vindex entries for vindex table `oname_keyspace` knowing that it is sharded.


### PR DESCRIPTION
This is a follow-up to https://github.com/vitessio/website/pull/1619 where the docs were updated to move from `vtctlclient` to `vtctldclient` and the examples changed in https://github.com/vitessio/website/pull/1619/files#diff-3fa06a66472f0c25278194a50fa70abc88b109d64404009fc9a6c8c61be241de were not correct. For example here you can see that the workflow name and details were different between the old and new commands: https://github.com/vitessio/website/pull/1619/files#diff-3fa06a66472f0c25278194a50fa70abc88b109d64404009fc9a6c8c61be241deL220-R196

The changes made are identical in all versions changed (18-21), the only difference is that in v21 the default vindex type used was changed from `binary_md5` to `xxhash` via https://github.com/vitessio/vitess/pull/16113). 

Previews:
  - 18.0: 
    - https://deploy-preview-1854--vitess.netlify.app/docs/18.0/user-guides/vschema-guide/backfill-vindexes/
    - https://deploy-preview-1854--vitess.netlify.app/docs/18.0/user-guides/configuration-advanced/region-sharding/
    - https://deploy-preview-1854--vitess.netlify.app/docs/18.0/user-guides/configuration-advanced/createlookupvindex/
  - 19.0: 
    - https://deploy-preview-1854--vitess.netlify.app/docs/19.0/user-guides/vschema-guide/backfill-vindexes/
    - https://deploy-preview-1854--vitess.netlify.app/docs/19.0/user-guides/configuration-advanced/region-sharding/
    - https://deploy-preview-1854--vitess.netlify.app/docs/19.0/user-guides/configuration-advanced/createlookupvindex/
  - 20.0: 
    - https://deploy-preview-1854--vitess.netlify.app/docs/20.0/user-guides/vschema-guide/backfill-vindexes/
    - https://deploy-preview-1854--vitess.netlify.app/docs/20.0/user-guides/configuration-advanced/region-sharding/
    - https://deploy-preview-1854--vitess.netlify.app/docs/20.0/user-guides/configuration-advanced/createlookupvindex/
  - 21.0
    - https://deploy-preview-1854--vitess.netlify.app/docs/21.0/user-guides/vschema-guide/backfill-vindexes/
    - https://deploy-preview-1854--vitess.netlify.app/docs/21.0/user-guides/configuration-advanced/region-sharding/
    - https://deploy-preview-1854--vitess.netlify.app/docs/21.0/user-guides/configuration-advanced/createlookupvindex/