### PR TITLE
Delete 404ing Grafana Dashboards Page Since The Dashboard Source Does Not Exist Anymore

### DIFF
--- a/content/en/docs/faq/advanced-configuration/metrics/what-grafana-dashboards-are-available.md
+++ b/content/en/docs/faq/advanced-configuration/metrics/what-grafana-dashboards-are-available.md
@@ -5,4 +5,4 @@ notoc: true
 weight: 1
 ---
 
-There are a set of [Grafana dashboards and Prometheus alerts](https://github.com/vitessio/vitess/tree/main/vitess-mixin) available on the Vitess tree in GitHub. For more context on these dashboards please refer to the [original pull request](https://github.com/vitessio/vitess/pull/5609).
+A set of Grafana Dashboards used to exist as part of the `vitess-mixin` which [was removed in this pull request](https://github.com/vitessio/vitess/pull/16657). For more context on these dashboards please refer to the [original pull request](https://github.com/vitessio/vitess/pull/5609) if you would still like to use them.


### PR DESCRIPTION
Hi, I don't see a contributing doc for this website but noticed this page was out of date and no longer functioning, apologies for any noise if you're not accepting contributions - here's a PR to delete the out-of-date doc.

This page links to the `vitess-mixin` which no longer exists: https://github.com/vitessio/vitess/tree/main/vitess-mixin. It was deleted last year as part of https://github.com/vitessio/vitess/pull/16657

A publicly available Grafana dashboard does not appear to exist in Vitess or the Website project so instead of linking to something new, this links to the deleted original dashboards instead to fix the deadlink that currently exists. I have also checked [`vitess/contrib`](https://github.com/vitessio/contrib) and do not see any dashboards there either that might be a good target for this page.

I don't know if there is additional process required here for contributing to these docs - lmk if I've missed something.