### PR TITLE
Fix docs for `unmanaged` and `queryserver-config-max-result-size` flags

### DIFF
--- a/content/en/docs/20.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/20.0/reference/programs/vttablet/_index.md
@@ -13,8 +13,6 @@ The VTTablet server _controls_ a running MySQL server. VTTablet supports two pri
 * Managed MySQL (most common)
 * External MySQL
 
-In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
-
 ### Managed MySQL
 
 In this mode, Vitess actively manages MySQL.

--- a/content/en/docs/20.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/20.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,7 +79,7 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --disable_active_reparents &
+ --unmanaged &
 ```
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).

--- a/content/en/docs/20.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/20.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -142,7 +142,7 @@ There are some additional parameters that we recommend setting:
 * `queryserver-config-query-timeout`: This value should be set to the upper limit you’re willing to allow an OLTP query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * `queryserver-config-transaction-timeout`: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
 * `queryserver-config-idle-timeout`:  This value sets a time in seconds after which, if a connection has not been used, this connection will be removed from pool. This effectively manages number of connection objects and optimizes the pool performance.
-* `queryserver-config-max-result-size`: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* `queryserver-config-max-result-size`: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 Here is a typical vttablet invocation:
 

--- a/content/en/docs/21.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/21.0/reference/programs/vttablet/_index.md
@@ -13,8 +13,6 @@ The VTTablet server _controls_ a running MySQL server. VTTablet supports two pri
 * Managed MySQL (most common)
 * External MySQL
 
-In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
-
 ### Managed MySQL
 
 In this mode, Vitess actively manages MySQL.

--- a/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/21.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,7 +79,7 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --disable_active_reparents &
+ --unmanaged &
 ```
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).

--- a/content/en/docs/21.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -142,7 +142,7 @@ There are some additional parameters that we recommend setting:
 * `queryserver-config-query-timeout`: This value should be set to the upper limit you’re willing to allow an OLTP query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * `queryserver-config-transaction-timeout`: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
 * `queryserver-config-idle-timeout`:  This value sets a time in seconds after which, if a connection has not been used, this connection will be removed from pool. This effectively manages number of connection objects and optimizes the pool performance.
-* `queryserver-config-max-result-size`: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* `queryserver-config-max-result-size`: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 Here is a typical vttablet invocation:
 

--- a/content/en/docs/22.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/22.0/reference/programs/vttablet/_index.md
@@ -13,8 +13,6 @@ The VTTablet server _controls_ a running MySQL server. VTTablet supports two pri
 * Managed MySQL (most common)
 * External MySQL
 
-In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
-
 ### Managed MySQL
 
 In this mode, Vitess actively manages MySQL.

--- a/content/en/docs/22.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/22.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,7 +79,7 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --disable_active_reparents &
+ --unmanaged &
 ```
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).

--- a/content/en/docs/22.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/22.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -142,7 +142,7 @@ There are some additional parameters that we recommend setting:
 * `queryserver-config-query-timeout`: This value should be set to the upper limit you’re willing to allow an OLTP query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * `queryserver-config-transaction-timeout`: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
 * `queryserver-config-idle-timeout`:  This value sets a time in seconds after which, if a connection has not been used, this connection will be removed from pool. This effectively manages number of connection objects and optimizes the pool performance.
-* `queryserver-config-max-result-size`: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* `queryserver-config-max-result-size`: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 Here is a typical vttablet invocation:
 

--- a/content/en/docs/23.0/reference/programs/vttablet/_index.md
+++ b/content/en/docs/23.0/reference/programs/vttablet/_index.md
@@ -13,8 +13,6 @@ The VTTablet server _controls_ a running MySQL server. VTTablet supports two pri
 * Managed MySQL (most common)
 * External MySQL
 
-In addition to these deployment types, a partially managed VTTablet is also possible by setting `--disable_active_reparents`.
-
 ### Managed MySQL
 
 In this mode, Vitess actively manages MySQL.

--- a/content/en/docs/23.0/user-guides/configuration-advanced/unmanaged-tablet.md
+++ b/content/en/docs/23.0/user-guides/configuration-advanced/unmanaged-tablet.md
@@ -79,7 +79,7 @@ vttablet \
  --db_allprivs_user msandbox \
  --db_allprivs_password msandbox \
  --init_db_name_override legacy \
- --disable_active_reparents &
+ --unmanaged &
 ```
 
 You should be able to see debug information written to screen confirming Vitess can reach the unmanaged server. A common problem is that you may need to change the authentication plugin to `mysql_native_password` (MySQL 8.0).

