### PR TITLE
Document changes from https://github.com/vitessio/vitess/pull/16906

### DIFF
--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient
 
@@ -42,6 +42,7 @@ vtctldclient [flags]
 * [vtctldclient ApplyVSchema](./vtctldclient_applyvschema/)	 - Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
 * [vtctldclient Backup](./vtctldclient_backup/)	 - Uses the BackupStorage service on the given tablet to create and store a new backup.
 * [vtctldclient BackupShard](./vtctldclient_backupshard/)	 - Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard and uses the BackupStorage service on that tablet to create and store a new backup.
+* [vtctldclient ChangeTabletTags](./vtctldclient_changetablettags/)	 - Changes the tablet tags for the specified tablet, if possible.
 * [vtctldclient ChangeTabletType](./vtctldclient_changetablettype/)	 - Changes the db type for the specified tablet, if possible.
 * [vtctldclient CheckThrottler](./vtctldclient_checkthrottler/)	 - Issue a throttler check on the given tablet.
 * [vtctldclient CreateKeyspace](./vtctldclient_createkeyspace/)	 - Creates the specified keyspace in the topology.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
@@ -1,28 +1,27 @@
 ---
-title: Workflow start
+title: ChangeTabletTags
 series: vtctldclient
 commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
-## vtctldclient Workflow start
+## vtctldclient ChangeTabletTags
 
-Start a VReplication workflow.
+Changes the tablet tags for the specified tablet, if possible.
+
+### Synopsis
+
+Changes the tablet tags for the specified tablet, if possible.
+
+Tags must be specified as key=value pairs.
 
 ```
-vtctldclient Workflow start
-```
-
-### Examples
-
-```
-vtctldclient --server localhost:15999 workflow --keyspace customer start --workflow commerce2customer
+vtctldclient ChangeTabletTags <alias> <tablet-tag> [ <tablet-tag> ... ]
 ```
 
 ### Options
 
 ```
-  -h, --help              help for start
-      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
-  -w, --workflow string   The workflow you want to start.
+  -h, --help      help for ChangeTabletTags
+  -r, --replace   Replace all tablet tags with the tags provided. By default tags are merged/updated.
 ```
 
 ### Options inherited from parent commands
@@ -30,7 +29,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
       --compact                              use compact format for otherwise verbose outputs
-  -k, --keyspace string                      Keyspace context for the workflow.
       --server string                        server to use for the connection (required)
       --topo-global-root string              the path of the global topology data in the global topology server (default "/vitess/global")
       --topo-global-server-address strings   the address of the global topology server(s) (default [localhost:2379])
@@ -39,5 +37,5 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 
 ### SEE ALSO
 
