### PR TITLE
Add OSS 2021 talk

### DIFF
--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -11,6 +11,10 @@ resources:
   # Note: To generate "thumbnail_url", visit https://embed.ly/docs/explore/extract
   # and enter the link to the resource. Once you do that, select any thumbnail url of choice to use.
 
+  - url: "https://video.fosdem.org/2025/ua2114/fosdem-2025-4759-migrating-massive-aurora-and-mysql-databases-to-vitess-kubernetes-clusters-with-near-zero-downtime.av1.webm"
+    title: "Migrating Massive Aurora and MySQL Databases to Vitess Kubernetes Clusters with Near-Zero Downtime - Matthias Crauwels & Rohit Nayak, PlanetScale"
+    date: 2025
+    type: video
   - youtube: PM213WqA-vg
     title: "Introduction to Vitess: Scalable Database for Modern Applications"
     date: 2024

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -11,6 +11,10 @@ resources:
   # Note: To generate "thumbnail_url", visit https://embed.ly/docs/explore/extract
   # and enter the link to the resource. Once you do that, select any thumbnail url of choice to use.
 
+  - youtube: TjyzDlQEgdU
+    title: "Atomic Distributed Transactions in Vitess - Harshit Gangal & Manan Gupta, PlanetScale"
+    date: 2025
+    type: video
   - url: "https://video.fosdem.org/2025/ua2114/fosdem-2025-4759-migrating-massive-aurora-and-mysql-databases-to-vitess-kubernetes-clusters-with-near-zero-downtime.mp4"
     title: "Migrating Massive Aurora and MySQL Databases to Vitess Kubernetes Clusters with Near-Zero Downtime - Matthias Crauwels & Rohit Nayak, PlanetScale"
     date: 2025

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -51,7 +51,7 @@ resources:
   - url: "https://se-radio.net/2023/04/se-radio-560-sugu-sougoumarane-on-distributed-sql-with-vitess/"
     title: "Distributed SQL with Vitess - Sugu Sougoumarane, PlanetScale"
     date: 2023
-    thumbnail_url: "https://se-radio.net/wp-content/uploads/2023/04/sugu.png"
+    thumbnail_url: "https://se-radio.net/wp-content/uploads/2023/10/SE-radio-logo-color-600x100-1-e1704759241296.png"
     type: podcast
   - youtube: C2DsT1_zK_4
     title: "Introduction to Vitess and Real World Usage - Arthur Schreiber, GitHub & Florent Poinsard, PlanetScale"
@@ -88,7 +88,7 @@ resources:
   - url: "https://se-radio.net/2022/05/episode-510-deepthi-sigireddi-on-how-vitess-scales-mysql/"
     title: "How Vitess Scales MySQL - Deepthi Sigireddi, PlanetScale"
     date: 2022
-    thumbnail_url: "https://se-radio.net/wp-content/uploads/2022/05/deepthi-sigreddi.jpeg"
+    thumbnail_url: "https://se-radio.net/wp-content/uploads/2023/10/SE-radio-logo-color-600x100-1-e1704759241296.png"
     type: podcast
   - url: "https://changelog.com/podcast/485"
     title: "The Story of Vitess - Deepthi Sigireddi, PlanetScale"

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -11,8 +11,12 @@ resources:
   # Note: To generate "thumbnail_url", visit https://embed.ly/docs/explore/extract
   # and enter the link to the resource. Once you do that, select any thumbnail url of choice to use.
 
-  - url: "https://video.fosdem.org/2025/ua2114/fosdem-2025-4759-migrating-massive-aurora-and-mysql-databases-to-vitess-kubernetes-clusters-with-near-zero-downtime.av1.webm"
+  - url: "https://video.fosdem.org/2025/ua2114/fosdem-2025-4759-migrating-massive-aurora-and-mysql-databases-to-vitess-kubernetes-clusters-with-near-zero-downtime.mp4"
     title: "Migrating Massive Aurora and MySQL Databases to Vitess Kubernetes Clusters with Near-Zero Downtime - Matthias Crauwels & Rohit Nayak, PlanetScale"
+    date: 2025
+    type: video
+  - url: "https://video.fosdem.org/2025/h1301/fosdem-2025-4921-schemadiff-in-memory-schema-analysis-validation-normalization-diffing-and-manipulation.mp4"
+    title: "schemadiff: in memory schema analysis, validation, normalization, diffing, and manipulation - Shlomi Noach, PlanetScale"
     date: 2025
     type: video
   - youtube: PM213WqA-vg

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -93,6 +93,10 @@ resources:
     title: "Vitess: Introduction and New Features - Deepthi Sigireddi & Alkin Tezuysal, PlanetScale; Andrew Mason & Malcolm Akinje, Slack Corp."
     date: 2021
     type: video
