### PR TITLE
v21 release: refresh generated docs before GA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,14 @@ generated-docs: mysqlctl-docs \
 
 
 %-docs:
+	set -e
 	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $*
+	LC_ALL=C find content -type f -exec sed -i '' 's;${VITESS_DIR};\<WORKDIR\>;g' {} +
+	find . -type f -name '*md-e' -exec rm -f {} +
+	git add content
+	git commit -s -m "Update cobra docs using make generated-docs for vitess repo sha `git -C ${VITESS_DIR} rev-parse HEAD` "
+
+
 
 .PHONY: generated-docs
 

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check-all-links: clean build link-checker-setup
 	bin/htmltest --conf .htmltest.external.yml
 
 ifndef COBRADOC_VERSION_PAIRS
-export COBRADOC_VERSION_PAIRS="main:20.0,v19.0.3:19.0,v18.0.4:18.0,v17.0.6:17.0"
+export COBRADOC_VERSION_PAIRS="main:20.0,v19.0.3:19.0,v18.0.4:18.0"
 endif
 
 generated-docs: mysqlctl-docs \
@@ -65,78 +65,9 @@ generated-docs: mysqlctl-docs \
 	zkctl-docs \
 	zkctld-docs
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make mysqlctl-docs
-mysqlctl-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" mysqlctl
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make mysqlctld-docs
-mysqlctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" mysqlctld
+%-docs:
+	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $*
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtaclcheck-docs
-vtaclcheck-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtaclcheck
+.PHONY: generated-docs
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make topo2topo-docs
-topo2topo-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" topo2topo
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtbackup-docs
-vtbackup-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtbackup
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtbench-docs
-vtbench-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtbench
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtclient-docs
-vtclient-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtclient
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtcombo-docs
-vtcombo-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtcombo
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtctld-docs
-vtctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtctld
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtctldclient-docs
-vtctldclient-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtctldclient
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtgate-docs
-vtgate-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtgate
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtgateclienttest-docs
-vtgateclienttest-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtgateclienttest
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtorc-docs
-vtorc-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtorc
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttablet-docs
-vttablet-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttablet
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttestserver-docs
-vttestserver-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttestserver
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttlstest-docs
-vttlstest-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttlstest
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zk-docs
-zk-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zk
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zkctl-docs
-zkctl-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zkctl
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zkctld-docs
-zkctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zkctld

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,6 @@ generated-docs: mysqlctl-docs \
 	topo2topo-docs \
 	vtaclcheck-docs \
 	vtbackup-docs \
-	vtbench-docs \
 	vtclient-docs \
 	vtcombo-docs \
 	vtctld-docs \
@@ -72,7 +71,7 @@ generated-docs: mysqlctl-docs \
 	LC_ALL=C find content -type f -exec sed -i '' 's;${VITESS_DIR};\<WORKDIR\>;g' {} +
 	find . -type f -name '*md-e' -exec rm -f {} +
 	git add content
-	git commit -s -m "Update cobra docs using make generated-docs for vitess repo sha `git -C ${VITESS_DIR} rev-parse HEAD` "
+	git commit --allow-empty -s -m "Update cobra docs using make generated-docs for $* (vitess sha `git -C ${VITESS_DIR} rev-parse HEAD`) "
 
 
 

--- a/content/en/docs/21.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl
 
@@ -39,7 +39,7 @@ This helps ensure that `mysqld` is automatically restarted after failures.
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl init
 
@@ -58,7 +58,7 @@ mysqlctl \
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,7 @@
 ---
 title: init config
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl init_config
 
@@ -56,7 +56,7 @@ mysqlctl \
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,7 @@
 ---
 title: position
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl position
 
@@ -41,7 +41,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,7 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl reinit_config
 
@@ -56,7 +56,7 @@ mysqlctl \
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl shutdown
 
@@ -54,7 +54,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl start
 
@@ -53,7 +53,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: mysqlctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctl teardown
 
@@ -57,7 +57,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --db-credentials-vault-tls-ca string                          Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                       Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                           How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password

--- a/content/en/docs/21.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/21.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## mysqlctld
 
@@ -58,7 +58,7 @@ mysqlctld \
       --db-credentials-vault-tls-ca string                               Path to CA PEM for validating Vault server certificate
       --db-credentials-vault-tokenfile string                            Path to file containing Vault auth token; token can also be passed using VAULT_TOKEN environment variable
       --db-credentials-vault-ttl duration                                How long to cache DB credentials from the Vault server (default 30m0s)
-      --db_charset string                                                Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                                Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                               enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                        connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                           db dba password
@@ -78,6 +78,7 @@ mysqlctld \
       --db_tls_min_version string                                        Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
       --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/content/en/docs/21.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/21.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## topo2topo
 

--- a/content/en/docs/21.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtaclcheck
 

--- a/content/en/docs/21.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtbackup
 
@@ -106,7 +106,7 @@ vtbackup [flags]
       --db_appdebug_password string                                 db appdebug password
       --db_appdebug_use_ssl                                         Set this flag to false to make the appdebug connection to not use ssl (default true)
       --db_appdebug_user string                                     db appdebug user userKey (default "vt_appdebug")
