### PR TITLE
Removed no longer correct note about query timeout comment directives

### DIFF
--- a/content/en/docs/20.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/comment-directives.md
@@ -29,7 +29,6 @@ As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in millisec
 ### Limitation and caveats:
 
 - Only works for `SELECT` (read) queries.
-- Does not work when doing manual shard-targeting. See [this issue](https://github.com/vitessio/vitess/issues/7031).
 - Cannot set a higher limit to evade the settings for `--queryserver-config-query-timeout` and/or `--queryserver-config-transaction-timeout`.
 
 ## Multi-shard Autocommit (`MULTI_SHARD_AUTOCOMMIT`)

--- a/content/en/docs/21.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/comment-directives.md
@@ -29,7 +29,6 @@ As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in millisec
 ### Limitation and caveats:
 
 - Only works for `SELECT` (read) queries.
-- Does not work when doing manual shard-targeting. See [this issue](https://github.com/vitessio/vitess/issues/7031).
 - Cannot set a higher limit to evade the settings for `--queryserver-config-query-timeout` and/or `--queryserver-config-transaction-timeout`.
 
 ## Multi-shard Autocommit (`MULTI_SHARD_AUTOCOMMIT`)

--- a/content/en/docs/22.0/user-guides/configuration-advanced/comment-directives.md
+++ b/content/en/docs/22.0/user-guides/configuration-advanced/comment-directives.md
@@ -29,7 +29,6 @@ As indicated by the comment name (QUERY_TIMEOUT_MS), this timeout is in millisec
 ### Limitation and caveats:
 
 - Only works for `SELECT` (read) queries.
-- Does not work when doing manual shard-targeting. See [this issue](https://github.com/vitessio/vitess/issues/7031).
 - Cannot set a higher limit to evade the settings for `--queryserver-config-query-timeout` and/or `--queryserver-config-transaction-timeout`.
 
 ## Multi-shard Autocommit (`MULTI_SHARD_AUTOCOMMIT`)


### PR DESCRIPTION
Fixed by https://github.com/vitessio/vitess/pull/15898 in v20.