### PR TITLE
Cobradocs sync: improve makefile, resync without commit hash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 %-docs:
 	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
 	COMMIT_HASH=$(shell cd $(VITESS_DIR) && git rev-parse --short HEAD) && \
-        git add -u content && git commit -s -m "Update cobradocs for $$COMMIT_HASH"
+        git add -u content && git commit -s -m "Update cobradocs for $$COMMIT_HASH for $(patsubst %-docs,%,$@)"
 
 # Target to run them all.
 .PHONY: generated-docs

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check-all-links: clean build link-checker-setup
 	bin/htmltest --conf .htmltest.external.yml
 
 ifndef COBRADOC_VERSION_PAIRS
-export COBRADOC_VERSION_PAIRS="main:22.0,v21.0.0:21.0,v20.0.3:20.0,v19.0.7:19.0"
+export COBRADOC_VERSION_PAIRS="main:22.0,v21.0.3:21.0,v20.0.6:20.0"
 endif
 
 BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
@@ -59,9 +59,9 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 # `make mysqlctl-docs COBRADOC_VERSION_PAIRS="main:22.0" VITESS_DIR=~/go/src/github.com/vitessio/vitess`
 %-docs:
 	set -x
-	@if echo "$$COBRADOC_VERSION_PAIRS" | grep -qE '20\.0|19\.0'; then \
+	@if echo "$$COBRADOC_VERSION_PAIRS" | grep -qE '20\.0'; then \
     		if [ "$${GOROOT##*/}" != "go1.21" ]; then \
-    			echo "Error: Go 1.21 is required when COBRADOC_VERSION_PAIRS contains 20.0 or 19.0."; \
+    			echo "Error: Go 1.21 is required when COBRADOC_VERSION_PAIRS contains 20.0."; \
     			echo "Current GOROOT is: $$GOROOT"; \
     			exit 1; \
     		fi; \

--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,11 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 # `make mysqlctl-docs COBRADOC_VERSION_PAIRS="main:22.0" VITESS_DIR=~/go/src/github.com/vitessio/vitess`
 %-docs:
 	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
