### PR TITLE
Docs: new MySQL server throttler metrics

### DIFF
--- a/content/en/docs/22.0/reference/features/tablet-throttler.md
+++ b/content/en/docs/22.0/reference/features/tablet-throttler.md
@@ -46,6 +46,7 @@ The objective of the throttler is to push back work based on database load. Prev
 - `custom`: a custom query as defined by the user.
 - `mysqld-loadavg`: load average, per core, on the MySQL server/container.
 - `mysqld-datadir-used-ratio`: disk space usage on MySQL's `datadir` mount, range `0.0` (empty) to `1.0` (full)
+- `history_list_length`: InnoDB's history list length value.
 
 This list is expected to expand in the future.
 
@@ -66,6 +67,7 @@ Each metric has a "factory default" threshold, e.g.:
 - `100` for `threads_running`.
 - `1.0` (per core) for `mysqld-loadavg`.
 - `0.98` (98%) for `mysqld-datadir-used-ratio`.
+- `1000000000` for `history_list_length`.
 
 
 Thresholds are positive values. A threshold of `0` is considered _undefined_.
@@ -802,6 +804,7 @@ These are the metrics by which the throttler compares with the threshold and dec
 Gauge, the current metric value on the tablet. This is the result of a self-check, done continuously when the throttler is enabled. Available per metric:
 
 - `ThrottlerAggregatedSelfCustom`
+- `ThrottlerAggregatedSelfHistoryListLength`
 - `ThrottlerAggregatedSelfLag`
 - `ThrottlerAggregatedSelfLoadavg`
 - `ThrottlerAggregatedSelfThreadsRunning`
@@ -813,6 +816,7 @@ Gauge, the current metric value on the tablet. This is the result of a self-chec
 Gauge, on the `PRIMARY` tablet only, this is the aggregated collected metric value from all serving shard tables, including the `PRIMARY`. The value is the highest (aka _worst_) of all collected tablets. Available per metric:
 
 - `ThrottlerAggregatedShardCustom`
+- `ThrottlerAggregatedShardHistoryListLength`
 - `ThrottlerAggregatedShardLag`
 - `ThrottlerAggregatedShardLoadavg`
 - `ThrottlerAggregatedShardThreadsRunning`

--- a/content/en/docs/22.0/reference/features/tablet-throttler.md
+++ b/content/en/docs/22.0/reference/features/tablet-throttler.md
@@ -40,10 +40,12 @@ However, we limit the collaboration to specific tablet types, based on `--thrott
 
 The objective of the throttler is to push back work based on database load. Previously, this was done based on a single metric, which could be either the replication lag, or the result of a custom query. Now, the throttler collects multiple metrics. The current supported metrics are:
 
-- Replication lag (`lag`), measured in seconds.
-- Load average (`loadavg`), per core, on the tablet server/container.
-- MySQL `Threads_running` value (`threads_running`).
-- Custom query (`custom`) as defined by the user.
+- `lag`: replication lag, measured in seconds.
+- `loadavg`: load average, per core, on the tablet server/container.
+- `threads_running`: MySQL's `Threads_running` value.
+- `custom`: a custom query as defined by the user.
+- `mysqld-loadavg`: load average, per core, on the MySQL server/container.
+- `mysqld-datadir-used-ratio`: disk space usage on MySQL's `datadir` mount, range `0.0` (empty) to `1.0` (full)
 
 This list is expected to expand in the future.
 
@@ -62,6 +64,9 @@ Each metric has a "factory default" threshold, e.g.:
 - `5` (5 seconds) for `lag`.
 - `1.0` (per core) for `loadavg`.
 - `100` for `threads_running`.
+- `1.0` (per core) for `mysqld-loadavg`.
+- `0.98` (98%) for `mysqld-datadir-used-ratio`.
+
 
 Thresholds are positive values. A threshold of `0` is considered _undefined_.
 
@@ -799,8 +804,9 @@ Gauge, the current metric value on the tablet. This is the result of a self-chec
 - `ThrottlerAggregatedSelfCustom`
 - `ThrottlerAggregatedSelfLag`
 - `ThrottlerAggregatedSelfLoadavg`
-- `ThrottlerAggregatedSelfThreads_running`
-
+- `ThrottlerAggregatedSelfThreadsRunning`
+- `ThrottlerAggregatedSelfMysqldLoadavg`
+- `ThrottlerAggregatedSelfMysqldDatadirUsedRatio`
 
 ##### `ThrottlerAggregatedShard<metric>`
 
@@ -809,8 +815,10 @@ Gauge, on the `PRIMARY` tablet only, this is the aggregated collected metric val
 - `ThrottlerAggregatedShardCustom`
 - `ThrottlerAggregatedShardLag`
 - `ThrottlerAggregatedShardLoadavg`
-- `ThrottlerAggregatedShardThreads_running`
-  
+- `ThrottlerAggregatedShardThreadsRunning`
+- `ThrottlerAggregatedShardMysqldLoadavg`
+- `ThrottlerAggregatedShardMysqldDatadirUsedRatio`
+
 #### Check metrics
 
 The throttler is checked by apps (`vreplication`, `online-ddl`, etc), and responds with status codes, "OK" for "good to proceed" or any other code for "hold off".


### PR DESCRIPTION
Documenting the changes made in https://github.com/vitessio/vitess/pull/16904, namely the addition of two new built-in throttler metrics:

- `mysqld-loadavg`: load average, per core, on the MySQL server/container.
- `mysqld-datadir-used-ratio`: disk space usage on MySQL's `datadir` mount, range `0.0` (empty) to `1.0` (full)

Only merge when https://github.com/vitessio/vitess/pull/16904 is merged.

**UPDATE** this PR also documents `history_list_length` as introduced in https://github.com/vitessio/vitess/pull/17262