-      --db_charset string                                           Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                           Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                          enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                   connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                      db dba password
@@ -142,6 +142,7 @@ vtbackup [flags]
       --file_backup_storage_root string                             Root directory for the file backup storage.
       --gcs_backup_storage_bucket string                            Google Cloud Storage bucket to use for backups.
       --gcs_backup_storage_root string                              Root prefix for all backup-related object names.
+      --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
       --grpc_enable_tracing                                         Enable gRPC tracing.
@@ -161,7 +162,7 @@ vtbackup [flags]
       --keep-alive-timeout duration                                 Wait until timeout elapses after a successful backup before shutting down.
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)
-      --lock-timeout duration                                       Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                       Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --log_backtrace_at traceLocations                             when logging hits line file:N, emit a stack trace
       --log_dir string                                              If non-empty, write log files in this directory
       --log_err_stacks                                              log stack traces for errors
@@ -189,6 +190,12 @@ vtbackup [flags]
       --mycnf_slow_log_path string                                  mysql slow query log path
       --mycnf_socket_file string                                    mysql socket file
       --mycnf_tmp_dir string                                        mysql tmp directory
+      --mysql-shell-backup-location string                          location where the backup will be stored
+      --mysql-shell-dump-flags string                               flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
+      --mysql-shell-flags string                                    execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
+      --mysql-shell-load-flags string                               flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-should-drain                                    decide if we should drain while taking a backup or continue to serving traffic
+      --mysql-shell-speedup-restore                                 speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                             how long to wait for mysqld shutdown (default 5m0s)
       --mysql_port int                                              mysql port (default 3306)
       --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")

--- a/content/en/docs/21.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtclient
 series: vtclient
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtclient
 

--- a/content/en/docs/21.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtcombo
 
@@ -90,7 +90,7 @@ vtcombo [flags]
       --db_appdebug_password string                                      db appdebug password
       --db_appdebug_use_ssl                                              Set this flag to false to make the appdebug connection to not use ssl (default true)
       --db_appdebug_user string                                          db appdebug user userKey (default "vt_appdebug")
-      --db_charset string                                                Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                                Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                               enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                        connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                           db dba password
@@ -153,7 +153,7 @@ vtcombo [flags]
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gc_check_interval duration                                       Interval between garbage collection checks (default 1h0m0s)
       --gc_purge_check_interval duration                                 Interval between purge discovery checks (default 1m0s)
-      --gh-ost-path string                                               override default gh-ost binary full path
+      --gh-ost-path string                                               override default gh-ost binary full path (default "gh-ost")
       --grpc-send-session-in-streaming                                   If set, will send the session as last packet in streaming api to support transactions in streaming
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
@@ -181,7 +181,6 @@ vtcombo [flags]
       --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_use_effective_callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
       --health_check_interval duration                                   Interval between health checks (default 20s)
-      --healthcheck-dial-concurrency int                                 Maximum concurrency of new healthcheck connections. This should be less than the golang max thread limit of 10000. (default 1024)
       --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
       --heartbeat_enable                                                 If true, vttablet records (if master) or checks (if replica) the current time of a replication heartbeat in the sidecar database's heartbeat table. The result is used to inform the serving state of the vttablet via healthchecks.
@@ -203,7 +202,7 @@ vtcombo [flags]
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --lock-timeout duration                                            Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
@@ -237,8 +236,15 @@ vtcombo [flags]
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for already connected clients to complete their in flight work
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
+      --mysql-shell-backup-location string                               location where the backup will be stored
+      --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
+      --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
+      --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
+      --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
       --mysql_auth_server_impl string                                    Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
@@ -277,7 +283,7 @@ vtcombo [flags]
       --proto_topo vttest.TopoData                                       vttest proto definition of the topology, encoded in compact text format. See vttest.proto for more information.
       --proxy_protocol                                                   Enable HAProxy PROXY protocol on MySQL listener socket
       --proxy_tablets                                                    Setting this true will make vtctld proxy the tablet status instead of redirecting to them
-      --pt-osc-path string                                               override default pt-online-schema-change binary full path
+      --pt-osc-path string                                               override default pt-online-schema-change binary full path (default "/usr/bin/pt-online-schema-change")
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
@@ -286,6 +292,7 @@ vtcombo [flags]
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results
@@ -311,14 +318,14 @@ vtcombo [flags]
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
-      --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.
       --queryserver_enable_online_ddl                                    Enable online DDL. (default true)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
-      --relay_log_max_items int                                          Maximum number of rows for VReplication target buffering. (default 5000)
-      --relay_log_max_size int                                           Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
+      --relay_log_max_items int                                          Maximum number of rows for vreplication target buffering. (default 5000)
+      --relay_log_max_size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored
       --restore-to-pos string                                            (init incremental restore parameter) if set, run a point in time recovery that ends with the given position. This will attempt to use one full backup followed by zero or more incremental backups
       --restore-to-timestamp string                                      (init incremental restore parameter) if set, run a point in time recovery that restores up to the given timestamp, if possible. Given timestamp in RFC3339 format. Example: '2006-01-02T15:04:05Z07:00'
       --restore_concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