--- a/content/en/docs/23.0/user-guides/configuration-basic/vttablet-mysql.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/vttablet-mysql.md
@@ -142,7 +142,7 @@ There are some additional parameters that we recommend setting:
 * `queryserver-config-query-timeout`: This value should be set to the upper limit you’re willing to allow an OLTP query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * `queryserver-config-transaction-timeout`: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
 * `queryserver-config-idle-timeout`:  This value sets a time in seconds after which, if a connection has not been used, this connection will be removed from pool. This effectively manages number of connection objects and optimizes the pool performance.
-* `queryserver-config-max-result-size`: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* `queryserver-config-max-result-size`: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 Here is a typical vttablet invocation:
 

--- a/content/zh/docs/20.0/launching/server-configuration.md
+++ b/content/zh/docs/20.0/launching/server-configuration.md
@@ -159,7 +159,7 @@ It is possible to host different parts of a MySQL server files on different part
 * **queryserver-config-transaction-cap**: This value should be set to how many concurrent transactions you wish to allow. This should be a function of transaction QPS and transaction length. Typical values are in the low 100s.
 * **queryserver-config-query-timeout**: This value should be set to the upper limit you’re willing to allow a query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * **queryserver-config-transaction-timeout**: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
-* **queryserver-config-max-result-size**: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* **queryserver-config-max-result-size**: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 ### DB config parameters
 

--- a/content/zh/docs/21.0/launching/server-configuration.md
+++ b/content/zh/docs/21.0/launching/server-configuration.md
@@ -159,7 +159,7 @@ It is possible to host different parts of a MySQL server files on different part
 * **queryserver-config-transaction-cap**: This value should be set to how many concurrent transactions you wish to allow. This should be a function of transaction QPS and transaction length. Typical values are in the low 100s.
 * **queryserver-config-query-timeout**: This value should be set to the upper limit you’re willing to allow a query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * **queryserver-config-transaction-timeout**: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
-* **queryserver-config-max-result-size**: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* **queryserver-config-max-result-size**: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 ### DB config parameters
 

--- a/content/zh/docs/22.0/launching/server-configuration.md
+++ b/content/zh/docs/22.0/launching/server-configuration.md
@@ -159,7 +159,7 @@ It is possible to host different parts of a MySQL server files on different part
 * **queryserver-config-transaction-cap**: This value should be set to how many concurrent transactions you wish to allow. This should be a function of transaction QPS and transaction length. Typical values are in the low 100s.
 * **queryserver-config-query-timeout**: This value should be set to the upper limit you’re willing to allow a query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * **queryserver-config-transaction-timeout**: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
-* **queryserver-config-max-result-size**: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* **queryserver-config-max-result-size**: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 ### DB config parameters
 

--- a/content/zh/docs/23.0/launching/server-configuration.md
+++ b/content/zh/docs/23.0/launching/server-configuration.md
@@ -159,7 +159,7 @@ It is possible to host different parts of a MySQL server files on different part
 * **queryserver-config-transaction-cap**: This value should be set to how many concurrent transactions you wish to allow. This should be a function of transaction QPS and transaction length. Typical values are in the low 100s.
 * **queryserver-config-query-timeout**: This value should be set to the upper limit you’re willing to allow a query to run before it’s deemed too expensive or detrimental to the rest of the system. VTTablet will kill any query that exceeds this timeout. This value is usually around 15-30s.
 * **queryserver-config-transaction-timeout**: This value is meant to protect the situation where a client has crashed without completing a transaction. Typical value for this timeout is 30s.
-* **queryserver-config-max-result-size**: This parameter prevents the OLTP application from accidentally requesting too many rows. If the result exceeds the specified number of rows, VTTablet returns an error. The default value is 10,000.
+* **queryserver-config-max-result-size**: This parameter acts as a safeguard, ensuring the OLTP application doesn’t unintentionally query or modify an excessive number of rows. If a query returns more rows than the defined limit, or if a DML operation targets more rows than permitted, VTTablet will generate an error. The default limit is 10,000 rows.
 
 ### DB config parameters
 


### PR DESCRIPTION
### Description

This PR has a couple of fixes - 
1. `--unmanaged` flag: When we deprecated `--disable_active_reparents` and replaced it with `--unmanaged` flag, we made the docs changes, but didn't fix the provided example and another file. This PR fixes that.
2. `--queryserver-config-max-result-size` flag: The flag affects DMLs and the rows affected too, but the documentation was unclear regarding that.