### PR TITLE
Website layout change: new `skipversions` header param

### DIFF
--- a/content/en/docs/faq/_index.md
+++ b/content/en/docs/faq/_index.md
@@ -3,6 +3,8 @@ title: FAQ
 description: Frequently Asked Questions about Vitess
 weight: 2900
 docs_nav_disable_expand: true
+cascade:
+  skipversions: true
 aliases: ['/docs/user-guides/faq/']
 ---
 

--- a/layouts/partials/docs/landing-page.html
+++ b/layouts/partials/docs/landing-page.html
@@ -45,6 +45,7 @@
 {{ if and
   (not (isset .Page.Params "version"))
   (not (isset .Page.Params "designdoc"))
+  (not (isset .Page.Params "skipversions"))
 }}
 <h1>Versions</h1>
 {{ end }}


### PR DESCRIPTION
This removes the excessive `Versions` header in pages that explicitly set `skipversions: true`.