@@ -351,6 +358,7 @@ vtcombo [flags]
       --stream_health_buffer_size uint                                   max streaming health entries to buffer per streaming health client (default 20)
       --table-refresh-interval int                                       interval in milliseconds to refresh tables in status page with refreshRequired class
       --table_gc_lifecycle string                                        States for a DROP TABLE garbage collection cycle. Default is 'hold,purge,evac,drop', use any subset ('drop' implicitly always included) (default "hold,purge,evac,drop")
+      --tablet-filter-tags StringMap                                     Specifies a comma-separated list of tablet tags (as key:value pairs) to filter the tablets to watch.
       --tablet_dir string                                                The directory within the vtdataroot to store vttablet/mysql files. Defaults to being generated by the tablet uid.
       --tablet_filters strings                                           Specifies a comma-separated list of 'keyspace|shard_name or keyrange' values to filter the tablets to watch.
       --tablet_health_keep_alive duration                                close streaming tablet health connection if there are no requests for this long (default 5m0s)
@@ -390,6 +398,7 @@ vtcombo [flags]
       --tracing-enable-logging                                           whether to enable logging in the tracing service
       --tracing-sampling-rate float                                      sampling rate for the probabilistic jaeger sampler (default 0.1)
       --tracing-sampling-type string                                     sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
+      --track-udfs                                                       Track UDFs in vtgate.
       --track_schema_versions                                            When enabled, vttablet will store versions of schemas at each position that a DDL is applied and allow retrieval of the schema corresponding to a position
       --transaction-log-stream-handler string                            URL handler for streaming transactions log (default "/debug/txlog")
       --transaction_limit_by_component                                   Include CallerID.component when considering who the user is for the purpose of transaction limit.
@@ -400,7 +409,6 @@ vtcombo [flags]
       --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
-      --twopc_coordinator_address string                                 address of the (VTGate) process(es) that will be used to notify of abandoned transactions.
       --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
       --tx-throttler-default-priority int                                Default priority assigned to queries that lack priority information (default 100)

--- a/content/en/docs/21.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctld
 series: vtctld
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctld
 
@@ -74,6 +74,7 @@ vtctld \
       --file_backup_storage_root string                                  Root directory for the file backup storage.
       --gcs_backup_storage_bucket string                                 Google Cloud Storage bucket to use for backups.
       --gcs_backup_storage_root string                                   Root prefix for all backup-related object names.
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
@@ -102,13 +103,12 @@ vtctld \
       --grpc_server_keepalive_enforcement_policy_permit_without_stream   gRPC server permit client keepalive pings even when there are no active streams (RPCs)
       --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
       --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
-      --healthcheck-dial-concurrency int                                 Maximum concurrency of new healthcheck connections. This should be less than the golang max thread limit of 10000. (default 1024)
   -h, --help                                                             help for vtctld
       --jaeger-agent-host string                                         host and port to send spans to. if empty, no tracing will be done
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --lock-timeout duration                                            Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
       --log_err_stacks                                                   log stack traces for errors

--- a/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtctldclient
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellInfo
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient AddCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_AddCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: AddCellsAlias
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient AddCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyKeyspaceRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ApplyKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ApplyRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplySchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ApplySchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyShardRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ApplyShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ApplyVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ApplyVSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ApplyVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -1,7 +1,7 @@
 ---
 title: Backup
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Backup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -1,7 +1,7 @@
 ---
 title: BackupShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient BackupShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletTags.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletTags
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ChangeTabletTags
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ChangeTabletType.md
@@ -1,7 +1,7 @@
 ---
 title: ChangeTabletType
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ChangeTabletType
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CheckThrottler.md
@@ -1,7 +1,7 @@
 ---
 title: CheckThrottler
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient CheckThrottler
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: CreateKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient CreateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_CreateShard.md
@@ -1,7 +1,7 @@
 ---
 title: CreateShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient CreateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellInfo
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteCellsAlias
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteShards.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteShards
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteShards
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteSrvVSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DeleteTablets.md
@@ -1,7 +1,7 @@
 ---
 title: DeleteTablets
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DeleteTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/_index.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DistributedTransaction
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_conclude.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction conclude
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DistributedTransaction conclude
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_DistributedTransaction/vtctldclient_DistributedTransaction_unresolved-list.md
@@ -1,7 +1,7 @@
 ---
 title: DistributedTransaction unresolved-list
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient DistributedTransaction unresolved-list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_EmergencyReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: EmergencyReparentShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient EmergencyReparentShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsApp.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsApp
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ExecuteFetchAsApp
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteFetchAsDBA
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ExecuteFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteHook.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteHook
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ExecuteHook
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ExecuteMultiFetchAsDBA.md
@@ -1,7 +1,7 @@
 ---
 title: ExecuteMultiFetchAsDBA
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ExecuteMultiFetchAsDBA
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_FindAllShardsInKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: FindAllShardsInKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient FindAllShardsInKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GenerateShardRanges.md
@@ -1,7 +1,7 @@
 ---
 title: GenerateShardRanges
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GenerateShardRanges
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetBackups.md
@@ -1,7 +1,7 @@
 ---
 title: GetBackups
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetBackups
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfo
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellInfoNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellInfoNames
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetCellInfoNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetCellsAliases.md
@@ -1,7 +1,7 @@
 ---
 title: GetCellsAliases
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetCellsAliases
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetFullStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetFullStatus
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetFullStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaceRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaceRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetKeyspaceRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetKeyspaces
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetMirrorRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetMirrorRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetMirrorRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetPermissions.md
@@ -1,7 +1,7 @@
 ---
 title: GetPermissions
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetPermissions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShard.md
@@ -1,7 +1,7 @@
 ---
 title: GetShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardReplication.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardReplication
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetShardReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetShardRoutingRules.md
@@ -1,7 +1,7 @@
 ---
 title: GetShardRoutingRules
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetShardRoutingRules
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaceNames.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaceNames
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetSrvKeyspaceNames
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvKeyspaces.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvKeyspaces
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetSrvKeyspaces
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetSrvVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetSrvVSchemas.md
@@ -1,7 +1,7 @@
 ---
 title: GetSrvVSchemas
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetSrvVSchemas
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablet.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablet
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTabletVersion.md
@@ -1,7 +1,7 @@
 ---
 title: GetTabletVersion
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetTabletVersion
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTablets.md
@@ -1,7 +1,7 @@
 ---
 title: GetTablets
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetTablets
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetThrottlerStatus.md
@@ -1,7 +1,7 @@
 ---
 title: GetThrottlerStatus
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetThrottlerStatus
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetTopologyPath.md
@@ -1,7 +1,7 @@
 ---
 title: GetTopologyPath
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetTopologyPath
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetVSchema.md
@@ -1,7 +1,7 @@
 ---
 title: GetVSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetVSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_GetWorkflows.md
