### PR TITLE
Fix date on Vitess 23 announcement blog

### DIFF
--- a/content/en/blog/2025-11-04-announcing-vitess-23.md
+++ b/content/en/blog/2025-11-04-announcing-vitess-23.md
@@ -1,6 +1,6 @@
 ---
 title: "Announcing Vitess 23.0.0"
-date: 2025-11-03  
+date: 2025-11-04
 authors: [“Vitess Maintainer Team”]
 slug: '2025-11-04-announcing-vitess-23'
 tags: [ 'release', 'Vitess', 'v23', 'MySQL', 'kubernetes', 'operator', 'vreplication', 'multi-tenancy', 'Usability', 'Online DDL' ]


### PR DESCRIPTION
The slug had the correct date, but the `date` metadata was off-by-one, showing the incorrect date on the website:

<img width="1350" height="1010" alt="CleanShot 2025-11-04 at 08 19 07@2x" src="https://github.com/user-attachments/assets/43240552-22aa-4826-8de9-d7bea45e3b01" />