+  - youtube: 6ZZkxrM7Rk0
+    title: "Horizontal Scaling with Vitess - Deepthi Sigireddi, PlanetScale"
+    date: 2021
+    type: video
   - youtube: Bllc-u_cCGA
     title: "Deploying a Sharded Vitess Sandbox Cluster in Public Cloud Kubernetes in 10 Minutes - Jordan Moldow, Box"
     date: 2021

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -50,7 +50,7 @@ resources:
     type: video
   - url: "https://se-radio.net/2023/04/se-radio-560-sugu-sougoumarane-on-distributed-sql-with-vitess/"
     title: "Distributed SQL with Vitess - Sugu Sougoumarane, PlanetScale"
-    date: 2022
+    date: 2023
     thumbnail_url: "https://se-radio.net/wp-content/uploads/2023/04/sugu.png"
     type: podcast
   - youtube: C2DsT1_zK_4
@@ -94,6 +94,7 @@ resources:
     title: "The Story of Vitess - Deepthi Sigireddi, PlanetScale"
     date: 2022
     type: podcast
+    thumbnail_url: "https://snap.fly.dev/podcast/485/img"
   - url: "https://video.fosdem.org/2022/D.mysql/relational_model_dev.webm"
     title: "The relational model in the modern development age - Shlomi Noach, PlanetScale"
     date: 2022

--- a/data/resources.yaml
+++ b/data/resources.yaml
@@ -48,6 +48,11 @@ resources:
     title: "MySQL and Vitess (and Kubernetes) at HubSpot - Jean-François Gagné & Swetha Narayanaswamy, HubSpot"
     date: 2023
     type: video
+  - url: "https://se-radio.net/2023/04/se-radio-560-sugu-sougoumarane-on-distributed-sql-with-vitess/"
+    title: "Distributed SQL with Vitess - Sugu Sougoumarane, PlanetScale"
+    date: 2022
+    thumbnail_url: "https://se-radio.net/wp-content/uploads/2023/04/sugu.png"
+    type: podcast
   - youtube: C2DsT1_zK_4
     title: "Introduction to Vitess and Real World Usage - Arthur Schreiber, GitHub & Florent Poinsard, PlanetScale"
     date: 2023
@@ -72,16 +77,12 @@ resources:
     title: "Vitess: Introduction and New Features - Deepthi Sigireddi, Matt Lord & Rohit Nayak, PlanetScale"
     date: 2022
     type: video
-  - youtube: HgSlmzC7O-E
-    title: "Scaling Databases with Vitess - Harshit Gangal & Manan Gupta, PlanetScale"
-    date: 2022
-    type: video
   - youtube: ltoJ8gxs0YU
     title: "Vitess VReplication: Standing on the Shoulders of a MySQL Giant - Matt Lord, PlanetScale"
     date: 2022
     type: video
-  - url: "https://video.fosdem.org/2022/D.mysql/relational_model_dev.webm"
-    title: "The relational model in the modern development age - Shlomi Noach, PlanetScale"
+  - youtube: HgSlmzC7O-E
+    title: "Scaling Databases with Vitess - Harshit Gangal & Manan Gupta, PlanetScale"
     date: 2022
     type: video
   - url: "https://se-radio.net/2022/05/episode-510-deepthi-sigireddi-on-how-vitess-scales-mysql/"
@@ -89,6 +90,14 @@ resources:
     date: 2022
     thumbnail_url: "https://se-radio.net/wp-content/uploads/2022/05/deepthi-sigreddi.jpeg"
     type: podcast
+  - url: "https://changelog.com/podcast/485"
+    title: "The Story of Vitess - Deepthi Sigireddi, PlanetScale"
+    date: 2022
+    type: podcast
+  - url: "https://video.fosdem.org/2022/D.mysql/relational_model_dev.webm"
+    title: "The relational model in the modern development age - Shlomi Noach, PlanetScale"
+    date: 2022
+    type: video
   - youtube: fLullHPddvg
     title: "Continuous Performance Benchmarking for Vitess - Alkin Tezuysal, Florent Poinsard & Manan Gupta, PlanetScale"
     date: 2021


### PR DESCRIPTION
Open Source Summit 2021 Vitess talk was missing from `Resources`.