@@ -1,7 +1,7 @@
 ---
 title: GetWorkflows
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient GetWorkflows
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LegacyVtctlCommand.md
@@ -1,7 +1,7 @@
 ---
 title: LegacyVtctlCommand
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LegacyVtctlCommand
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/_index.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LookupVindex
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LookupVindex cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_create.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LookupVindex create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_externalize.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex externalize
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LookupVindex externalize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_LookupVindex/vtctldclient_LookupVindex_show.md
@@ -1,7 +1,7 @@
 ---
 title: LookupVindex show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient LookupVindex show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_create.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_show.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_start.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize start
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Materialize/vtctldclient_Materialize_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Materialize stop
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Materialize stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate complete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_show.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_status.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate status
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Migrate status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Mount
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Mount
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_list.md
@@ -1,7 +1,7 @@
 ---
 title: Mount list
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Mount list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_register.md
@@ -1,7 +1,7 @@
 ---
 title: Mount register
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Mount register
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_show.md
@@ -1,7 +1,7 @@
 ---
 title: Mount show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Mount show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Mount/vtctldclient_Mount_unregister.md
@@ -1,7 +1,7 @@
 ---
 title: Mount unregister
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Mount unregister
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/_index.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_complete.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables complete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_mirrortraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables mirrortraffic
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables mirrortraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables reversetraffic
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_show.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_start.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables start
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_status.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables status
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_stop.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables stop
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: MoveTables switchtraffic
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient MoveTables switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_cleanup.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL cleanup
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL cleanup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_complete.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL complete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_force-cutover.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL force-cutover
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL force-cutover
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_launch.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL launch
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL launch
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_retry.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL retry
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL retry
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_show.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_throttle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL throttle
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL throttle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/vtctldclient_OnlineDDL_unthrottle.md
@@ -1,7 +1,7 @@
 ---
 title: OnlineDDL unthrottle
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient OnlineDDL unthrottle
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PingTablet.md
@@ -1,7 +1,7 @@
 ---
 title: PingTablet
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient PingTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_PlannedReparentShard.md
@@ -1,7 +1,7 @@
 ---
 title: PlannedReparentShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient PlannedReparentShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildKeyspaceGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildKeyspaceGraph
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RebuildKeyspaceGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RebuildVSchemaGraph.md
@@ -1,7 +1,7 @@
 ---
 title: RebuildVSchemaGraph
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RebuildVSchemaGraph
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshState.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshState
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RefreshState
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RefreshStateByShard.md
@@ -1,7 +1,7 @@
 ---
 title: RefreshStateByShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RefreshStateByShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchema.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchema
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ReloadSchema
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ReloadSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReloadSchemaShard.md
@@ -1,7 +1,7 @@
 ---
 title: ReloadSchemaShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ReloadSchemaShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveBackup
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RemoveBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveKeyspaceCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveKeyspaceCell
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RemoveKeyspaceCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RemoveShardCell.md
@@ -1,7 +1,7 @@
 ---
 title: RemoveShardCell
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RemoveShardCell
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ReparentTablet.md
@@ -1,7 +1,7 @@
 ---
 title: ReparentTablet
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ReparentTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard cancel
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard cancel
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_complete.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard complete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard complete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_reversetraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard reversetraffic
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard reversetraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_show.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_start.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard start
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_status.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard status
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard status
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard stop
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_switchtraffic.md
@@ -1,7 +1,7 @@
 ---
 title: Reshard switchtraffic
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Reshard switchtraffic
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RestoreFromBackup.md
@@ -1,7 +1,7 @@
 ---
 title: RestoreFromBackup
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RestoreFromBackup
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_RunHealthCheck.md
@@ -1,7 +1,7 @@
 ---
 title: RunHealthCheck
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient RunHealthCheck
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetKeyspaceDurabilityPolicy.md
@@ -1,7 +1,7 @@
 ---
 title: SetKeyspaceDurabilityPolicy
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SetKeyspaceDurabilityPolicy
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardIsPrimaryServing.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardIsPrimaryServing
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SetShardIsPrimaryServing
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetShardTabletControl.md
@@ -1,7 +1,7 @@
 ---
 title: SetShardTabletControl
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SetShardTabletControl
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SetWritable.md
@@ -1,7 +1,7 @@
 ---
 title: SetWritable
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SetWritable
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationFix.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationFix
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ShardReplicationFix
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ShardReplicationPositions.md
@@ -1,7 +1,7 @@
 ---
 title: ShardReplicationPositions
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ShardReplicationPositions
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SleepTablet.md
@@ -1,7 +1,7 @@
 ---
 title: SleepTablet
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SleepTablet
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardAdd.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardAdd
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SourceShardAdd
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_SourceShardDelete.md
@@ -1,7 +1,7 @@
 ---
 title: SourceShardDelete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient SourceShardDelete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StartReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StartReplication
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient StartReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_StopReplication.md
@@ -1,7 +1,7 @@
 ---
 title: StopReplication
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient StopReplication
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_TabletExternallyReparented.md
@@ -1,7 +1,7 @@
 ---
 title: TabletExternallyReparented
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient TabletExternallyReparented
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellInfo.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellInfo
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient UpdateCellInfo
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateCellsAlias.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateCellsAlias
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient UpdateCellsAlias
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_UpdateThrottlerConfig.md
@@ -1,7 +1,7 @@
 ---
 title: UpdateThrottlerConfig
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient UpdateThrottlerConfig
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/_index.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_create.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff create
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff create
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_delete.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff delete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_resume.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff resume
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff resume
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_show.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_VDiff/vtctldclient_VDiff_stop.md
@@ -1,7 +1,7 @@
 ---
 title: VDiff stop
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient VDiff stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Validate.md
@@ -1,7 +1,7 @@
 ---
 title: Validate
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Validate
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ValidateKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateSchemaKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateSchemaKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ValidateSchemaKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ValidateShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionKeyspace.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionKeyspace
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ValidateVersionKeyspace
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_ValidateVersionShard.md
@@ -1,7 +1,7 @@
 ---
 title: ValidateVersionShard
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient ValidateVersionShard
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_delete.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow delete
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow delete
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_list.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow list
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow list
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_show.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow show
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow show
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_start.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow start
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow start
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_stop.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow stop
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow stop
 

