### PR TITLE
Update cobradocs before v22.0.0-RC1

### DIFF
--- a/content/en/docs/22.0/reference/programs/vtcombo/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtcombo/_index.md
@@ -239,7 +239,7 @@ vtcombo [flags]
       --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
-      --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
+      --mysql-shutdown-timeout duration                                  Timeout to use when MySQL is being shut down. (default 5m0s)
       --mysql_allow_clear_text_without_tls                               If set, the server will allow the use of a clear text password over non-SSL connections.
       --mysql_auth_server_impl string                                    Which auth server implementation to use. Options: none, ldap, clientcert, static, vault. (default "static")
       --mysql_default_workload string                                    Default session workload (OLTP, OLAP, DBA) (default "OLTP")

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Backup.md
@@ -13,12 +13,13 @@ vtctldclient Backup [--concurrency <concurrency>] [--allow-primary] [--increment
 ### Options
 
 ```
-      --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --backup-engine string          Request a specific backup engine for this backup request. Defaults to the preferred backup engine of the target vttablet
-      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
-  -h, --help                          help for Backup
-      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
-      --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
+      --allow-primary                     Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
+      --backup-engine string              Request a specific backup engine for this backup request. Defaults to the preferred backup engine of the target vttablet
+      --concurrency int32                 Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+  -h, --help                              help for Backup
+      --incremental-from-pos string       Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
+      --mysql-shutdown-timeout duration   Timeout to use when MySQL is being shut down. (default 5m0s)
+      --upgrade-safe                      Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_BackupShard.md
@@ -19,11 +19,12 @@ vtctldclient BackupShard [--concurrency <concurrency>] [--allow-primary] [--incr
 ### Options
 
 ```
-      --allow-primary                 Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
-      --concurrency int32             Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
-  -h, --help                          help for BackupShard
-      --incremental-from-pos string   Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
-      --upgrade-safe                  Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
+      --allow-primary                     Allow the primary of a shard to be used for the backup. WARNING: If using the builtin backup engine, this will shutdown mysqld on the primary and stop writes for the duration of the backup.
+      --concurrency int32                 Specifies the number of compression/checksum jobs to run simultaneously. (default 4)
+  -h, --help                              help for BackupShard
+      --incremental-from-pos string       Position, or name of backup from which to create an incremental backup. Default: empty. If given, then this backup becomes an incremental backup from given position or given backup. If value is 'auto', this backup will be taken from the last successful backup position.
+      --mysql-shutdown-timeout duration   Timeout to use when MySQL is being shut down. (default 5m0s)
+      --upgrade-safe                      Whether to use innodb_fast_shutdown=0 for the backup so it is safe to use for MySQL upgrades.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Migrate/vtctldclient_Migrate_create.md
@@ -24,7 +24,7 @@ vtctldclient --server localhost:15999 migrate --workflow import --target-keyspac
       --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --config-overrides strings           Specify one or more VReplication config flags to override as a comma-separated list of key=value pairs.
-      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied. (default true)
       --exclude-tables strings             Source tables to exclude from copying.
   -h, --help                               help for create
       --mount-name string                  Name external cluster is mounted as.

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_MoveTables/vtctldclient_MoveTables_create.md
@@ -25,7 +25,7 @@ vtctldclient --server localhost:15999 movetables --workflow commerce2customer --
       --auto-start                               Start the workflow after creating it. (default true)
   -c, --cells strings                            Cells and/or CellAliases to copy table data from.
       --config-overrides strings                 Specify one or more VReplication config flags to override as a comma-separated list of key=value pairs.
-      --defer-secondary-keys                     Defer secondary index creation for a table until after it has been copied.
+      --defer-secondary-keys                     Defer secondary index creation for a table until after it has been copied. (default true)
       --exclude-tables strings                   Source tables to exclude from copying.
       --global-keyspace string                   If specified, then attempt to create any global resources here such as sequence tables needed to replace auto_increment table clauses that are removed due to --sharded-auto-increment-handling=REPLACE. The value must be an unsharded keyspace that already exists.
   -h, --help                                     help for create

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_OnlineDDL/_index.md
@@ -9,7 +9,8 @@ Operates on online DDL (schema migrations).
 ### Options
 
 ```
-  -h, --help   help for OnlineDDL
+      --caller-id string   Effective caller ID used for the operation and should map to an ACL name which grants this identity the necessary permissions to perform the operation (this is only necessary when strict table ACLs are used).
+  -h, --help               help for OnlineDDL
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_cancel.md
@@ -19,7 +19,8 @@ vtctldclient --server localhost:15999 Reshard --workflow cust2cust --target-keys
 ### Options
 
 ```
-  -h, --help   help for cancel
+  -h, --help        help for cancel
+      --keep-data   Keep the partially copied table data from the Reshard workflow in the target shards.
 ```
 
 ### Options inherited from parent commands

--- a/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
+++ b/content/en/docs/22.0/reference/programs/vtctldclient/vtctldclient_Reshard/vtctldclient_Reshard_create.md
@@ -23,7 +23,7 @@ vtctldclient --server localhost:15999 reshard --workflow customer2customer --tar
       --auto-start                         Start the workflow after creating it. (default true)
   -c, --cells strings                      Cells and/or CellAliases to copy table data from.
       --config-overrides strings           Specify one or more VReplication config flags to override as a comma-separated list of key=value pairs.
-      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied.
+      --defer-secondary-keys               Defer secondary index creation for a table until after it has been copied. (default true)
   -h, --help                               help for create
       --on-ddl string                      What to do when DDL is encountered in the VReplication stream. Possible values are IGNORE, STOP, EXEC, and EXEC_IGNORE. (default "IGNORE")
       --skip-schema-copy                   Skip copying the schema from the source shards to the target shards.

--- a/content/en/docs/22.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/22.0/reference/programs/vttablet/_index.md
@@ -263,7 +263,7 @@ vttablet \
       --mysql-shell-load-flags string                                    flags to pass to mysql shell load utility. This should be a JSON string (default "{\"threads\": 4, \"loadUsers\": true, \"updateGtidSet\": \"replace\", \"skipBinlog\": true, \"progressFile\": \"\"}")
       --mysql-shell-should-drain                                         decide if we should drain while taking a backup or continue to serving traffic
       --mysql-shell-speedup-restore                                      speed up restore by disabling redo logging and double write buffer during the restore process
-      --mysql-shutdown-timeout duration                                  timeout to use when MySQL is being shut down. (default 5m0s)
+      --mysql-shutdown-timeout duration                                  Timeout to use when MySQL is being shut down. (default 5m0s)
       --mysql_server_version string                                      MySQL server version to advertise. (default "8.0.40-Vitess")
       --mysqlctl_mycnf_template string                                   template file to use for generating the my.cnf file during server init
       --mysqlctl_socket string                                           socket file to use for remote mysqlctl actions (empty for local actions)


### PR DESCRIPTION
This PR updates the codebradocs for `release-22.0:22.0` ahead of the v22.0 RC-1 release.

Part of https://github.com/vitessio/vitess/issues/18023 and https://github.com/vitessio/vitess/issues/17898.