### PR TITLE
Issue-1970 - docs: remove topo_flags notification from Global TopoServer

### DIFF
--- a/content/en/docs/20.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/20.0/user-guides/configuration-basic/global-topo.md
@@ -28,8 +28,6 @@ The following command line options are required for every Vitess component:
 --topo_implementation=etcd2 --topo_global_server_address=<comma_separated_addresses> --topo_global_root=/vitess/global
 ```
 
-To avoid repetition we will use `<topo_flags>` in our examples to signify the above flags.
-
 Note that the topo implementation for etcd is `etcd2`. This is because Vitess uses the v2 API of etcd.
 
 {{< info >}}

--- a/content/en/docs/21.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/21.0/user-guides/configuration-basic/global-topo.md
@@ -28,8 +28,6 @@ The following command line options are required for every Vitess component:
 --topo_implementation=etcd2 --topo_global_server_address=<comma_separated_addresses> --topo_global_root=/vitess/global
 ```
 
-To avoid repetition we will use `<topo_flags>` in our examples to signify the above flags.
-
 Note that the topo implementation for etcd is `etcd2`. This is because Vitess uses the v2 API of etcd.
 
 {{< info >}}

--- a/content/en/docs/22.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/22.0/user-guides/configuration-basic/global-topo.md
@@ -28,8 +28,6 @@ The following command line options are required for every Vitess component:
 --topo_implementation=etcd2 --topo_global_server_address=<comma_separated_addresses> --topo_global_root=/vitess/global
 ```
 
-To avoid repetition we will use `<topo_flags>` in our examples to signify the above flags.
-
 Note that the topo implementation for etcd is `etcd2`. This is because Vitess uses the v2 API of etcd.
 
 {{< info >}}

--- a/content/en/docs/23.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/global-topo.md
@@ -28,8 +28,6 @@ The following command line options are required for every Vitess component:
 --topo_implementation=etcd2 --topo_global_server_address=<comma_separated_addresses> --topo_global_root=/vitess/global
 ```
 
-To avoid repetition we will use `<topo_flags>` in our examples to signify the above flags.
-
 Note that the topo implementation for etcd is `etcd2`. This is because Vitess uses the v2 API of etcd.
 
 {{< info >}}


### PR DESCRIPTION
## Summary Copilot:

This pull request makes a small documentation update to the global topology configuration guides for Vitess across multiple versions. The change removes a note about using the `<topo_flags>` placeholder in example commands.

* Removed the statement "To avoid repetition we will use `<topo_flags>` in our examples to signify the above flags." from the global topology configuration documentation for versions 20.0, 21.0, 22.0, and 23.0.


## References:
- #1970 
- #1955 

---

✅ Closes #1970 