--- a/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
+++ b/content/en/docs/21.0/reference/programs/vtctldclient/vtctldclient_Workflow/vtctldclient_Workflow_update.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow update
 series: vtctldclient
-commit: 477bb22995e2e6a6dbaf9b45cc8259c017cb95db
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtctldclient Workflow update
 

--- a/content/en/docs/21.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgate
 series: vtgate
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtgate
 
@@ -85,6 +85,7 @@ vtgate \
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
       --gate_query_cache_memory int                                      gate server query cache size in bytes, maximum amount of memory to be cached. vtgate analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
       --gateway_initial_tablet_timeout duration                          At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type (default 30s)
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc-send-session-in-streaming                                   If set, will send the session as last packet in streaming api to support transactions in streaming
       --grpc-use-effective-groups                                        If set, and SSL is not used, will set the immediate caller's security groups from the effective caller id's groups.
       --grpc-use-static-authentication-callerid                          If set, will set the immediate caller id to the username authenticated by the static auth plugin.
@@ -117,7 +118,6 @@ vtgate \
       --grpc_server_keepalive_time duration                              After a duration of this time, if the server doesn't see any activity, it pings the client to see if the transport is still alive. (default 10s)
       --grpc_server_keepalive_timeout duration                           After having pinged for keepalive check, the server waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_use_effective_callerid                                      If set, and SSL is not used, will set the immediate caller id from the effective caller id's principal.
-      --healthcheck-dial-concurrency int                                 Maximum concurrency of new healthcheck connections. This should be less than the golang max thread limit of 10000. (default 1024)
       --healthcheck_retry_delay duration                                 health check retry delay (default 2ms)
       --healthcheck_timeout duration                                     the health check timeout period (default 1m0s)
   -h, --help                                                             help for docgen
@@ -127,7 +127,7 @@ vtgate \
       --keyspaces_to_watch strings                                       Specifies which keyspaces this vtgate should have access to while routing queries or accessing the vschema.
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
       --legacy_replication_lag_algorithm                                 Use the legacy algorithm when selecting vttablets for serving. (default true)
