### PR TITLE
Change invite link

### DIFF
--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -48,7 +48,7 @@
 /blog/rss                                /blog/index.xml 301
 
 # Redirect to Slack invite link.
-/slack https://join.slack.com/t/vitess/shared_invite/zt-2x79jeadd-zLYBssoc~phT956nowO77g 302
+/slack https://join.slack.com/t/vitess/shared_invite/zt-39md39eck-L4jzfgRC6hzsPKxungoUNQ 302
 
 # Redirect archived docs
 /docs/19.0/                              /docs/archive/19.0/


### PR DESCRIPTION
The previous Slack invite link was owned by Deepthi and she would get messages by those who join Vitess using this link. 

I deactivated all invite links and have added a new one which doesn't expire.

An admin can deactivate or a add a new invite link at https://vitess.slack.com/admin/invites