-* [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DistributedTransaction
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction conclude
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient DistributedTransaction conclude
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
@@ -1,28 +1,22 @@
 ---
-title: Workflow start
+title: DistributedTransaction unresolved-list
 series: vtctldclient
 commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
-## vtctldclient Workflow start
+## vtctldclient DistributedTransaction unresolved-list
 
-Start a VReplication workflow.
-
-```
-vtctldclient Workflow start
-```
-
-### Examples
+Retrieves unresolved transactions for the given keyspace.
 
 ```
-vtctldclient --server localhost:15999 workflow --keyspace customer start --workflow commerce2customer
+vtctldclient DistributedTransaction unresolved-list --keyspace <keyspace> --abandon-age <abandon_time_seconds>
 ```
 
 ### Options
 
 ```
-  -h, --help              help for start
-      --shards strings    (Optional) Specifies a comma-separated list of shards to operate on.
-  -w, --workflow string   The workflow you want to start.
+  -a, --abandon-age int   unresolved transactions list which are older than the specified age(in seconds).
+  -h, --help              help for unresolved-list
+  -k, --keyspace string   unresolved transactions list for the given keyspace.
 ```
 
 ### Options inherited from parent commands
@@ -30,7 +24,6 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 ```
       --action_timeout duration              timeout to use for the command (default 1h0m0s)
       --compact                              use compact format for otherwise verbose outputs
-  -k, --keyspace string                      Keyspace context for the workflow.
       --server string                        server to use for the connection (required)
       --topo-global-root string              the path of the global topology data in the global topology server (default "/vitess/global")
       --topo-global-server-address strings   the address of the global topology server(s) (default [localhost:2379])
@@ -39,5 +32,5 @@ vtctldclient --server localhost:15999 workflow --keyspace customer start --workf
 
 ### SEE ALSO
 
-* [vtctldclient Workflow](../)	 - Administer VReplication workflows (Reshard, MoveTables, etc) in the given keyspace.
+* [vtctldclient DistributedTransaction](../)	 - Perform commands on distributed transaction
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient EmergencyReparentShard
 
@@ -14,6 +14,7 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
 ### Options
 
 ```
+      --expected-primary string          Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                             help for EmergencyReparentShard
   -i, --ignore-replicas strings          Comma-separated, repeated list of replica tablet aliases to ignore during the emergency reparent.
       --new-primary string               Alias of a tablet that should be the new primary. If not specified, the vtctld will select the best candidate to promote.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -16,6 +16,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ```
       --allow-cross-cell-promotion           Allow cross cell promotion
       --avoid-primary string                 Alias of a tablet that should not be the primary; i.e. "reparent to any other tablet if this one is the primary".
+      --expected-primary string              Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                                 help for PlannedReparentShard
       --new-primary string                   Alias of a tablet that should be the new primary.
       --tolerable-replication-lag duration   Amount of replication lag that is considered acceptable for a tablet to be eligible for promotion when Vitess makes the choice of a new primary.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient
 
@@ -42,6 +42,7 @@ vtctldclient [flags]
 * [vtctldclient ApplyVSchema](./vtctldclient_applyvschema/)	 - Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
 * [vtctldclient Backup](./vtctldclient_backup/)	 - Uses the BackupStorage service on the given tablet to create and store a new backup.
 * [vtctldclient BackupShard](./vtctldclient_backupshard/)	 - Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard and uses the BackupStorage service on that tablet to create and store a new backup.
+* [vtctldclient ChangeTabletTags](./vtctldclient_changetablettags/)	 - Changes the tablet tags for the specified tablet, if possible.
 * [vtctldclient ChangeTabletType](./vtctldclient_changetablettype/)	 - Changes the db type for the specified tablet, if possible.
 * [vtctldclient CheckThrottler](./vtctldclient_checkthrottler/)	 - Issue a throttler check on the given tablet.
 * [vtctldclient CreateKeyspace](./vtctldclient_createkeyspace/)	 - Creates the specified keyspace in the topology.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
@@ -1,0 +1,41 @@
+---
+title: ChangeTabletTags
+series: vtctldclient
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
+---
+## vtctldclient ChangeTabletTags
+
+Changes the tablet tags for the specified tablet, if possible.
+
+### Synopsis
+
+Changes the tablet tags for the specified tablet, if possible.
+
+Tags must be specified as key=value pairs.
+
+```
+vtctldclient ChangeTabletTags <alias> <tablet-tag> [ <tablet-tag> ... ]
+```
+
+### Options
+
+```
+  -h, --help      help for ChangeTabletTags
+  -r, --replace   Replace all tablet tags with the tags provided. By default tags are merged/updated.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration              timeout to use for the command (default 1h0m0s)
+      --compact                              use compact format for otherwise verbose outputs
+      --server string                        server to use for the connection (required)
+      --topo-global-root string              the path of the global topology data in the global topology server (default "/vitess/global")
+      --topo-global-server-address strings   the address of the global topology server(s) (default [localhost:2379])
+      --topo-implementation string           the topology implementation to use (default "etcd2")
+```
+
+### SEE ALSO
+
+* [vtctldclient](../)	 - Executes a cluster management command on the remote vtctld server.
+

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DistributedTransaction
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DistributedTransaction
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction conclude
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient DistributedTransaction conclude
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction conclude
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient DistributedTransaction conclude
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
@@ -1,0 +1,36 @@
+---
+title: DistributedTransaction unresolved-list
+series: vtctldclient
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
+---
+## vtctldclient DistributedTransaction unresolved-list
+
+Retrieves unresolved transactions for the given keyspace.
+
+```
+vtctldclient DistributedTransaction unresolved-list --keyspace <keyspace> --abandon-age <abandon_time_seconds>
+```
+
+### Options
+
+```
+  -a, --abandon-age int   unresolved transactions list which are older than the specified age(in seconds).
+  -h, --help              help for unresolved-list
+  -k, --keyspace string   unresolved transactions list for the given keyspace.
+```
+
+### Options inherited from parent commands
+
+```
+      --action_timeout duration              timeout to use for the command (default 1h0m0s)
+      --compact                              use compact format for otherwise verbose outputs
+      --server string                        server to use for the connection (required)
+      --topo-global-root string              the path of the global topology data in the global topology server (default "/vitess/global")
+      --topo-global-server-address strings   the address of the global topology server(s) (default [localhost:2379])
+      --topo-implementation string           the topology implementation to use (default "etcd2")
+```
+
+### SEE ALSO
+
+* [vtctldclient DistributedTransaction](../)	 - Perform commands on distributed transaction
+

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient EmergencyReparentShard
 
@@ -14,6 +14,7 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
 ### Options
 
 ```
+      --expected-primary string          Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                             help for EmergencyReparentShard
   -i, --ignore-replicas strings          Comma-separated, repeated list of replica tablet aliases to ignore during the emergency reparent.
       --new-primary string               Alias of a tablet that should be the new primary. If not specified, the vtctld will select the best candidate to promote.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables cancel
 
@@ -20,10 +20,11 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-  -h, --help                 help for cancel
-      --keep-data            Keep the partially copied table data from the MoveTables workflow in the target keyspace.
-      --keep-routing-rules   Keep the routing rules created for the MoveTables workflow.
-      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
+      --delete-batch-size int   When cleaning up the migrated data in tables moved as part of a mult-tenant workflow, delete the records in batches of this size. (default 1000)
+  -h, --help                    help for cancel
+      --keep-data               Keep the partially copied table data from the MoveTables workflow in the target keyspace.
+      --keep-routing-rules      Keep the routing rules created for the MoveTables workflow.
+      --shards strings          (Optional) Specifies a comma-separated list of shards to operate on.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables cancel
 
@@ -20,7 +20,7 @@ vtctldclient --server localhost:15999 MoveTables --workflow commerce2customer --
 ### Options
 
 ```
-      --delete-batch-size int   When cleaning up the migrated data in tables moved as part of a mult-tenant workflow, delete the records in batches of this size. (default 1000)
+      --delete-batch-size int   When cleaning up the migrated data in tables moved as part of a multi-tenant workflow, delete the records in batches of this size. (default 1000)
   -h, --help                    help for cancel
       --keep-data               Keep the partially copied table data from the MoveTables workflow in the target keyspace.
       --keep-routing-rules      Keep the routing rules created for the MoveTables workflow.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -16,6 +16,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ```
       --allow-cross-cell-promotion           Allow cross cell promotion
       --avoid-primary string                 Alias of a tablet that should not be the primary; i.e. "reparent to any other tablet if this one is the primary".
+      --expected-primary string              Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                                 help for PlannedReparentShard
       --new-primary string                   Alias of a tablet that should be the new primary.
       --tolerable-replication-lag duration   Amount of replication lag that is considered acceptable for a tablet to be eligible for promotion when Vitess makes the choice of a new primary.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff create
 
@@ -30,7 +30,7 @@ vtctldclient --server :15999 vdiff --workflow c2c --target-keyspace customer cre
       --max-diff-duration duration                How long should an individual table diff run before being stopped and restarted in order to lessen the impact on tablets due to holding open database snapshots for long periods of time (0 is the default and means no time limit).
       --max-extra-rows-to-compare int             If there are collation differences between the source and target, you can have rows that are identical but simply returned in a different order from MySQL. We will do a second pass to compare the rows for any actual differences in this case and this flag allows you to control the resources used for this operation. (default 1000)
       --max-report-sample-rows int                Maximum number of row differences to report (0 for all differences). NOTE: when increasing this value it is highly recommended to also specify --only-pks (default 10)
-      --only-pks                                  When reporting missing rows, only show primary keys in the report.
+      --only-pks                                  When reporting row differences, only show primary keys in the report.
       --row-diff-column-truncate-at int           When showing row differences, truncate the non Primary Key column values to this length. A value less than 1 means do not truncate. (default 128)
       --source-cells strings                      The source cell(s) to compare from; default is any available cell.
       --tables strings                            Only run vdiff for these tables in the workflow.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff create
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow delete
 
@@ -20,11 +20,12 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
 ### Options
 
 ```
-  -h, --help                 help for delete
-      --keep-data            Keep the partially copied table data from the workflow in the target keyspace.
-      --keep-routing-rules   Keep the routing rules created for the workflow.
-      --shards strings       (Optional) Specifies a comma-separated list of shards to operate on.
-  -w, --workflow string      The workflow you want to delete.
+      --delete-batch-size int   The batch size to use when deleting a subset of data from the migrated tables. This is only used with multi-tenant MoveTables workflows. (default 1000)
+  -h, --help                    help for delete
+      --keep-data               Keep the partially copied table data from the workflow in the target keyspace.
+      --keep-routing-rules      Keep the routing rules created for the workflow.
+      --shards strings          (Optional) Specifies a comma-separated list of shards to operate on.
+  -w, --workflow string         The workflow you want to delete.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow delete
 
@@ -20,7 +20,7 @@ vtctldclient --server localhost:15999 workflow --keyspace customer delete --work
 ### Options
 
 ```
-      --delete-batch-size int   The batch size to use when deleting a subset of data from the migrated tables. This is only used with multi-tenant MoveTables workflows. (default 1000)
+      --delete-batch-size int   When cleaning up the migrated data in tables moved as part of a multi-tenant MoveTables workflow, delete the records in batches of this size. (default 1000)
   -h, --help                    help for delete
       --keep-data               Keep the partially copied table data from the workflow in the target keyspace.
       --keep-routing-rules      Keep the routing rules created for the workflow.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 76350bd01072921484303a16e9879f69d907f6f3
+commit: b0b79813f21f8ecbf409f558ad6f8864332637cf
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 76350bd01072921484303a16e9879f69d907f6f3
 ---
 ## vtctldclient Workflow update
 


### PR DESCRIPTION
Pages changed (adding `--delete-batch-size`):
  - https://deploy-preview-1866--vitess.netlify.app/docs/22.0/reference/programs/vtctldclient/vtctldclient_workflow/vtctldclient_workflow_delete/
  - https://deploy-preview-1866--vitess.netlify.app/docs/22.0/reference/programs/vtctldclient/vtctldclient_movetables/vtctldclient_movetables_cancel/

This PR also brings the v21 and v22 docs up to date with the `release-21.0` and `main` branches respectively.