### PR TITLE
Remove references to unnecessary/removed --init_populate_metadata option

### DIFF
--- a/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/18.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/19.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/19.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/20.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/22.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/22.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/archive/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/archive/16.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -80,12 +80,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 

--- a/content/en/docs/archive/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/archive/17.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,12 +79,8 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --init_populate_metadata \
  --disable_active_reparents &
 ```
-
-Note that if your tablet is using a MySQL instance type where you do not have `SUPER` privileges to the database
-(e.g. AWS RDS, AWS Aurora or Google CloudSQL), you should omit the `--init_populate_metadata` flag. The `--init_populate_metadata` flag should only be enabled if the cluster is being managed through Vitess.
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).
 


### PR DESCRIPTION
The `--init_populate_metadata` option to `vttablet` was deprecated in v16 and removed in v18, but the Unmanaged Tablet example commands still reference it. This PR removes the references to the argument since it was unnecessary in v16/v17 and removed v18 and later.