-	COMMIT_HASH=$(shell cd $(VITESS_DIR) && git rev-parse --short HEAD) && \
-        git add -u content && git commit -s -m "Update cobradocs for $$COMMIT_HASH for $(patsubst %-docs,%,$@)"
+	COMMIT_HASH=$(shell cd $(VITESS_DIR) && git rev-parse --short HEAD); \
+    	git add -u content && \
+    	if ! git diff --cached --quiet HEAD --; then \
+    	  git commit -s -m "Update cobradocs for $$COMMIT_HASH for $(patsubst %-docs,%,$@)"; \
+    	fi
 
 # Target to run them all.
 .PHONY: generated-docs

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
     			exit 1; \
     		fi; \
     fi
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
+	go run ./tools/cobradocs/  --debug --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
 	find . -name "*md-e" -exec rm {} \;
 	@CHANGED_FILES=$$(git diff --name-only) && \
     	if [ -n "$$CHANGED_FILES" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
     			exit 1; \
     		fi; \
     fi
-	go run ./tools/cobradocs/  --debug --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
+	go run ./tools/cobradocs/  --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
 	find . -name "*md-e" -exec rm {} \;
 	@CHANGED_FILES=$$(git diff --name-only) && \
     	if [ -n "$$CHANGED_FILES" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 %-docs:
 	set -x
 	@if echo "$$COBRADOC_VERSION_PAIRS" | grep -qE '20\.0'; then \
-    		if [ "$${GOROOT##*/}" != "go1.21" ]; then \
+    		if [[ "$${GOROOT##*/}" != *go1.21* ]]; then \
     			echo "Error: Go 1.21 is required when COBRADOC_VERSION_PAIRS contains 20.0."; \
     			echo "Current GOROOT is: $$GOROOT"; \
     			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,24 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 # For a specific version, you can specify COBRADOC_VERSION_PAIRS as an environment variable, Example:
 # `make mysqlctl-docs COBRADOC_VERSION_PAIRS="main:22.0" VITESS_DIR=~/go/src/github.com/vitessio/vitess`
 %-docs:
+	set -x
+	@if echo "$$COBRADOC_VERSION_PAIRS" | grep -qE '20\.0|19\.0'; then \
+    		if [ "$${GOROOT##*/}" != "go1.21" ]; then \
+    			echo "Error: Go 1.21 is required when COBRADOC_VERSION_PAIRS contains 20.0 or 19.0."; \
+    			echo "Current GOROOT is: $$GOROOT"; \
+    			exit 1; \
+    		fi; \
+    fi
 	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
+	find . -name "*md-e" -exec rm {} \;
+	@CHANGED_FILES=$$(git diff --name-only) && \
+    	if [ -n "$$CHANGED_FILES" ]; then \
+    		for file in $$CHANGED_FILES; do \
+    			sed -i "" -e 's|${VITESS_DIR}|<WORKDIR>|g' $$file; \
+    		done; \
+    	else \
+    		echo "No changed files found."; \
+    	fi
 	COMMIT_HASH=$(shell cd $(VITESS_DIR) && git rev-parse --short HEAD); \
     	git add -u content && \
     	if ! git diff --cached --quiet HEAD --; then \

--- a/Makefile
+++ b/Makefile
@@ -42,101 +42,24 @@ check-all-links: clean build link-checker-setup
 	bin/htmltest --conf .htmltest.external.yml
 
 ifndef COBRADOC_VERSION_PAIRS
-export COBRADOC_VERSION_PAIRS="main:22.0,v21.0.2:21.0,v20.0.5:20.0,v19.0.9:19.0,v18.0.8:18.0"
+export COBRADOC_VERSION_PAIRS="main:22.0,v21.0.0:21.0,v20.0.3:20.0,v19.0.7:19.0"
 endif
 
-generated-docs: mysqlctl-docs \
-	mysqlctld-docs \
-	topo2topo-docs \
-	vtaclcheck-docs \
-	vtbackup-docs \
-	vtbench-docs \
-	vtclient-docs \
-	vtcombo-docs \
-	vtctld-docs \
-	vtctldclient-docs \
-	vtgate-docs \
-	vtgateclienttest-docs \
-	vtorc-docs \
-	vttablet-docs \
-	vttestserver-docs \
-	vttlstest-docs \
-	zk-docs \
-	zkctl-docs \
-	zkctld-docs
+BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
+        vtctld vtctldclient vtgate vtgateclienttest vtorc vttablet vttestserver \
+        vttlstest zk zkctl zkctld
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make mysqlctl-docs
-mysqlctl-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" mysqlctl
+# Pattern rule for building docs for a single binary.
+# Running `make mysqlctl-docs` will trigger this rule, for example.
+# VITESS_DIR should be specified as an environment variable, pointing to the root of the local Vitess repository
+# with most recent code and all release branches fetched, for which the docs are being generated.
+# Example, to make all current release  versions:
+# `make mysqlctl-docs VITESS_DIR=~/go/src/github.com/vitessio/vitess`
+# For a specific version, you can specify COBRADOC_VERSION_PAIRS as an environment variable, Example:
+# `make mysqlctl-docs COBRADOC_VERSION_PAIRS="main:22.0" VITESS_DIR=~/go/src/github.com/vitessio/vitess`
+%-docs:
+	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
 
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make mysqlctld-docs
-mysqlctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" mysqlctld
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtaclcheck-docs
-vtaclcheck-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtaclcheck
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make topo2topo-docs
-topo2topo-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" topo2topo
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtbackup-docs
-vtbackup-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtbackup
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtbench-docs
-vtbench-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtbench
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtclient-docs
-vtclient-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtclient
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtcombo-docs
-vtcombo-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtcombo
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtctld-docs
-vtctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtctld
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtctldclient-docs
-vtctldclient-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtctldclient
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtgate-docs
-vtgate-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtgate
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtgateclienttest-docs
-vtgateclienttest-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtgateclienttest
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vtorc-docs
-vtorc-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vtorc
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttablet-docs
-vttablet-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttablet
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttestserver-docs
-vttestserver-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttestserver
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make vttlstest-docs
-vttlstest-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" vttlstest
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zk-docs
-zk-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zk
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zkctl-docs
-zkctl-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zkctl
-
-# Usage: VITESS_DIR=/full/path/to/vitess.io/vitess make zkctld-docs
-zkctld-docs:
-	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" zkctld
+# Target to run them all.
+.PHONY: generated-docs
+generated-docs: $(BINS:%=%-docs)

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,8 @@ BINS := mysqlctl mysqlctld vtaclcheck topo2topo vtbackup vtclient vtcombo \
 # `make mysqlctl-docs COBRADOC_VERSION_PAIRS="main:22.0" VITESS_DIR=~/go/src/github.com/vitessio/vitess`
 %-docs:
 	go run ./tools/cobradocs/ --vitess-dir "${VITESS_DIR}" --version-pairs "${COBRADOC_VERSION_PAIRS}" $(patsubst %-docs,%,$@)
+	COMMIT_HASH=$(shell cd $(VITESS_DIR) && git rev-parse --short HEAD) && \
+        git add -u content && git commit -s -m "Update cobradocs for $$COMMIT_HASH"
 
 # Target to run them all.
 .PHONY: generated-docs

--- a/content/en/docs/archive/18.0/_index.md
+++ b/content/en/docs/archive/18.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v18.0 (EOL)
+title: v18.0 (Archived)
 description: >
   
   Everything you need to know about scaling MySQL with Vitess.

--- a/content/en/docs/archive/19.0/_index.md
+++ b/content/en/docs/archive/19.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v19.0 (EOL)
+title: v19.0 (Archived)
 description: >
   
   Everything you need to know about scaling MySQL with Vitess.

--- a/content/en/docs/archive/19.0/_index.md
+++ b/content/en/docs/archive/19.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v19.0 (Stable)
+title: v19.0 (EOL)
 description: >
   
   Everything you need to know about scaling MySQL with Vitess.

--- a/content/zh/docs/19.0/_index.md
+++ b/content/zh/docs/19.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v19.0 (Stable)
+title: v19.0 (EOL)
 description:  因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:

--- a/content/zh/docs/19.0/_index.md
+++ b/content/zh/docs/19.0/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v19.0 (EOL)
+title: v19.0 (Archived)
 description:  因为这些文档不维护，所以它们是旧的。你想了解的有关世界上最具扩展性的开源MySQL平台的一切，都在这里
 notoc: true
 cascade:

--- a/tools/cobradocs/version.go
+++ b/tools/cobradocs/version.go
@@ -78,9 +78,11 @@ func (v version) GenerateDocs(workdir string, vitessDir string, docgenPath strin
 
 	docgen := exec.Command("go", "run", docgenPath, "-d", v.Dir(workdir))
 	debugf(docgen.String())
-	if err = docgen.Run(); err != nil {
+	var output []byte
+	if output, err = docgen.CombinedOutput(); err != nil {
 		return err
 	}
+	debugf("docgen output: %s", output)
 
 	return err
 }

--- a/tools/cobradocs/version.go
+++ b/tools/cobradocs/version.go
@@ -40,28 +40,26 @@ func (v version) GenerateDocs(workdir string, vitessDir string, docgenPath strin
 	}
 
 	defer func() {
-		debugf("chdir %s", workdir)
+		debugf("in defer: chdir %s", workdir)
 		if cderr := os.Chdir(workdir); cderr != nil {
 			if err == nil {
 				err = cderr
 			}
 		}
 	}()
-
 	if v.Ref != "HEAD" {
 		gitCheckout := exec.Command("git", "checkout", v.Ref)
-		debugf(gitCheckout.String())
-		if err = gitCheckout.Run(); err != nil {
+		if output, err := gitCheckout.CombinedOutput(); err != nil {
+			debugf("output: %s, err: %s", output, err)
 			return err
 		}
-
 		defer func() {
 			gitCheckout := exec.Command("git", "checkout", "-")
-			debugf(gitCheckout.String())
-			if checkoutErr := gitCheckout.Run(); checkoutErr != nil {
+			if output, checkoutErr := gitCheckout.CombinedOutput(); checkoutErr != nil {
 				if err == nil {
 					err = checkoutErr
 				}
+				debugf("output: %s, err: %s", output, checkoutErr)
 			}
 		}()
 	}
@@ -80,9 +78,9 @@ func (v version) GenerateDocs(workdir string, vitessDir string, docgenPath strin
 	debugf(docgen.String())
 	var output []byte
 	if output, err = docgen.CombinedOutput(); err != nil {
+		debugf("docgen output: %s, err %s", output, err)
 		return err
 	}
 	debugf("docgen output: %s", output)
-
 	return err
 }


### PR DESCRIPTION
## Description

Updates the Makefile for cobra doc generation related targets:
* Create a single target for all binaries 
* Add new files automatically to the repo with the Vitess repo hash as part of the commit message
* Also improved error logging 
* Once we run  `make generated-docs` as part of a new PR to remove commit id from the docs, which was implemented in https://github.com/vitessio/vitess/pull/17392, future PRs should only contain modified files since we will no longer _every_ file with commit id on each resync.