-      --lock-timeout duration                                            Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_heartbeat_time duration                                     If there is lock function used. This will keep the lock connection active by using this heartbeat (default 5s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
@@ -140,6 +140,7 @@ vtgate \
       --max_payload_size int                                             The threshold for query payloads in bytes. A payload greater than this threshold will result in a failure to handle the query.
       --message_stream_grace_period duration                             the amount of time to give for a vttablet to resume if it ends a message stream, usually because of a reparent. (default 30s)
       --min_number_serving_vttablets int                                 The minimum number of vttablets for each replicating tablet_type (e.g. replica, rdonly) that will be continue to be used even with replication lag above discovery_low_replication_lag, but still below discovery_high_replication_lag_minimum_serving. (default 2)
+      --mysql-server-drain-onterm                                        If set, the server waits for --onterm_timeout for already connected clients to complete their in flight work
       --mysql-server-keepalive-period duration                           TCP period between keep-alives
       --mysql-server-pool-conn-read-buffers                              If set, the server will pool incoming connection read buffers
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
@@ -195,6 +196,7 @@ vtgate \
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --retry-count int                                                  retry count (default 2)
@@ -216,6 +218,7 @@ vtgate \
       --stderrthreshold severityFlag                                     logs at or above this threshold go to stderr (default 1)
       --stream_buffer_size int                                           the number of bytes sent from vtgate for each stream call. It's recommended to keep this value in sync with vttablet's query-server-config-stream-buffer-size. (default 32768)
       --table-refresh-interval int                                       interval in milliseconds to refresh tables in status page with refreshRequired class
+      --tablet-filter-tags StringMap                                     Specifies a comma-separated list of tablet tags (as key:value pairs) to filter the tablets to watch.
       --tablet_filters strings                                           Specifies a comma-separated list of 'keyspace|shard_name or keyrange' values to filter the tablets to watch.
       --tablet_grpc_ca string                                            the server ca to use to validate servers when connecting
       --tablet_grpc_cert string                                          the cert to use to connect
@@ -249,6 +252,7 @@ vtgate \
       --tracing-enable-logging                                           whether to enable logging in the tracing service
       --tracing-sampling-rate float                                      sampling rate for the probabilistic jaeger sampler (default 0.1)
       --tracing-sampling-type string                                     sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
+      --track-udfs                                                       Track UDFs in vtgate.
       --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --v Level                                                          log level for V logs

--- a/content/en/docs/21.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtgateclienttest
 
@@ -24,6 +24,7 @@ vtgateclienttest [flags]
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
       --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.

--- a/content/en/docs/21.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/21.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vtorc
 series: vtorc
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vtorc
 
@@ -47,6 +47,7 @@ vtorc \
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
+      --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
       --grpc_enable_tracing                                         Enable gRPC tracing.
@@ -61,7 +62,7 @@ vtorc \
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                    keep running at least this long after SIGTERM before stopping (default 50ms)
-      --lock-timeout duration                                       Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                       Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --log_backtrace_at traceLocations                             when logging hits line file:N, emit a stack trace
       --log_dir string                                              If non-empty, write log files in this directory
       --log_err_stacks                                              log stack traces for errors

--- a/content/en/docs/21.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttablet
 series: vttablet
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttablet
 
@@ -128,7 +128,7 @@ vttablet \
       --db_appdebug_password string                                      db appdebug password
       --db_appdebug_use_ssl                                              Set this flag to false to make the appdebug connection to not use ssl (default true)
       --db_appdebug_user string                                          db appdebug user userKey (default "vt_appdebug")
-      --db_charset string                                                Character set used for this tablet. (default "utf8mb4")
+      --db_charset string                                                Character set/collation used for this tablet. Make sure to configure this to a charset/collation supported by the lowest MySQL version in your environment. (default "utf8mb4")
       --db_conn_query_info                                               enable parsing and processing of QUERY_OK info fields
       --db_connect_timeout_ms int                                        connection timeout to mysqld in milliseconds (0 for no timeout)
       --db_dba_password string                                           db dba password
@@ -183,7 +183,8 @@ vttablet \
       --gc_purge_check_interval duration                                 Interval between purge discovery checks (default 1m0s)
       --gcs_backup_storage_bucket string                                 Google Cloud Storage bucket to use for backups.
       --gcs_backup_storage_root string                                   Root prefix for all backup-related object names.
-      --gh-ost-path string                                               override default gh-ost binary full path
+      --gh-ost-path string                                               override default gh-ost binary full path (default "gh-ost")
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
@@ -230,7 +231,7 @@ vttablet \
       --keep_logs duration                                               keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                      keep logs for this long (using mtime) (zero to keep forever)
       --lameduck-period duration                                         keep running at least this long after SIGTERM before stopping (default 50ms)
-      --lock-timeout duration                                            Maximum time for which a shard/keyspace lock can be acquired for (default 45s)
+      --lock-timeout duration                                            Maximum time to wait when attempting to acquire a lock from the topo server (default 45s)
       --lock_tables_timeout duration                                     How long to keep the table locked before timing out (default 1m0s)
       --log_backtrace_at traceLocations                                  when logging hits line file:N, emit a stack trace
       --log_dir string                                                   If non-empty, write log files in this directory
@@ -261,6 +262,12 @@ vttablet \
       --mycnf_slow_log_path string                                       mysql slow query log path
       --mycnf_socket_file string                                         mysql socket file
       --mycnf_tmp_dir string                                             mysql tmp directory
+      --mysql-shell-backup-location string                               location where the backup will be stored
+      --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
+      --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
+      --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
+      --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
       --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
@@ -274,13 +281,14 @@ vttablet \
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
       --pprof-http                                                       enable pprof http endpoints
-      --pt-osc-path string                                               override default pt-online-schema-change binary full path
+      --pt-osc-path string                                               override default pt-online-schema-change binary full path (default "/usr/bin/pt-online-schema-change")
       --publish_retry_interval duration                                  how long vttablet waits to retry publishing the tablet record (default 30s)
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
+      --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
       --queryserver-config-annotate-queries                              prefix queries to MySQL backend with comment indicating vtgate principal (user) and target tablet type
       --queryserver-config-enable-table-acl-dry-run                      If this flag is enabled, tabletserver will emit monitoring metrics and let the request pass regardless of table acl check results
@@ -306,14 +314,14 @@ vttablet \
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
-      --queryserver-enable-settings-pool                                 Enable pooling of connections with modified system settings (default true)
       --queryserver-enable-views                                         Enable views support in vttablet.
       --queryserver_enable_online_ddl                                    Enable online DDL. (default true)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
-      --relay_log_max_items int                                          Maximum number of rows for VReplication target buffering. (default 5000)
-      --relay_log_max_size int                                           Maximum buffer size (in bytes) for VReplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
+      --relay_log_max_items int                                          Maximum number of rows for vreplication target buffering. (default 5000)
+      --relay_log_max_size int                                           Maximum buffer size (in bytes) for vreplication target buffering. If single rows are larger than this, a single row is buffered at a time. (default 250000)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)
+      --restore-from-backup-allowed-engines strings                      (init restore parameter) if set, only backups taken with the specified engines are eligible to be restored
       --restore-to-pos string                                            (init incremental restore parameter) if set, run a point in time recovery that ends with the given position. This will attempt to use one full backup followed by zero or more incremental backups
       --restore-to-timestamp string                                      (init incremental restore parameter) if set, run a point in time recovery that restores up to the given timestamp, if possible. Given timestamp in RFC3339 format. Example: '2006-01-02T15:04:05Z07:00'
       --restore_concurrency int                                          (init restore parameter) how many concurrent files to restore at once (default 4)
