### PR TITLE
Remove incorrect doc on using shard targeting to target keyspace

### DIFF
--- a/content/en/docs/20.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/20.0/reference/features/schema-routing-rules.md
@@ -133,25 +133,6 @@ $ vtctldclient --server=localhost:15999 GetRoutingRules
 }
 ```
 
-## When Routing Rules Are Applied
-
-In the above example, we send all query traffic for the `customer` and `corder` tables to the `commerce` keyspace regardless of how
-the client specifies the database/schema and table qualifiers. There is, however, one important exception and that is when the client
-explicitly requests the usage of a specific shard, also known as "shard targeting". For example, if the client specifies the database
-as `customer:0` or `customer:0@replica` then the query will get run against that shard in the customer keyspace.
-
-{{< warning >}}
-You should exercise _extreme_ caution when executing ad-hoc *write* queries during this time as you may think that you're deleting data
-from the target keyspace, that is as of yet unused, when in reality you're deleting it from the source keyspace that is currently
-serving production traffic.
-{{</ warning >}}
-
-{{< info >}}
-You can leverage shard targeting to perform ad-hoc *read-only* queries against the target and source keyspace/shards to perform any
-additional data validation or checks that you want (beyond [`VDiff`](../../vreplication/vdiff/)). You can also use this shard targeting
-to see how your data is distributed across the keyspace's shards.
-{{</ info >}}
-
 ## Additional Details
 
 There are some key details to keep in mind if you will be creating and managing your own custom routing rules.

--- a/content/en/docs/21.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/21.0/reference/features/schema-routing-rules.md
@@ -133,25 +133,6 @@ $ vtctldclient --server=localhost:15999 GetRoutingRules
 }
 ```
 
-## When Routing Rules Are Applied
-
-In the above example, we send all query traffic for the `customer` and `corder` tables to the `commerce` keyspace regardless of how
-the client specifies the database/schema and table qualifiers. There is, however, one important exception and that is when the client
-explicitly requests the usage of a specific shard, also known as "shard targeting". For example, if the client specifies the database
-as `customer:0` or `customer:0@replica` then the query will get run against that shard in the customer keyspace.
-
-{{< warning >}}
-You should exercise _extreme_ caution when executing ad-hoc *write* queries during this time as you may think that you're deleting data
-from the target keyspace, that is as of yet unused, when in reality you're deleting it from the source keyspace that is currently
-serving production traffic.
-{{</ warning >}}
-
-{{< info >}}
-You can leverage shard targeting to perform ad-hoc *read-only* queries against the target and source keyspace/shards to perform any
-additional data validation or checks that you want (beyond [`VDiff`](../../vreplication/vdiff/)). You can also use this shard targeting
-to see how your data is distributed across the keyspace's shards.
-{{</ info >}}
-
 ## Additional Details
 
 There are some key details to keep in mind if you will be creating and managing your own custom routing rules.

--- a/content/en/docs/22.0/reference/features/schema-routing-rules.md
+++ b/content/en/docs/22.0/reference/features/schema-routing-rules.md
@@ -133,25 +133,6 @@ $ vtctldclient --server=localhost:15999 GetRoutingRules
 }
 ```
 
-## When Routing Rules Are Applied
-
-In the above example, we send all query traffic for the `customer` and `corder` tables to the `commerce` keyspace regardless of how
-the client specifies the database/schema and table qualifiers. There is, however, one important exception and that is when the client
-explicitly requests the usage of a specific shard, also known as "shard targeting". For example, if the client specifies the database
-as `customer:0` or `customer:0@replica` then the query will get run against that shard in the customer keyspace.
-
-{{< warning >}}
-You should exercise _extreme_ caution when executing ad-hoc *write* queries during this time as you may think that you're deleting data
-from the target keyspace, that is as of yet unused, when in reality you're deleting it from the source keyspace that is currently
-serving production traffic.
-{{</ warning >}}
-
-{{< info >}}
-You can leverage shard targeting to perform ad-hoc *read-only* queries against the target and source keyspace/shards to perform any
-additional data validation or checks that you want (beyond [`VDiff`](../../vreplication/vdiff/)). You can also use this shard targeting
-to see how your data is distributed across the keyspace's shards.
-{{</ info >}}
-
 ## Additional Details
 
 There are some key details to keep in mind if you will be creating and managing your own custom routing rules.


### PR DESCRIPTION
We were not creating denied tables on the target keyspace initially when a MoveTables workflow was created. It was added in June 2024 via https://github.com/vitessio/vitess/pull/15977. 

The section which this PR removes, was added earlier (in 2023 via https://github.com/vitessio/website/pull/1344). 

That worked because we were (incorrectly) not adding denied tables to the target. It would have only worked for a created but unswitched workflow: if we switch traffic back and forth, we would end up with denied tables on the target and hence not allowing queries to an unswitched keyspace.

This PR removes the incorrect documentation from all versions to which https://github.com/vitessio/website/pull/1344 was merged.

