### PR TITLE
Fix format of the vtbackup reference page

### DIFF
--- a/content/en/docs/19.0/reference/programs/vtbackup.md
+++ b/content/en/docs/19.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/20.0/reference/programs/vtbackup.md
+++ b/content/en/docs/20.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/21.0/reference/programs/vtbackup.md
+++ b/content/en/docs/21.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/22.0/reference/programs/vtbackup.md
+++ b/content/en/docs/22.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/archive/16.0/reference/programs/vtbackup.md
+++ b/content/en/docs/archive/16.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/archive/17.0/reference/programs/vtbackup.md
+++ b/content/en/docs/archive/17.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage

--- a/content/en/docs/archive/18.0/reference/programs/vtbackup.md
+++ b/content/en/docs/archive/18.0/reference/programs/vtbackup.md
@@ -6,18 +6,23 @@ description: The Vitess Batch Command for Backup Maintenance
 `vtbackup` is a batch comand to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, `vtbackup` can ensure these configurable policies:
+
  - There is always a recent backup for the shard.
+
  - Old backups for the shard are removed.
 
 Whatever system launches `vtbackup` is responsible for the following:
- - Running `vtbackup` with similar flags that would be used for a vttablet and
-   mysqlctld in the target shard to be backed up.
- - Provisioning as much disk space for `vtbackup` as would be given to vttablet.
-   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running `vtbackup` with similar flags that would be used for a vttablet and mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for `vtbackup` as would be given to vttablet. The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
  - Running `vtbackup` periodically for each shard, for each backup storage location.
- - Ensuring that at most one instance runs at a time for a given pair of shard
-   and backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard and backup storage location.
+
  - Retrying `vtbackup` if it fails.
+
  - Alerting human operators if the failure is persistent.
 
 ## Example Usage


### PR DESCRIPTION
The format of that page was broken with item lists being rendered in a single line:
<img width="2041" alt="image" src="https://github.com/user-attachments/assets/a2c63975-4312-4899-9f4e-848df4e3c142" />
