### PR TITLE
macOS: Update java install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tags
 
 # vscode files
 .vscode/
+
+# For mac users
+.DS_Store

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -103,8 +103,7 @@ NOVTADMINBUILD=1 make build
 The unit tests require that you first install a Java runtime. This is required for running ZooKeeper tests:
 
 ```shell
-brew tap adoptopenjdk/openjdk
-brew install adoptopenjdk8
+brew install java
 brew info java
 ```
 


### PR DESCRIPTION
OpenJDK 8 is *very* old now and you won't be able to build the Java client / gRPC driver.

The homebrew core java formula currently installs OpenJDK 25.0:
```
❯ brew info java
==> openjdk: stable 25.0.1 (bottled) [keg-only]
Development kit for the Java programming language
https://openjdk.org/
Installed
/opt/homebrew/Cellar/openjdk/25.0.1 (557 files, 371.7MB)
  Poured from bottle using the formulae.brew.sh API on 2025-10-30 at 11:04:25
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/o/openjdk.rb
License: GPL-2.0-only WITH Classpath-exception-2.0
```