### PR TITLE
Update setup docs: Add dev.env sourcing step for all OS

### DIFF
--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -91,6 +91,24 @@ export VTDATAROOT=/tmp/vtdataroot
 export PATH=~/vitess/bin:${PATH}
 ```
 
+
+After setting these variables, apply the environment changes:
+
+```
+source ~/.bashrc
+```
+
+Next, set up the development environment:
+
+```
+source dev.env
+```
+
+Notes:
+ * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
+
+
 Build Vitess:
 
 ```

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -105,7 +105,7 @@ source dev.env
 ```
 
 Notes:
- * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * ```dev.env``` sets up important environment variables, directories, and Git pre-commit hooks that automatically run gofmt and linters before commits.
  * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
 
 

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -62,7 +62,7 @@ git clone https://github.com/vitessio/vitess.git
 cd vitess
 ```
 
-Set environment variables that Vitess will require. It is recommended to put these in your `~/.bash_profile` file:
+Set environment variables that Vitess will require. It is recommended to put these in your `~/.zshrc` file:
 
 ```
 # Vitess binaries
@@ -72,7 +72,7 @@ export PATH=~/vitess/bin:${PATH}
 After setting these variables, apply the environment changes:
 
 ```
-source ~/.bash_profile
+source ~/.zshrc
 ```
 
 Next, set up the development environment:

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -69,6 +69,23 @@ Set environment variables that Vitess will require. It is recommended to put the
 export PATH=~/vitess/bin:${PATH}
 ```
 
+After setting these variables, apply the environment changes:
+
+```
+source ~/.bash_profile
+```
+
+Next, set up the development environment:
+
+```
+source dev.env
+```
+
+Notes:
+ * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
+
+
 Build Vitess:
 
 ```shell

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -82,7 +82,7 @@ source dev.env
 ```
 
 Notes:
- * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * ```dev.env``` sets up important environment variables, directories, and Git pre-commit hooks that automatically run gofmt and linters before commits.
  * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
 
 

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -116,7 +116,7 @@ source dev.env
 ```
 
 Notes:
- * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * ```dev.env``` sets up important environment variables, directories, and Git pre-commit hooks that automatically run gofmt and linters before commits.
  * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
 
 

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -103,6 +103,23 @@ export VTDATAROOT=/tmp/vtdataroot
 export PATH=~/vitess/bin:${PATH}
 ```
 
+After setting these variables, apply the environment changes:
+
+```
+source ~/.bashrc
+```
+
+Next, set up the development environment:
+
+```
+source dev.env
+```
+
+Notes:
+ * ```dev.env``` sets up important Git pre-commit hooks that automatically run gofmt and linters on your code before commits.
+ * If you encounter any issues (e.g., the command hangs), try running ```source build.env``` instead.
+
+
 Build Vitess:
 
 ```


### PR DESCRIPTION
Added `source dev.env ` to the setup instructions for Ubuntu/Debian, macOS, and CentOS to ensure proper environment setup.