### PR TITLE
Docs: Update outdated links in Operator's Guide

### DIFF
--- a/content/en/docs/19.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/19.0/reference/vtadmin/operators_guide.md
@@ -106,9 +106,9 @@ For further reading on VTAdmin's RBAC design, please refer to the [reference pag
 There is no trust boundary between `vtadmin-web` and `vtadmin-api`, with deployment-specific authentication mechanisms being left to the operator to design for their specific environment.
 As such, you should deploy VTAdmin **within** a trusted environment, for example, behind a single sign-on (SSO) integration, such as [okta](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/go/main/).
 
-[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/local/vtadmin/discovery.json
+[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/common/vtadmin/discovery.json
 [go_embed]:https://pkg.go.dev/embed
-[local_example]: https://github.com/vitessio/vitess/blob/main/examples/local/scripts/vtadmin-up.sh
+[local_example]: https://github.com/vitessio/vitess/blob/main/examples/common/scripts/vtadmin-up.sh
 [npm_serve]: https://www.npmjs.com/package/serve
 [principle_of_least_privilege]: https://csrc.nist.gov/glossary/term/least_privilege#:~:text=Definition(s)%3A,needs%20to%20perform%20its%20function.
 [rbac_docs]: ../role-based-access-control

--- a/content/en/docs/20.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/20.0/reference/vtadmin/operators_guide.md
@@ -106,9 +106,9 @@ For further reading on VTAdmin's RBAC design, please refer to the [reference pag
 There is no trust boundary between `vtadmin-web` and `vtadmin-api`, with deployment-specific authentication mechanisms being left to the operator to design for their specific environment.
 As such, you should deploy VTAdmin **within** a trusted environment, for example, behind a single sign-on (SSO) integration, such as [okta](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/go/main/).
 
-[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/local/vtadmin/discovery.json
+[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/common/vtadmin/discovery.json
 [go_embed]:https://pkg.go.dev/embed
-[local_example]: https://github.com/vitessio/vitess/blob/main/examples/local/scripts/vtadmin-up.sh
+[local_example]: https://github.com/vitessio/vitess/blob/main/examples/common/scripts/vtadmin-up.sh
 [npm_serve]: https://www.npmjs.com/package/serve
 [principle_of_least_privilege]: https://csrc.nist.gov/glossary/term/least_privilege#:~:text=Definition(s)%3A,needs%20to%20perform%20its%20function.
 [rbac_docs]: ../role-based-access-control

--- a/content/en/docs/21.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/21.0/reference/vtadmin/operators_guide.md
@@ -106,9 +106,9 @@ For further reading on VTAdmin's RBAC design, please refer to the [reference pag
 There is no trust boundary between `vtadmin-web` and `vtadmin-api`, with deployment-specific authentication mechanisms being left to the operator to design for their specific environment.
 As such, you should deploy VTAdmin **within** a trusted environment, for example, behind a single sign-on (SSO) integration, such as [okta](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/go/main/).
 
-[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/local/vtadmin/discovery.json
+[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/common/vtadmin/discovery.json
 [go_embed]:https://pkg.go.dev/embed
-[local_example]: https://github.com/vitessio/vitess/blob/main/examples/local/scripts/vtadmin-up.sh
+[local_example]: https://github.com/vitessio/vitess/blob/main/examples/common/scripts/vtadmin-up.sh
 [npm_serve]: https://www.npmjs.com/package/serve
 [principle_of_least_privilege]: https://csrc.nist.gov/glossary/term/least_privilege#:~:text=Definition(s)%3A,needs%20to%20perform%20its%20function.
 [rbac_docs]: ../role-based-access-control

--- a/content/en/docs/22.0/reference/vtadmin/operators_guide.md
+++ b/content/en/docs/22.0/reference/vtadmin/operators_guide.md
@@ -106,9 +106,9 @@ For further reading on VTAdmin's RBAC design, please refer to the [reference pag
 There is no trust boundary between `vtadmin-web` and `vtadmin-api`, with deployment-specific authentication mechanisms being left to the operator to design for their specific environment.
 As such, you should deploy VTAdmin **within** a trusted environment, for example, behind a single sign-on (SSO) integration, such as [okta](https://developer.okta.com/docs/guides/sign-into-web-app-redirect/go/main/).
 
-[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/local/vtadmin/discovery.json
+[discovery_json]: https://github.com/vitessio/vitess/blob/main/examples/common/vtadmin/discovery.json
 [go_embed]:https://pkg.go.dev/embed
-[local_example]: https://github.com/vitessio/vitess/blob/main/examples/local/scripts/vtadmin-up.sh
+[local_example]: https://github.com/vitessio/vitess/blob/main/examples/common/scripts/vtadmin-up.sh
 [npm_serve]: https://www.npmjs.com/package/serve
 [principle_of_least_privilege]: https://csrc.nist.gov/glossary/term/least_privilege#:~:text=Definition(s)%3A,needs%20to%20perform%20its%20function.
 [rbac_docs]: ../role-based-access-control


### PR DESCRIPTION
Fixes #1890 by updating links for discovery.json and it's corresponding local example.