### PR TITLE
vtorc Reference architecture: Backticks error out in mermaid rendering

### DIFF
--- a/content/en/docs/19.0/reference/vtorc/architecture.md
+++ b/content/en/docs/19.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/20.0/reference/vtorc/architecture.md
+++ b/content/en/docs/20.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/21.0/reference/vtorc/architecture.md
+++ b/content/en/docs/21.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/22.0/reference/vtorc/architecture.md
+++ b/content/en/docs/22.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/archive/15.0/reference/vtorc/architecture.md
+++ b/content/en/docs/archive/15.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/archive/16.0/reference/vtorc/architecture.md
+++ b/content/en/docs/archive/16.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/archive/17.0/reference/vtorc/architecture.md
+++ b/content/en/docs/archive/17.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information

--- a/content/en/docs/archive/18.0/reference/vtorc/architecture.md
+++ b/content/en/docs/archive/18.0/reference/vtorc/architecture.md
@@ -21,8 +21,8 @@ stateDiagram-v2
   problems: Problems Found
   fixes: Run Fixes
   
-  start --> topoServer: Every `topo-information-refresh-duration`
-  start --> vttablets: Every `instance-poll-time`
+  start --> topoServer: Every <code>topo-information-refresh-duration</code>
+  start --> vttablets: Every <code>instance-poll-time</code>
   topoServer --> infoCollected: Keyspace and Vttablet records
   vttablets --> infoCollected: MySQL information
   infoCollected --> problems: Analyze collected information


### PR DESCRIPTION
Fix rendering errors in vtorc. See https://vitess.io/docs/22.0/reference/vtorc/architecture/ for what is happening atm.