### PR TITLE
Fix broken vtctl client links to point to relevant vtctldclient pages

### DIFF
--- a/content/en/docs/22.0/reference/features/sharding.md
+++ b/content/en/docs/22.0/reference/features/sharding.md
@@ -94,6 +94,6 @@ Cool a hot tablet | For read access, add replicas or split shards. For write acc
 
 Vitess provides the following tools to help manage range-based shards:
 
-* The [vtctl GenerateShardRanges](../../../reference/programs/vtctl/shards/#generateshardranges) command-line tool supports generating shard ranges based on the provided number of shards.
-* There are additional [Shard specific vtctl](../../../reference/programs/vtctl/shards) command-line tools. 
+* The [vtctldclient GenerateShardRanges](../../../reference/programs/vtctldclient/vtctldclient_generateshardranges/) command-line tool supports generating shard ranges based on the provided number of shards.
+* There are additional [Shard specific vtctldclient](../../../reference/programs/vtctlclient/) command-line tools. 
 * Client APIs account for sharding operations.

--- a/content/en/docs/23.0/reference/features/sharding.md
+++ b/content/en/docs/23.0/reference/features/sharding.md
@@ -94,6 +94,6 @@ Cool a hot tablet | For read access, add replicas or split shards. For write acc
 
 Vitess provides the following tools to help manage range-based shards:
 
-* The [vtctl GenerateShardRanges](../../../reference/programs/vtctl/shards/#generateshardranges) command-line tool supports generating shard ranges based on the provided number of shards.
-* There are additional [Shard specific vtctl](../../../reference/programs/vtctl/shards) command-line tools. 
+* The [vtctldclient GenerateShardRanges](../../../reference/programs/vtctldclient/vtctldclient_generateshardranges/) command-line tool supports generating shard ranges based on the provided number of shards.
+* There are additional [Shard specific vtctldclient](../../../reference/programs/vtctlclient/) command-line tools.
 * Client APIs account for sharding operations.

--- a/content/en/docs/24.0/reference/features/sharding.md
+++ b/content/en/docs/24.0/reference/features/sharding.md
@@ -94,6 +94,6 @@ Cool a hot tablet | For read access, add replicas or split shards. For write acc
 
 Vitess provides the following tools to help manage range-based shards:
 
-* The [vtctl GenerateShardRanges](../../../reference/programs/vtctl/shards/#generateshardranges) command-line tool supports generating shard ranges based on the provided number of shards.
-* There are additional [Shard specific vtctl](../../../reference/programs/vtctl/shards) command-line tools. 
+* The [vtctldclient GenerateShardRanges](../../../reference/programs/vtctldclient/vtctldclient_generateshardranges/) command-line tool supports generating shard ranges based on the provided number of shards.
+* There are additional [Shard specific vtctldclient](../../../reference/programs/vtctlclient/) command-line tools.
 * Client APIs account for sharding operations.


### PR DESCRIPTION
There are some broken links that point to the removed docs about the deprecated `vtctl` client on the "sharding" features page.

This PR re-points these links to the corresponding `vtctldclient` docs pages instead.