### PR TITLE
Re-generate CLI documentation for v22

### DIFF
--- a/content/en/docs/22.0/reference/programs/mysqlctl/_index.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/_index.md
@@ -1,7 +1,6 @@
 ---
 title: mysqlctl
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl
 
@@ -70,7 +69,7 @@ This helps ensure that `mysqld` is automatically restarted after failures.
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_init.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_init.md
@@ -1,7 +1,6 @@
 ---
 title: init
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl init
 
@@ -88,7 +87,7 @@ mysqlctl \
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_init_config.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_init_config.md
@@ -1,7 +1,6 @@
 ---
 title: init config
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl init_config
 
@@ -86,7 +85,7 @@ mysqlctl \
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_position.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_position.md
@@ -1,7 +1,6 @@
 ---
 title: position
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl position
 
@@ -71,7 +70,7 @@ mysqlctl position <operation> <pos1> <pos2 | gtid> [flags]
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_reinit_config.md
@@ -1,7 +1,6 @@
 ---
 title: reinit config
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl reinit_config
 
@@ -86,7 +85,7 @@ mysqlctl \
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_shutdown.md
@@ -1,7 +1,6 @@
 ---
 title: shutdown
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl shutdown
 
@@ -84,7 +83,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr shutdown
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_start.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_start.md
@@ -1,7 +1,6 @@
 ---
 title: start
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl start
 
@@ -83,7 +82,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr start
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_teardown.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctl/mysqlctl_teardown.md
@@ -1,7 +1,6 @@
 ---
 title: teardown
 series: mysqlctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctl teardown
 
@@ -87,7 +86,7 @@ mysqlctl --tablet_uid 101 --alsologtostderr teardown
       --logtostderr                                                 log to standard error instead of files
       --max-stack-size int                                          configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                              MySQL port. (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         Path to the mysqld socket file.
       --mysqlctl_client_protocol string                             the protocol to use to talk to the mysqlctl server (default "grpc")
       --mysqlctl_mycnf_template string                              template file to use for generating the my.cnf file during server init

--- a/content/en/docs/22.0/reference/programs/mysqlctld/_index.md
+++ b/content/en/docs/22.0/reference/programs/mysqlctld/_index.md
@@ -1,7 +1,6 @@
 ---
 title: mysqlctld
 series: mysqlctld
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## mysqlctld
 
@@ -116,7 +115,7 @@ mysqlctld \
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
       --mysql_port int                                                   MySQL port (default 3306)
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                              Path to the mysqld socket file
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)

--- a/content/en/docs/22.0/reference/programs/topo2topo/_index.md
+++ b/content/en/docs/22.0/reference/programs/topo2topo/_index.md
@@ -1,7 +1,6 @@
 ---
 title: topo2topo
 series: topo2topo
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## topo2topo
 

--- a/content/en/docs/22.0/reference/programs/vtaclcheck/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtaclcheck/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtaclcheck
 series: vtaclcheck
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtaclcheck
 

--- a/content/en/docs/22.0/reference/programs/vtbackup/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtbackup/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtbackup
 series: vtbackup
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtbackup
 
@@ -12,19 +11,25 @@ vtbackup is a batch command to perform a single pass of backup maintenance for a
 vtbackup is a batch command to perform a single pass of backup maintenance for a shard.
 
 When run periodically for each shard, vtbackup can ensure these configurable policies:
-	* There is always a recent backup for the shard.
-	* Old backups for the shard are removed.
+ * There is always a recent backup for the shard.
+
+ * Old backups for the shard are removed.
 
 Whatever system launches vtbackup is responsible for the following:
-	- Running vtbackup with similar flags that would be used for a vttablet and
-    mysqlctld in the target shard to be backed up.
-	- Provisioning as much disk space for vtbackup as would be given to vttablet.
-    The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
-	- Running vtbackup periodically for each shard, for each backup storage location.
-	- Ensuring that at most one instance runs at a time for a given pair of shard
-    and backup storage location.
-	- Retrying vtbackup if it fails.
-	- Alerting human operators if the failure is persistent.
+ - Running vtbackup with similar flags that would be used for a vttablet and 
+   mysqlctld in the target shard to be backed up.
+
+ - Provisioning as much disk space for vtbackup as would be given to vttablet.
+   The data directory MUST be empty at startup. Do NOT reuse a persistent disk.
+
+ - Running vtbackup periodically for each shard, for each backup storage location.
+
+ - Ensuring that at most one instance runs at a time for a given pair of shard
+   and backup storage location.
+
+ - Retrying vtbackup if it fails.
+
+ - Alerting human operators if the failure is persistent.
 
 The process vtbackup follows to take a new backup has the following steps:
  1. Restore from the most recent backup.
@@ -198,7 +203,7 @@ vtbackup [flags]
       --mysql-shell-speedup-restore                                 speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                             how long to wait for mysqld shutdown (default 5m0s)
       --mysql_port int                                              mysql port (default 3306)
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_socket string                                         path to the mysql socket
       --mysql_timeout duration                                      how long to wait for mysqld startup (default 5m0s)
       --opentsdb_uri string                                         URI of opentsdb /api/put method
@@ -209,6 +214,7 @@ vtbackup [flags]
       --remote_operation_timeout duration                           time to wait for a remote operation (default 15s)
       --restart_before_backup                                       Perform a mysqld clean/full restart after applying binlogs, but before taking the backup. Only makes sense to work around xtrabackup bugs.
       --s3_backup_aws_endpoint string                               endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                              Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                 AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                   AWS request retries. (default -1)
       --s3_backup_force_path_style                                  force the s3 path style.
