### PR TITLE
Xtrabackup configuration instructions

### DIFF
--- a/content/en/docs/23.0/get-started/operator.md
+++ b/content/en/docs/23.0/get-started/operator.md
@@ -69,7 +69,7 @@ In this directory, you will see a group of yaml files. The first digit of each f
 kubectl apply -f 101_initial_cluster.yaml
 ```
 
-{{<info>}} If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc.{{<info>}}
+{{<info>}} If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc. {{</info>}}
 
 for example
 ```yaml
@@ -78,7 +78,7 @@ for example
     locations:
       - volume:
           persistentVolumeClaim:
-            claimName: vitess-backup-pvc
+            claimName: vitess-backup-pvc # required ReadWriteMany
 ```
 
 ### Verify cluster

--- a/content/en/docs/23.0/get-started/operator.md
+++ b/content/en/docs/23.0/get-started/operator.md
@@ -68,6 +68,17 @@ In this directory, you will see a group of yaml files. The first digit of each f
 ```bash
 kubectl apply -f 101_initial_cluster.yaml
 ```
+{{}}If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc.{{}}
+
+for example
+```yaml
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          persistentVolumeClaim:
+            claimName: vitess-backup-pvc
+```
 
 ### Verify cluster
 

--- a/content/en/docs/23.0/get-started/operator.md
+++ b/content/en/docs/23.0/get-started/operator.md
@@ -69,9 +69,9 @@ In this directory, you will see a group of yaml files. The first digit of each f
 kubectl apply -f 101_initial_cluster.yaml
 ```
 
-{{<info>}} If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc. {{</info>}}
+{{< info >}}
+If you are not a running the examples in a minikube cluster, and the backup engine is xtrabackup, then you will need to configure a proper shared storage resource that can be used across pods, or you will need to create a custom PVC to be used by the backdup engine. For example:
 
-for example
 ```yaml
   backup:
     engine: xtrabackup
@@ -80,6 +80,8 @@ for example
           persistentVolumeClaim:
             claimName: vitess-backup-pvc # required ReadWriteMany
 ```
+
+{{</ info >}}
 
 ### Verify cluster
 

--- a/content/en/docs/23.0/get-started/operator.md
+++ b/content/en/docs/23.0/get-started/operator.md
@@ -68,7 +68,8 @@ In this directory, you will see a group of yaml files. The first digit of each f
 ```bash
 kubectl apply -f 101_initial_cluster.yaml
 ```
-{{}}If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc.{{}}
+
+{{<info>}} If it's not a minikube cluster, and the backup engine is xtrabackup, please configure the locations to file, gcs, s3, ceph, etc., or customize pvc.{{<info>}}
 
 for example
 ```yaml

--- a/content/en/docs/24.0/get-started/operator.md
+++ b/content/en/docs/24.0/get-started/operator.md
@@ -69,6 +69,20 @@ In this directory, you will see a group of yaml files. The first digit of each f
 kubectl apply -f 101_initial_cluster.yaml
 ```
 
+{{< info >}}
+If you are not a running the examples in a minikube cluster, and the backup engine is xtrabackup, then you will need to configure a proper shared storage resource that can be used across pods, or you will need to create a custom PVC to be used by the backdup engine. For example:
+
+```yaml
+  backup:
+    engine: xtrabackup
+    locations:
+      - volume:
+          persistentVolumeClaim:
+            claimName: vitess-backup-pvc # required ReadWriteMany
+```
+
+{{</ info >}}
+
 ### Verify cluster
 
 You can check the state of your cluster with `kubectl get pods -n example`. After a few minutes, it should show that all pods are in the status of running:


### PR DESCRIPTION
XtraBackup doesn't support hostPath when not a minikube cluster.Because shared storage is required, hostpath cannot share storage when deployed across multiple nodes.