### PR TITLE
Fix typo in the release page

### DIFF
--- a/content/en/docs/releases/_index.md
+++ b/content/en/docs/releases/_index.md
@@ -33,9 +33,7 @@ Each major release is maintained for 1 year.
 - **Current version:** [v19.0.9](https://github.com/vitessio/vitess/releases/tag/v19.0.9) (2025-01-21)
 - **Initial GA release:** [v19.0.0](https://github.com/vitessio/vitess/releases/tag/v19.0.0) (2024-03-06)
 - **End of life:** 2025-03-06
-- **Patch releases:** [v19.0.1](https://github.com/vitessio/vitess/releases/tag/v19.0.1), [v19.0.3](https://github.
-  com/vitessio/vitess/releases/tag/v19.0.3), [v19.0.4](https://github.com/vitessio/vitess/releases/tag/v19.0.4),
-  [v19.0.5](https://github.com/vitessio/vitess/releases/tag/v19.0.5), [v19.0.6](https://github.com/vitessio/vitess/releases/tag/v19.0.6), [v19.0.7](https://github.com/vitessio/vitess/releases/tag/v19.0.7), [v19.0.8](https://github.com/vitessio/vitess/releases/tag/v19.0.8), [v19.0.9](https://github.com/vitessio/vitess/releases/tag/v19.0.9)
+- **Patch releases:** [v19.0.1](https://github.com/vitessio/vitess/releases/tag/v19.0.1), [v19.0.3](https://github.com/vitessio/vitess/releases/tag/v19.0.3), [v19.0.4](https://github.com/vitessio/vitess/releases/tag/v19.0.4), [v19.0.5](https://github.com/vitessio/vitess/releases/tag/v19.0.5), [v19.0.6](https://github.com/vitessio/vitess/releases/tag/v19.0.6), [v19.0.7](https://github.com/vitessio/vitess/releases/tag/v19.0.7), [v19.0.8](https://github.com/vitessio/vitess/releases/tag/v19.0.8), [v19.0.9](https://github.com/vitessio/vitess/releases/tag/v19.0.9)
 
 ----
 

--- a/content/en/docs/releases/_index.md
+++ b/content/en/docs/releases/_index.md
@@ -43,8 +43,7 @@ Each major release is maintained for 1 year.
 - **Current version:** [v18.0.8](https://github.com/vitessio/vitess/releases/tag/v18.0.8) (2024-11-06)
 - **Initial GA release:** [v18.0.0](https://github.com/vitessio/vitess/releases/tag/v18.0.0) (2023-11-07)
 - **End of life:** 2024-11-07
-- **Patch releases:** [v18.0.1](https://github.com/vitessio/vitess/releases/tag/v18.0.1), [v18.0.2](https://github.
-  com/vitessio/vitess/releases/tag/v18.0.2), [v18.0.3](https://github.com/vitessio/vitess/releases/tag/v18.0.3), [v18.0.4](https://github.com/vitessio/vitess/releases/tag/v18.0.4), [v18.0.5](https://github.com/vitessio/vitess/releases/tag/v18.0.5), [v18.0.6](https://github.com/vitessio/vitess/releases/tag/v18.0.6), [v18.0.7](https://github.com/vitessio/vitess/releases/tag/v18.0.7), [v18.0.8](https://github.com/vitessio/vitess/releases/tag/v18.0.8)
+- **Patch releases:** [v18.0.1](https://github.com/vitessio/vitess/releases/tag/v18.0.1), [v18.0.2](https://github.com/vitessio/vitess/releases/tag/v18.0.2), [v18.0.3](https://github.com/vitessio/vitess/releases/tag/v18.0.3), [v18.0.4](https://github.com/vitessio/vitess/releases/tag/v18.0.4), [v18.0.5](https://github.com/vitessio/vitess/releases/tag/v18.0.5), [v18.0.6](https://github.com/vitessio/vitess/releases/tag/v18.0.6), [v18.0.7](https://github.com/vitessio/vitess/releases/tag/v18.0.7), [v18.0.8](https://github.com/vitessio/vitess/releases/tag/v18.0.8)
 
 ### v17.0
 - **Current version:** [v17.0.7](https://github.com/vitessio/vitess/releases/tag/v17.0.7) (2024-05-08)


### PR DESCRIPTION
Small fix to the release page, here is the issue:
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/ebea8bde-62b0-4346-abc0-948c399ac5f8" />