@@ -245,6 +251,7 @@ vtbackup [flags]
       --topo_global_root string                                     the path of the global topology data in the global topology server
       --topo_global_server_address string                           the address of the global topology server
       --topo_implementation string                                  the topology implementation to use
+      --topo_read_concurrency int                                   Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                    auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                               zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                 maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/content/en/docs/22.0/reference/programs/vtclient/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtclient/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtclient
 series: vtclient
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtclient
 
@@ -38,10 +37,20 @@ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1,
       --config-persistence-min-interval duration                    minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --count int                                                   DMLs only: Number of times each thread executes the query. Useful for simple, sustained load testing. (default 1)
+      --datadog-agent-host string                                   host to send spans to. if empty, no tracing will be done
+      --datadog-agent-port string                                   port to send spans to. if empty, no tracing will be done
+      --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
+      --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
+      --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
       --grpc_enable_tracing                                         Enable gRPC tracing.
+      --grpc_initial_conn_window_size int                           gRPC initial connection window size
+      --grpc_initial_window_size int                                gRPC initial window size
+      --grpc_keepalive_time duration                                After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+      --grpc_keepalive_timeout duration                             After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
       --grpc_max_message_size int                                   Maximum allowed RPC message size. Larger messages will be rejected by gRPC with the error 'exceeding the max size'. (default 16777216)
       --grpc_prometheus                                             Enable gRPC monitoring with Prometheus.
   -h, --help                                                        help for vtclient
+      --jaeger-agent-host string                                    host and port to send spans to. if empty, no tracing will be done
       --json                                                        Output JSON instead of human-readable table
       --keep_logs duration                                          keep logs for this long (using ctime) (zero to keep forever)
       --keep_logs_by_mtime duration                                 keep logs for this long (using mtime) (zero to keep forever)
@@ -52,7 +61,7 @@ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1,
       --logtostderr                                                 log to standard error instead of files
       --max_sequence_id int                                         max sequence ID.
       --min_sequence_id int                                         min sequence ID to generate. When max_sequence_id > min_sequence_id, for each query, a number is generated in [min_sequence_id, max_sequence_id) and attached to the end of the bind variables.
-      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                 MySQL server version to advertise. (default "8.0.40-Vitess")
       --parallel int                                                DMLs only: Number of threads executing the same query in parallel. Useful for simple load testing. (default 1)
       --pprof strings                                               enable profiling
       --pprof-http                                                  enable pprof http endpoints
@@ -64,9 +73,19 @@ vtclient --server vtgate:15991 --target '@primary' --bind_variables '[ 12345, 1,
       --streaming                                                   use a streaming query
       --target string                                               keyspace:shard@tablet_type
       --timeout duration                                            timeout for queries (default 30s)
+      --tracer string                                               tracing service to use (default "noop")
+      --tracing-enable-logging                                      whether to enable logging in the tracing service
+      --tracing-sampling-rate float                                 sampling rate for the probabilistic jaeger sampler (default 0.1)
+      --tracing-sampling-type string                                sampling strategy to use for jaeger. possible values are 'const', 'probabilistic', 'rateLimiting', or 'remote' (default "const")
       --use_random_sequence                                         use random sequence for generating [min_sequence_id, max_sequence_id)
       --v Level                                                     log level for V logs
   -v, --version                                                     print binary version
       --vmodule vModuleFlag                                         comma-separated list of pattern=N settings for file-filtered logging
