### PR TITLE
Bring v21 vtctldclient generated docs up to date

### DIFF
--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient
 
@@ -42,6 +42,7 @@ vtctldclient [flags]
 * [vtctldclient ApplyVSchema](./vtctldclient_applyvschema/)	 - Applies the VTGate routing schema to the provided keyspace. Shows the result after application.
 * [vtctldclient Backup](./vtctldclient_backup/)	 - Uses the BackupStorage service on the given tablet to create and store a new backup.
 * [vtctldclient BackupShard](./vtctldclient_backupshard/)	 - Finds the most up-to-date REPLICA, RDONLY, or SPARE tablet in the given shard and uses the BackupStorage service on that tablet to create and store a new backup.
+* [vtctldclient ChangeTabletTags](./vtctldclient_changetablettags/)	 - Changes the tablet tags for the specified tablet, if possible.
 * [vtctldclient ChangeTabletType](./vtctldclient_changetablettype/)	 - Changes the db type for the specified tablet, if possible.
 * [vtctldclient CheckThrottler](./vtctldclient_checkthrottler/)	 - Issue a throttler check on the given tablet.
 * [vtctldclient CreateKeyspace](./vtctldclient_createkeyspace/)	 - Creates the specified keyspace in the topology.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DistributedTransaction
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction conclude
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient DistributedTransaction conclude
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient EmergencyReparentShard
 
@@ -14,6 +14,7 @@ vtctldclient EmergencyReparentShard <keyspace/shard>
 ### Options
 
 ```
+      --expected-primary string          Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                             help for EmergencyReparentShard
   -i, --ignore-replicas strings          Comma-separated, repeated list of replica tablet aliases to ignore during the emergency reparent.
       --new-primary string               Alias of a tablet that should be the new primary. If not specified, the vtctld will select the best candidate to promote.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient PlannedReparentShard
 
@@ -16,6 +16,7 @@ vtctldclient PlannedReparentShard <keyspace/shard>
 ```
       --allow-cross-cell-promotion           Allow cross cell promotion
       --avoid-primary string                 Alias of a tablet that should not be the primary; i.e. "reparent to any other tablet if this one is the primary".
+      --expected-primary string              Alias of a tablet that must be the current primary in order for the reparent to be processed.
   -h, --help                                 help for PlannedReparentShard
       --new-primary string                   Alias of a tablet that should be the new primary.
       --tolerable-replication-lag duration   Amount of replication lag that is considered acceptable for a tablet to be eligible for promotion when Vitess makes the choice of a new primary.

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 14b6873142558358a99a68d2b5ef0ec204f3776a
+commit: 376c478ce7daca627d063f22af9121e173787e31
 ---
 ## vtctldclient Workflow update
 


### PR DESCRIPTION
These updates were generated by this command after ensuring that the local `release-21.0` branch was up to date:
```
go run ./tools/cobradocs/ --vitess-dir "/Users/matt/git/vitess" --version-pairs "release-21.0:21.0" vtctldclient
```