@@ -405,7 +413,6 @@ vttablet \
       --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
       --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
       --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
-      --twopc_coordinator_address string                                 address of the (VTGate) process(es) that will be used to notify of abandoned transactions.
       --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
       --tx-throttler-default-priority int                                Default priority assigned to queries that lack priority information (default 100)
@@ -435,7 +442,6 @@ vttablet \
       --vstream-binlog-rotation-threshold int                            Byte size at which a VStreamer will attempt to rotate the source's open binary log before starting a GTID snapshot based stream (e.g. a ResultStreamer or RowStreamer) (default 67108864)
       --vstream_dynamic_packet_size                                      Enable dynamic packet sizing for VReplication. This will adjust the packet size during replication to improve performance. (default true)
       --vstream_packet_size int                                          Suggested packet size for VReplication streamer. This is used only as a recommendation. The actual packet size may be more or less than this amount. (default 250000)
-      --vtgate_protocol string                                           how to talk to vtgate (default "grpc")
       --vttablet_skip_buildinfo_tags string                              comma-separated list of buildinfo tags to skip from merging with --init_tags. each tag is either an exact match or a regular expression of the form '/regexp/'. (default "/.*/")
       --wait_for_backup_interval duration                                (init restore parameter) if this is greater than 0, instead of starting up empty when no backups are found, keep checking at this interval for a backup to appear
       --watch_replication_stream                                         When enabled, vttablet will stream the MySQL replication stream from the local server, and use it to update schema when it sees a DDL.

--- a/content/en/docs/21.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttestserver
 
@@ -53,6 +53,7 @@ vttestserver [flags]
       --external_topo_implementation string                              the topology implementation to use for vtcombo process
       --extra_my_cnf string                                              extra files to add to the config, separated by ':'
       --foreign_key_mode string                                          This is to provide how to handle foreign key constraint in create/alter table. Valid values are: allow, disallow (default "allow")
+      --grpc-dial-concurrency-limit int                                  Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_mode string                                            Which auth plugin implementation to use (eg: static)
       --grpc_auth_mtls_allowed_substrings string                         List of substrings of at least one of the client certificate names (separated by colon).
       --grpc_auth_static_client_creds string                             When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
@@ -97,11 +98,18 @@ vttestserver [flags]
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
       --max_table_shard_size int                                         The maximum number of initial rows in a table shard. Ignored if--initialize_with_random_data is false. The actual number is chosen randomly (default 10000)
       --min_table_shard_size int                                         The minimum number of initial rows in a table shard. Ignored if--initialize_with_random_data is false. The actual number is chosen randomly. (default 1000)
+      --mysql-shell-backup-location string                               location where the backup will be stored
+      --mysql-shell-dump-flags string                                    flags to pass to mysql shell dump utility. This should be a JSON string and will be saved in the MANIFEST (default "{\"threads\": 4}")
+      --mysql-shell-flags string                                         execution flags to pass to mysqlsh binary to be used during dump/load (default "--defaults-file=/dev/null --js -h localhost")
+      --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
+      --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
+      --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql_bind_host string                                           which host to bind vtgate mysql listener to (default "localhost")
       --mysql_only                                                       If this flag is set only mysql is initialized. The rest of the vitess components are not started. Also, the output specifies the mysql unix socket instead of the vtgate port.
       --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