+      --vtgate_grpc_ca string                                       the server ca to use to validate servers when connecting
+      --vtgate_grpc_cert string                                     the cert to use to connect
+      --vtgate_grpc_crl string                                      the server crl to use to validate server certificates when connecting
+      --vtgate_grpc_key string                                      the key to use to connect
+      --vtgate_grpc_server_name string                              the server name to use to validate server certificate
+      --vtgate_protocol string                                      how to talk to vtgate (default "grpc")
 ```
 

--- a/content/en/docs/22.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtcombo/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtcombo
 series: vtcombo
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtcombo
 
@@ -35,15 +34,8 @@ vtcombo [flags]
       --backup_storage_compress                                          if set, the backup files will be compressed. (default true)
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
       --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
-      --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
-      --binlog_password string                                           PITR restore parameter: password of binlog server.
+      --binlog-in-memory-decompressor-max-size uint                      This value sets the uncompressed transaction payload size at which we switch from in-memory buffer based decompression to the slower streaming mode. (default 134217728)
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
-      --binlog_port int                                                  PITR restore parameter: port of binlog server.
-      --binlog_ssl_ca string                                             PITR restore parameter: Filename containing TLS CA certificate to verify binlog server TLS certificate against.
-      --binlog_ssl_cert string                                           PITR restore parameter: Filename containing mTLS client certificate to present to binlog server as authentication.
-      --binlog_ssl_key string                                            PITR restore parameter: Filename containing mTLS client private key for use in binlog server authentication.
-      --binlog_ssl_server_name string                                    PITR restore parameter: TLS server name (common name) to verify against for the binlog server we are connecting to (If not set: use the hostname or IP supplied in --binlog_host).
-      --binlog_user string                                               PITR restore parameter: username of binlog server.
       --buffer_drain_concurrency int                                     Maximum number of requests retried simultaneously. More concurrency will increase the load on the PRIMARY vttablet when draining the buffer. (default 1)
       --buffer_keyspace_shards string                                    If not empty, limit buffering to these entries (comma separated). Entry format: keyspace or keyspace/shard. Requires --enable_buffer=true.
       --buffer_max_failover_duration duration                            Stop buffering completely if a failover takes longer than this duration. (default 20s)
@@ -65,6 +57,7 @@ vtcombo [flags]
       --config-path strings                                              Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
+      --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
@@ -123,13 +116,16 @@ vtcombo [flags]
       --ddl_strategy string                                              Set default strategy for DDL statements. Override with @@ddl_strategy session variable (default "direct")
       --default_tablet_type topodatapb.TabletType                        The default tablet type to set for queries, when one is not explicitly selected. (default PRIMARY)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
+      --disk-write-dir string                                            if provided, tablet will attempt to write a file to this directory to check if the disk is stalled
+      --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
+      --disk-write-timeout duration                                      if writes exceed this duration, the disk is considered stalled (default 30s)
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
       --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
       --enable-per-workload-table-metrics                                If true, query counts and query error metrics include a label that identifies the workload
       --enable-tx-throttler                                              Synonym to -enable_tx_throttler
-      --enable-views                                                     Enable views support in vtgate.
+      --enable-views                                                     Enable views support in vtgate. (default true)
       --enable_buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
       --enable_consolidator                                              This option enables the query consolidator. (default true)
@@ -262,7 +258,7 @@ vtcombo [flags]
       --mysql_server_ssl_key string                                      Path to ssl key for mysql server plugin SSL
       --mysql_server_ssl_server_ca string                                path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --mysql_server_tls_min_version string                              Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_server_write_timeout duration                              connection write timeout
       --mysql_slow_connect_warn_threshold duration                       Warn if it takes more than the given threshold for a mysql connection to establish
       --mysql_tcp_version string                                         Select tcp, tcp4, or tcp6 to control the socket type. (default "tcp")
@@ -273,7 +269,6 @@ vtcombo [flags]
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
-      --pitr_gtid_lookup_timeout duration                                PITR restore parameter: timeout for fetching gtid from timestamp. (default 1m0s)
       --planner-version string                                           Sets the default planner to use when the session has not changed it. Valid values are: Gen4, Gen4Greedy, Gen4Left2Right
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
@@ -289,6 +284,7 @@ vtcombo [flags]
       --querylog-buffer-size int                                         Maximum number of buffered query logs before throttling log output (default 10)
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
@@ -302,11 +298,13 @@ vtcombo [flags]
       --queryserver-config-pool-conn-max-lifetime duration               query server connection max lifetime, vttablet manages various mysql connection pools. This config means if a connection has lived at least this long, it connection will be removed from pool upon the next time it is returned to the pool.
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --queryserver-config-query-pool-max-idle-count int                 query server query pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
+      --queryserver-config-stream-pool-max-idle-count int                query server stream pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
@@ -314,6 +312,7 @@ vtcombo [flags]
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
+      --queryserver-config-txpool-max-idle-count int                     query server transaction pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-views                                         Enable views support in vttablet.
@@ -336,6 +335,7 @@ vtcombo [flags]
       --schema_change_signal                                             Enable the schema tracker; requires queryserver-config-schema-change-signal to be enabled on the underlying vttablets for this to work (default true)
       --schema_dir string                                                Schema base directory. Should contain one directory per keyspace, with a vschema.json file if necessary.
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --semi-sync-monitor-interval duration                              How frequently the semi-sync monitor checks if the primary is blocked on semi-sync ACKs (default 10s)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
@@ -385,7 +385,7 @@ vtcombo [flags]
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)
@@ -406,8 +406,7 @@ vtcombo [flags]
       --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
       --transaction_mode string                                          SINGLE: disallow multi-db transactions, MULTI: allow multi-db transactions with best effort commit, TWOPC: allow multi-db transactions with 2pc commit (default "MULTI")
       --truncate-error-len int                                           truncate errors sent to client if they are longer than this value (0 means do not truncate)
-      --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
-      --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
+      --twopc_abandon_age time.Duration                                  Any unresolved transaction older than this time will be sent to the coordinator to be resolved. NOTE: Providing time as seconds (float64) is deprecated. Use time.Duration format (e.g., '1s', '2m', '1h'). (default 15m0s)
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
       --tx-throttler-default-priority int                                Default priority assigned to queries that lack priority information (default 100)
       --tx-throttler-dry-run                                             If present, the transaction throttler only records metrics about requests received and throttled, but does not actually throttle any requests.
@@ -421,11 +420,12 @@ vtcombo [flags]
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
+      --vreplication-enable-http-log                                     Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.
       --vreplication-parallel-insert-workers int                         Number of parallel insertion workers to use during copy phase. Set <= 1 to disable parallelism, or > 1 to enable concurrent insertion during copy phase. (default 1)
       --vreplication_copy_phase_duration duration                        Duration for each copy phase loop (before running the next catchup: default 1h) (default 1h0m0s)
       --vreplication_copy_phase_max_innodb_history_list_length int       The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 1000000)
       --vreplication_copy_phase_max_mysql_replication_lag int            The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 43200)
-      --vreplication_experimental_flags int                              (Bitmask) of experimental features in vreplication to enable (default 3)
+      --vreplication_experimental_flags int                              (Bitmask) of experimental features in vreplication to enable (default 7)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
       --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)

--- a/content/en/docs/22.0/reference/programs/vtctld/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctld/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtctld
 series: vtctld
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtctld
 
@@ -115,7 +114,7 @@ vtctld \
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --opentsdb_uri string                                              URI of opentsdb /api/put method
@@ -127,6 +126,7 @@ vtctld \
       --purge_logs_interval duration                                     how often try to remove old logs (default 1h0m0s)
       --remote_operation_timeout duration                                time to wait for a remote operation (default 15s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.
@@ -181,7 +181,7 @@ vtctld \
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/content/en/docs/22.0/reference/programs/vtgate/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtgate/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtgate
 series: vtgate
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtgate
 
@@ -75,7 +74,7 @@ vtgate \
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-balancer                                                  Enable the tablet balancer to evenly spread query load for a given tablet type
       --enable-partial-keyspace-migration                                (Experimental) Follow shard routing rules: enable only while migrating a keyspace shard by shard. See documentation on Partial MoveTables for more. (default false)
-      --enable-views                                                     Enable views support in vtgate.
+      --enable-views                                                     Enable views support in vtgate. (default true)
       --enable_buffer                                                    Enable buffering (stalling) of primary traffic during failovers.
       --enable_buffer_dry_run                                            Detect and log failover events, but do not actually buffer requests.
       --enable_direct_ddl                                                Allow users to submit direct DDL statements (default true)
@@ -175,7 +174,7 @@ vtgate \
       --mysql_server_ssl_key string                                      Path to ssl key for mysql server plugin SSL
       --mysql_server_ssl_server_ca string                                path to server CA in PEM format, which will be combine with server cert, return full certificate chain to clients
       --mysql_server_tls_min_version string                              Configures the minimal TLS version negotiated when SSL is enabled. Defaults to TLSv1.2. Options: TLSv1.0, TLSv1.1, TLSv1.2, TLSv1.3.
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysql_server_write_timeout duration                              connection write timeout
       --mysql_slow_connect_warn_threshold duration                       Warn if it takes more than the given threshold for a mysql connection to establish
       --mysql_tcp_version string                                         Select tcp, tcp4, or tcp6 to control the socket type. (default "tcp")
@@ -195,6 +194,7 @@ vtgate \
       --querylog-buffer-size int                                         Maximum number of buffered query logs before throttling log output (default 10)
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --redact-debug-ui-queries                                          redact full queries and bind variables from debug UI
@@ -241,7 +241,7 @@ vtgate \
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
-      --topo_read_concurrency int                                        Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/content/en/docs/22.0/reference/programs/vtgateclienttest/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtgateclienttest/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtgateclienttest
 series: vtgateclienttest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtgateclienttest
 
@@ -63,7 +62,7 @@ vtgateclienttest [flags]
       --log_rotate_max_size uint                                         size in bytes at which logs are rotated (glog.MaxSize) (default 1887436800)
       --logtostderr                                                      log to standard error instead of files
       --max-stack-size int                                               configure the maximum stack size in bytes (default 67108864)
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.

--- a/content/en/docs/22.0/reference/programs/vtorc/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtorc/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vtorc
 series: vtorc
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vtorc
 
@@ -34,11 +33,12 @@ vtorc \
       --audit-purge-duration duration                               Duration for which audit logs are held before being purged. Should be in multiples of days (default 168h0m0s)
       --audit-to-backend                                            Whether to store the audit log in the VTOrc database
       --audit-to-syslog                                             Whether to store the audit log in the syslog
+      --backend-read-concurrency int                                Maximum concurrency for reads to the backend (default 32)
+      --backend-write-concurrency int                               Maximum concurrency for writes to the backend (default 24)
       --bind-address string                                         Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
       --catch-sigpipe                                               catch and ignore SIGPIPE on stdout and stderr if specified
       --change-tablets-with-errant-gtid-to-drained                  Whether VTOrc should be changing the type of tablets with errant GTIDs to DRAINED
-      --clusters_to_watch strings                                   Comma-separated list of keyspaces or keyspace/shards that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
-      --config string                                               config file name
+      --clusters_to_watch strings                                   Comma-separated list of keyspaces or keyspace/keyranges that this instance will monitor and repair. Defaults to all clusters in the topology. Example: "ks1,ks2/-80"
       --config-file string                                          Full path of the config file (with extension) to use. If set, --config-path, --config-type, and --config-name are ignored.
       --config-file-not-found-handling ConfigFileNotFoundHandling   Behavior when a config file is not found. (Options: error, exit, ignore, warn) (default warn)
       --config-name string                                          Name of the config file (without extension) to search for. (default "vtconfig")
@@ -47,6 +47,7 @@ vtorc \
       --config-type string                                          Config file type (omit to infer config type from file extension).
       --consul_auth_static_file string                              JSON File to read the topos/tokens from.
       --emit_stats                                                  If set, emit stats to push-based monitoring and stats backends
+      --enable-primary-disk-stalled-recovery                        Whether VTOrc should detect a stalled disk on the primary and failover
       --grpc-dial-concurrency-limit int                             Maximum concurrency of grpc dial operations. This should be less than the golang max thread limit of 10000. (default 1024)
       --grpc_auth_static_client_creds string                        When using grpc_static_auth in the server, this file provides the credentials to use to authenticate with server.
       --grpc_compression string                                     Which protocol to use for compressing gRPC. Default: nothing. Supported: snappy
@@ -112,7 +113,7 @@ vtorc \
       --topo_global_root string                                     the path of the global topology data in the global topology server
       --topo_global_server_address string                           the address of the global topology server
       --topo_implementation string                                  the topology implementation to use
-      --topo_read_concurrency int                                   Concurrency of topo reads. (default 32)
+      --topo_read_concurrency int                                   Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                    auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                               zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                 maximum number of pending requests to send to a Zookeeper server. (default 64)

--- a/content/en/docs/22.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/22.0/reference/programs/vttablet/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vttablet
 series: vttablet
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttablet
 
@@ -74,20 +73,13 @@ vttablet \
       --backup_storage_implementation string                             Which backup storage implementation to use for creating and restoring backups.
       --backup_storage_number_blocks int                                 if backup_storage_compress is true, backup_storage_number_blocks sets the number of blocks that can be processed, in parallel, before the writer blocks, during compression (default is 2). It should be equal to the number of CPUs available for compression. (default 2)
       --bind-address string                                              Bind address for the server. If empty, the server will listen on all available unicast and anycast IP addresses of the local system.
-      --binlog_host string                                               PITR restore parameter: hostname/IP of binlog server.
-      --binlog_password string                                           PITR restore parameter: password of binlog server.
+      --binlog-in-memory-decompressor-max-size uint                      This value sets the uncompressed transaction payload size at which we switch from in-memory buffer based decompression to the slower streaming mode. (default 134217728)
       --binlog_player_grpc_ca string                                     the server ca to use to validate servers when connecting
       --binlog_player_grpc_cert string                                   the cert to use to connect
       --binlog_player_grpc_crl string                                    the server crl to use to validate server certificates when connecting
       --binlog_player_grpc_key string                                    the key to use to connect
       --binlog_player_grpc_server_name string                            the server name to use to validate server certificate
       --binlog_player_protocol string                                    the protocol to download binlogs from a vttablet (default "grpc")
-      --binlog_port int                                                  PITR restore parameter: port of binlog server.
-      --binlog_ssl_ca string                                             PITR restore parameter: Filename containing TLS CA certificate to verify binlog server TLS certificate against.
-      --binlog_ssl_cert string                                           PITR restore parameter: Filename containing mTLS client certificate to present to binlog server as authentication.
-      --binlog_ssl_key string                                            PITR restore parameter: Filename containing mTLS client private key for use in binlog server authentication.
-      --binlog_ssl_server_name string                                    PITR restore parameter: TLS server name (common name) to verify against for the binlog server we are connecting to (If not set: use the hostname or IP supplied in --binlog_host).
-      --binlog_user string                                               PITR restore parameter: username of binlog server.
       --builtinbackup-file-read-buffer-size uint                         read files using an IO buffer of this many bytes. Golang defaults are used when set to 0.
       --builtinbackup-file-write-buffer-size uint                        write files using an IO buffer of this many bytes. Golang defaults are used when set to 0. (default 2097152)
       --builtinbackup-incremental-restore-path string                    the directory where incremental restore files, namely binlog files, are extracted to. In k8s environments, this should be set to a directory that is shared between the vttablet and mysqld pods. The path should exist. When empty, the default OS temp dir is assumed.
@@ -103,6 +95,7 @@ vttablet \
       --config-path strings                                              Paths to search for config files in. (default [<WORKDIR>])
       --config-persistence-min-interval duration                         minimum interval between persisting dynamic config changes back to disk (if no change has occurred, nothing is done). (default 1s)
       --config-type string                                               Config file type (omit to infer config type from file extension).
+      --consolidator-query-waiter-cap int                                Configure the maximum number of clients allowed to wait on the consolidator.
       --consolidator-stream-query-size int                               Configure the stream consolidator query size in bytes. Setting to 0 disables the stream consolidator. (default 2097152)
       --consolidator-stream-total-size int                               Configure the stream consolidator total size in bytes. Setting to 0 disables the stream consolidator. (default 134217728)
       --consul_auth_static_file string                                   JSON File to read the topos/tokens from.
@@ -158,6 +151,9 @@ vttablet \
       --dba_idle_timeout duration                                        Idle timeout for dba connections (default 1m0s)
       --dba_pool_size int                                                Size of the connection pool for dba connections (default 20)
       --degraded_threshold duration                                      replication lag after which a replica is considered degraded (default 30s)
+      --disk-write-dir string                                            if provided, tablet will attempt to write a file to this directory to check if the disk is stalled
+      --disk-write-interval duration                                     how often to write to the disk to check whether it is stalled (default 5s)
+      --disk-write-timeout duration                                      if writes exceed this duration, the disk is considered stalled (default 30s)
       --emit_stats                                                       If set, emit stats to push-based monitoring and stats backends
       --enable-consolidator                                              Synonym to -enable_consolidator (default true)
       --enable-consolidator-replicas                                     Synonym to -enable_consolidator_replicas
@@ -268,14 +264,13 @@ vttablet \
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --onclose_timeout duration                                         wait no more than this for OnClose handlers before stopping (default 10s)
       --onterm_timeout duration                                          wait no more than this for OnTermSync handlers before stopping (default 10s)
       --opentsdb_uri string                                              URI of opentsdb /api/put method
       --pid_file string                                                  If set, the process will write its pid to the named file, and delete it on graceful shutdown.
-      --pitr_gtid_lookup_timeout duration                                PITR restore parameter: timeout for fetching gtid from timestamp. (default 1m0s)
       --pool_hostname_resolve_interval duration                          if set force an update to all hostnames and reconnect if changed, defaults to 0 (disabled)
       --port int                                                         port for the server
       --pprof strings                                                    enable profiling
@@ -285,6 +280,7 @@ vttablet \
       --query-log-stream-handler string                                  URL handler for streaming queries log (default "/debug/querylog")
       --querylog-filter-tag string                                       string that must be present in the query for it to be logged; if using a value as the tag, you need to disable query normalization
       --querylog-format string                                           format for query logs ("text" or "json") (default "text")
+      --querylog-mode string                                             Mode for logging queries. "error" will only log queries that return an error. Otherwise all queries will be logged. (default "all")
       --querylog-row-threshold uint                                      Number of rows a query has to return or affect before being logged; not useful for streaming queries. 0 means all queries will be logged.
       --querylog-sample-rate float                                       Sample rate for logging queries. Value must be between 0.0 (no logging) and 1.0 (all queries)
       --queryserver-config-acl-exempt-acl string                         an acl that exempt from table acl checking (this acl is free to access any vitess tables).
@@ -298,11 +294,13 @@ vttablet \
       --queryserver-config-pool-conn-max-lifetime duration               query server connection max lifetime, vttablet manages various mysql connection pools. This config means if a connection has lived at least this long, it connection will be removed from pool upon the next time it is returned to the pool.
       --queryserver-config-pool-size int                                 query server read pool size, connection pool is used by regular queries (non streaming, not in a transaction) (default 16)
       --queryserver-config-query-cache-memory int                        query server query cache size in bytes, maximum amount of memory to be used for caching. vttablet analyzes every incoming query and generate a query plan, these plans are being cached in a lru cache. This config controls the capacity of the lru cache. (default 33554432)
+      --queryserver-config-query-pool-max-idle-count int                 query server query pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-query-pool-timeout duration                   query server query pool timeout, it is how long vttablet waits for a connection from the query pool. If set to 0 (default) then the overall query timeout is used instead.
       --queryserver-config-query-timeout duration                        query server query timeout, this is the query timeout in vttablet side. If a query takes more than this timeout, it will be killed. (default 30s)
       --queryserver-config-schema-change-signal                          query server schema signal, will signal connected vtgates that schema has changed whenever this is detected. VTGates will need to have -schema_change_signal enabled for this to work (default true)
       --queryserver-config-schema-reload-time duration                   query server schema reload time, how often vttablet reloads schemas from underlying MySQL instance. vttablet keeps table schemas in its own memory and periodically refreshes it from MySQL. This config controls the reload time. (default 30m0s)
       --queryserver-config-stream-buffer-size int                        query server stream buffer size, the maximum number of bytes sent from vttablet for each stream call. It's recommended to keep this value in sync with vtgate's stream_buffer_size. (default 32768)
+      --queryserver-config-stream-pool-max-idle-count int                query server stream pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-stream-pool-size int                          query server stream connection pool size, stream pool is used by stream queries: queries that return results to client in a streaming fashion (default 200)
       --queryserver-config-stream-pool-timeout duration                  query server stream pool timeout, it is how long vttablet waits for a connection from the stream pool. If set to 0 (default) then there is no timeout.
       --queryserver-config-strict-table-acl                              only allow queries that pass table acl checks
@@ -310,6 +308,7 @@ vttablet \
       --queryserver-config-transaction-cap int                           query server transaction cap is the maximum number of transactions allowed to happen at any given point of a time for a single vttablet. E.g. by setting transaction cap to 100, there are at most 100 transactions will be processed by a vttablet and the 101th transaction will be blocked (and fail if it cannot get connection within specified timeout) (default 20)
       --queryserver-config-transaction-timeout duration                  query server transaction timeout, a transaction will be killed if it takes longer than this value (default 30s)
       --queryserver-config-truncate-error-len int                        truncate errors sent to client if they are longer than this value (0 means do not truncate)
+      --queryserver-config-txpool-max-idle-count int                     query server transaction pool - maximum number of idle connections to retain in the pool. Use this to balance between faster response times during traffic bursts and resource efficiency during low-traffic periods.
       --queryserver-config-txpool-timeout duration                       query server transaction pool timeout, it is how long vttablet waits if tx pool is full (default 1s)
       --queryserver-config-warn-result-size int                          query server result size warning threshold, warn if number of rows returned from vttablet for non-streaming queries exceeds this
       --queryserver-enable-views                                         Enable views support in vttablet.
@@ -327,6 +326,7 @@ vttablet \
       --restore_from_backup_ts string                                    (init restore parameter) if set, restore the latest backup taken at or before this timestamp. Example: '2021-04-29.133050'
       --retain_online_ddl_tables duration                                How long should vttablet keep an old migrated table before purging it (default 24h0m0s)
       --s3_backup_aws_endpoint string                                    endpoint of the S3 backend (region must be provided).
+      --s3_backup_aws_min_partsize int                                   Minimum part size to use, defaults to 5MiB but can be increased due to the dataset size. (default 5242880)
       --s3_backup_aws_region string                                      AWS region to use. (default "us-east-1")
       --s3_backup_aws_retries int                                        AWS request retries. (default -1)
       --s3_backup_force_path_style                                       force the s3 path style.
@@ -339,6 +339,7 @@ vttablet \
       --schema-change-reload-timeout duration                            query server schema change reload timeout, this is how long to wait for the signaled schema reload operation to complete before giving up (default 30s)
       --schema-version-max-age-seconds int                               max age of schema version records to kept in memory by the vreplication historian
       --security_policy string                                           the name of a registered security policy to use for controlling access to URLs - empty means allow all for anyone (built-in policies: deny-all, read-only)
+      --semi-sync-monitor-interval duration                              How frequently the semi-sync monitor checks if the primary is blocked on semi-sync ACKs (default 10s)
       --service_map strings                                              comma separated list of services to enable (or disable if prefixed with '-') Example: grpc-queryservice
       --serving_state_grace_period duration                              how long to pause after broadcasting health to vtgate, before enforcing a new serving state
       --shard_sync_retry_delay duration                                  delay between retries of updates to keep the tablet and its shard record in sync (default 30s)
@@ -391,6 +392,7 @@ vttablet \
       --topo_global_root string                                          the path of the global topology data in the global topology server
       --topo_global_server_address string                                the address of the global topology server
       --topo_implementation string                                       the topology implementation to use
+      --topo_read_concurrency int                                        Maximum concurrency of topo reads per global or local cell. (default 32)
       --topo_zk_auth_file string                                         auth to use when connecting to the zk topo server, file contents should be <scheme>:<auth>, e.g., digest:user:pass
       --topo_zk_base_timeout duration                                    zk base timeout (see zk.Connect) (default 30s)
       --topo_zk_max_concurrency int                                      maximum number of pending requests to send to a Zookeeper server. (default 64)
@@ -410,8 +412,7 @@ vttablet \
       --transaction_limit_by_subcomponent                                Include CallerID.subcomponent when considering who the user is for the purpose of transaction limit.
       --transaction_limit_by_username                                    Include VTGateCallerID.username when considering who the user is for the purpose of transaction limit. (default true)
       --transaction_limit_per_user float                                 Maximum number of transactions a single user is allowed to use at any time, represented as fraction of -transaction_cap. (default 0.4)
-      --twopc_abandon_age float                                          time in seconds. Any unresolved transaction older than this time will be sent to the coordinator to be resolved.
-      --twopc_enable                                                     if the flag is on, 2pc is enabled. Other 2pc flags must be supplied.
+      --twopc_abandon_age time.Duration                                  Any unresolved transaction older than this time will be sent to the coordinator to be resolved. NOTE: Providing time as seconds (float64) is deprecated. Use time.Duration format (e.g., '1s', '2m', '1h'). (default 15m0s)
       --tx-throttler-config string                                       Synonym to -tx_throttler_config (default "target_replication_lag_sec:2 max_replication_lag_sec:10 initial_rate:100 max_increase:1 emergency_decrease:0.5 min_duration_between_increases_sec:40 max_duration_between_increases_sec:62 min_duration_between_decreases_sec:20 spread_backlog_across_sec:20 age_bad_rate_after_sec:180 bad_rate_increase:0.1 max_rate_approach_threshold:0.9")
       --tx-throttler-default-priority int                                Default priority assigned to queries that lack priority information (default 100)
       --tx-throttler-dry-run                                             If present, the transaction throttler only records metrics about requests received and throttled, but does not actually throttle any requests.
@@ -425,11 +426,12 @@ vttablet \
       --v Level                                                          log level for V logs
   -v, --version                                                          print binary version
       --vmodule vModuleFlag                                              comma-separated list of pattern=N settings for file-filtered logging
+      --vreplication-enable-http-log                                     Enable the /debug/vrlog HTTP endpoint, which will produce a log of the events replicated on primary tablets in the target keyspace by all VReplication workflows that are in the running/replicating phase.
       --vreplication-parallel-insert-workers int                         Number of parallel insertion workers to use during copy phase. Set <= 1 to disable parallelism, or > 1 to enable concurrent insertion during copy phase. (default 1)
       --vreplication_copy_phase_duration duration                        Duration for each copy phase loop (before running the next catchup: default 1h) (default 1h0m0s)
       --vreplication_copy_phase_max_innodb_history_list_length int       The maximum InnoDB transaction history that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 1000000)
       --vreplication_copy_phase_max_mysql_replication_lag int            The maximum MySQL replication lag (in seconds) that can exist on a vstreamer (source) before starting another round of copying rows. This helps to limit the impact on the source tablet. (default 43200)
-      --vreplication_experimental_flags int                              (Bitmask) of experimental features in vreplication to enable (default 3)
+      --vreplication_experimental_flags int                              (Bitmask) of experimental features in vreplication to enable (default 7)
       --vreplication_heartbeat_update_interval int                       Frequency (in seconds, default 1, max 60) at which the time_updated column of a vreplication stream when idling (default 1)
       --vreplication_max_time_to_retry_on_error duration                 stop automatically retrying when we've had consecutive failures with the same error for this long after the first occurrence
       --vreplication_net_read_timeout int                                Session value of net_read_timeout for vreplication, in seconds (default 300)

--- a/content/en/docs/22.0/reference/programs/vttestserver/_index.md
+++ b/content/en/docs/22.0/reference/programs/vttestserver/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vttestserver
 series: vttestserver
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttestserver
 
@@ -106,7 +105,7 @@ vttestserver [flags]
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
       --mysql_bind_host string                                           which host to bind vtgate mysql listener to (default "localhost")
       --mysql_only                                                       If this flag is set only mysql is initialized. The rest of the vitess components are not started. Also, the output specifies the mysql unix socket instead of the vtgate port.
-      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.30-Vitess")
+      --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)
       --no_scatter                                                       when set to true, the planner will fail instead of producing a plan that includes scatter queries

--- a/content/en/docs/22.0/reference/programs/vttlstest/_index.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/_index.md
@@ -1,7 +1,6 @@
 ---
 title: vttlstest
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest
 

--- a/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateCA.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateCA.md
@@ -1,7 +1,6 @@
 ---
 title: CreateCA
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest CreateCA
 

--- a/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateCRL.md
@@ -1,7 +1,6 @@
 ---
 title: CreateCRL
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest CreateCRL
 

--- a/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateIntermediateCA.md
@@ -1,7 +1,6 @@
 ---
 title: CreateIntermediateCA
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest CreateIntermediateCA
 

--- a/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_CreateSignedCert.md
@@ -1,7 +1,6 @@
 ---
 title: CreateSignedCert
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest CreateSignedCert
 

--- a/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
+++ b/content/en/docs/22.0/reference/programs/vttlstest/vttlstest_RevokeCert.md
@@ -1,7 +1,6 @@
 ---
 title: RevokeCert
 series: vttlstest
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## vttlstest RevokeCert
 

--- a/content/en/docs/22.0/reference/programs/zk/_index.md
+++ b/content/en/docs/22.0/reference/programs/zk/_index.md
@@ -1,7 +1,6 @@
 ---
 title: zk
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_addAuth.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_addAuth.md
@@ -1,7 +1,6 @@
 ---
 title: addAuth
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk addAuth
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_cat.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_cat.md
@@ -1,7 +1,6 @@
 ---
 title: cat
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk cat
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_chmod.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_chmod.md
@@ -1,7 +1,6 @@
 ---
 title: chmod
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk chmod
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_cp.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_cp.md
@@ -1,7 +1,6 @@
 ---
 title: cp
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk cp
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_edit.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_edit.md
@@ -1,7 +1,6 @@
 ---
 title: edit
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk edit
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_ls.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_ls.md
@@ -1,7 +1,6 @@
 ---
 title: ls
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk ls
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_rm.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_rm.md
@@ -1,7 +1,6 @@
 ---
 title: rm
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk rm
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_stat.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_stat.md
@@ -1,7 +1,6 @@
 ---
 title: stat
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk stat
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_touch.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_touch.md
@@ -1,7 +1,6 @@
 ---
 title: touch
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk touch
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_unzip.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_unzip.md
@@ -1,7 +1,6 @@
 ---
 title: unzip
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk unzip
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_wait.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_wait.md
@@ -1,7 +1,6 @@
 ---
 title: wait
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk wait
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_watch.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_watch.md
@@ -1,7 +1,6 @@
 ---
 title: watch
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk watch
 

--- a/content/en/docs/22.0/reference/programs/zk/zk_zip.md
+++ b/content/en/docs/22.0/reference/programs/zk/zk_zip.md
@@ -1,7 +1,6 @@
 ---
 title: zip
 series: zk
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zk zip
 

--- a/content/en/docs/22.0/reference/programs/zkctl/_index.md
+++ b/content/en/docs/22.0/reference/programs/zkctl/_index.md
@@ -1,7 +1,6 @@
 ---
 title: zkctl
 series: zkctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctl
 

--- a/content/en/docs/22.0/reference/programs/zkctl/zkctl_init.md
+++ b/content/en/docs/22.0/reference/programs/zkctl/zkctl_init.md
@@ -1,7 +1,6 @@
 ---
 title: init
 series: zkctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctl init
 

--- a/content/en/docs/22.0/reference/programs/zkctl/zkctl_shutdown.md
+++ b/content/en/docs/22.0/reference/programs/zkctl/zkctl_shutdown.md
@@ -1,7 +1,6 @@
 ---
 title: shutdown
 series: zkctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctl shutdown
 

--- a/content/en/docs/22.0/reference/programs/zkctl/zkctl_start.md
+++ b/content/en/docs/22.0/reference/programs/zkctl/zkctl_start.md
@@ -1,7 +1,6 @@
 ---
 title: start
 series: zkctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctl start
 

--- a/content/en/docs/22.0/reference/programs/zkctl/zkctl_teardown.md
+++ b/content/en/docs/22.0/reference/programs/zkctl/zkctl_teardown.md
@@ -1,7 +1,6 @@
 ---
 title: teardown
 series: zkctl
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctl teardown
 

--- a/content/en/docs/22.0/reference/programs/zkctld/_index.md
+++ b/content/en/docs/22.0/reference/programs/zkctld/_index.md
@@ -1,7 +1,6 @@
 ---
 title: zkctld
 series: zkctld
-commit: d9ab9f7a1cf3cae19a1ea06963798a7646e8fb27
 ---
 ## zkctld
 


### PR DESCRIPTION
This PR re-generates all of the CLI documentation for `v22`

Taking into account all recent changes to our CLI + the most recent change to vtbackup (https://github.com/vitessio/vitess/pull/17892) that fixes https://github.com/vitessio/website/issues/1953.