### PR TITLE
Bump K8S version used by Minikube

### DIFF
--- a/content/en/docs/21.0/get-started/operator.md
+++ b/content/en/docs/21.0/get-started/operator.md
@@ -17,7 +17,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
     ```bash
-    minikube start --kubernetes-version=v1.28.5 --cpus=4 --memory=11000 --disk-size=32g
+    minikube start --kubernetes-version=v1.31.0 --cpus=4 --memory=11000 --disk-size=32g
     ```
 
     {{<warning>}}Allocating less memory than specified will cause crashes in subsequent steps and break the process{{</warning>}}

--- a/content/en/docs/22.0/get-started/operator.md
+++ b/content/en/docs/22.0/get-started/operator.md
@@ -17,7 +17,7 @@ Before we get started, let’s get a few pre-requisites out of the way:
 
 1. Install [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) and start a Minikube engine:
     ```bash
-    minikube start --kubernetes-version=v1.28.5 --cpus=4 --memory=11000 --disk-size=32g
+    minikube start --kubernetes-version=v1.32.2 --cpus=4 --memory=11000 --disk-size=32g
     ```
 
     {{<warning>}}Allocating less memory than specified will cause crashes in subsequent steps and break the process{{</warning>}}


### PR DESCRIPTION
This is a follow up of https://github.com/planetscale/vitess-operator/pull/670 and https://github.com/vitessio/vitess/pull/17889.

Bumping the default K8S version used by Minikube to the correct version for both 21.0 and 22.0.