+      --no_scatter                                                       when set to true, the planner will fail instead of producing a plan that includes scatter queries
       --null_probability float                                           The probability to initialize a field with 'NULL'  if --initialize_with_random_data is true. Only applies to fields that can contain NULL values. (default 0.1)
       --num_shards strings                                               Comma separated shard count (one per keyspace) (default [2])
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
@@ -115,7 +123,7 @@ vttestserver [flags]
       --pprof-http                                                       enable pprof http endpoints
       --proto_topo string                                                Define the fake cluster topology as a compact text format encoded vttest proto. See vttest.proto for more information.
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
-      --queryserver-config-transaction-timeout float                     query server transaction timeout (in seconds), a transaction will be killed if it takes longer than this value
+      --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --rdonly_count int                                                 Rdonly tablets per shard (default 1)
       --replica_count int                                                Replica tablets per shard (includes primary) (default 2)
       --replication_connect_retry duration                               how long to wait in between replica reconnect attempts. Only precise to the second. (default 10s)

--- a/content/en/docs/21.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/_index.md
@@ -1,7 +1,7 @@
 ---
 title: vttlstest
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCA
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest CreateCA
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -1,7 +1,7 @@
 ---
 title: CreateCRL
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest CreateCRL
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -1,7 +1,7 @@
 ---
 title: CreateIntermediateCA
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest CreateIntermediateCA
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -1,7 +1,7 @@
 ---
 title: CreateSignedCert
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest CreateSignedCert
 

--- a/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/21.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -1,7 +1,7 @@
 ---
 title: RevokeCert
 series: vttlstest
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## vttlstest RevokeCert
 

--- a/content/en/docs/21.0/reference/programs/zk/_index.md
+++ b/content/en/docs/21.0/reference/programs/zk/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zk
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_addAuth.md
@@ -1,7 +1,7 @@
 ---
 title: addAuth
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk addAuth
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_cat.md
@@ -1,7 +1,7 @@
 ---
 title: cat
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk cat
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_chmod.md
@@ -1,7 +1,7 @@
 ---
 title: chmod
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk chmod
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_cp.md
@@ -1,7 +1,7 @@
 ---
 title: cp
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk cp
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_edit.md
@@ -1,7 +1,7 @@
 ---
 title: edit
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk edit
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_ls.md
@@ -1,7 +1,7 @@
 ---
 title: ls
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk ls
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_rm.md
@@ -1,7 +1,7 @@
 ---
 title: rm
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk rm
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_stat.md
@@ -1,7 +1,7 @@
 ---
 title: stat
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk stat
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_touch.md
@@ -1,7 +1,7 @@
 ---
 title: touch
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk touch
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_unzip.md
@@ -1,7 +1,7 @@
 ---
 title: unzip
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk unzip
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_wait.md
@@ -1,7 +1,7 @@
 ---
 title: wait
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk wait
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_watch.md
@@ -1,7 +1,7 @@
 ---
 title: watch
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk watch
 

--- a/content/en/docs/21.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/21.0/reference/programs/zk/zk_zip.md
@@ -1,7 +1,7 @@
 ---
 title: zip
 series: zk
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zk zip
 

--- a/content/en/docs/21.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctl
 series: zkctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctl
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,7 @@
 ---
 title: init
 series: zkctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctl init
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,7 @@
 ---
 title: shutdown
 series: zkctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctl shutdown
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,7 @@
 ---
 title: start
 series: zkctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctl start
 

--- a/content/en/docs/21.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/21.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,7 @@
 ---
 title: teardown
 series: zkctl
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctl teardown
 

--- a/content/en/docs/21.0/reference/programs/zkctld/_index.md
+++ b/content/en/docs/21.0/reference/programs/zkctld/_index.md
@@ -1,7 +1,7 @@
 ---
 title: zkctld
 series: zkctld
-commit: 6cd09cce61fa79a1b7aacb36886b7dc44ae82a94
+commit: d9bc0da8c46a6f69fec4dd3d50187501d1d6268b
 ---
 ## zkctld
 


### PR DESCRIPTION

Regenerated cobra docs based on `release-21.0`.  
After running `make generated-docs` with `VITESS_DIR` pointing to the vitess directory in the `vitess-releaser` tool. 

Note that the executables from the build are required to be in the `bin` directory under the `VITESS_DIR`.  I ran the build using 
`(export VTROOT= ; make build)` to achieve this.

Updated the Makefile target to
```
%-docs:
	set -ego run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $*
        LC_ALL=C find content -type f -exec sed -i '' 's;${VITESS_DIR};\<WORKDIR\>;g' {} +
        find . -type f -name '*md-e' -exec rm -f {} +
        git add content
        git commit --allow-empty -s -m "Update cobra docs using make generated-docs for $* (vitess sha `git -C ${VITESS_DIR} rev-parse HEAD`) "

```
And then:
```
export VITESS_DIR=/Users/rohit/vitess
git checkout v21.0.0 // in VITESS_DIR
export COBRADOC_VERSION_PAIRS="v21.0.0:21.0"
% make generated-docs
"
```
