### PR TITLE
Add Titles to Embedded YouTube iframes for Accessibility

### DIFF
--- a/layouts/partials/home/video.html
+++ b/layouts/partials/home/video.html
@@ -10,6 +10,7 @@
           src="https://www.youtube.com/embed/E6H4bgJ3Z6c?rel=0"
           allowfullscreen=""
           style="position: relative; height: 315px; width: 660px;"
+          title="{{ T "intro_vitess" }}"
           frameborder="0"
         ></iframe>
       </div>
@@ -22,6 +23,7 @@
           src="https://www.youtube.com/embed/HgSlmzC7O-E?si=E75Ot4V-pZYSN6Wy"
           allowfullscreen=""
           style="position: relative; height: 315px; width: 660px;"
+          title="{{ T "scaling_vitess" }}"
           frameborder="0"
         ></iframe>
       </div>

--- a/layouts/partials/social-buttons.html
+++ b/layouts/partials/social-buttons.html
@@ -4,9 +4,9 @@
 {{ $slack   := $social.slack }}
 {{ $stack   := printf "https://stackoverflow.com/search?q=%s" $social.stackoverflow }}
 <div class="buttons">
-  <a class="button is-white" href="{{ $github }}" target="_blank">
+  <a class="button is-white" href="{{ $github }}" target="_blank" aria-label="GitHub">
     <span class="icon">
-      <i class="fab fa-lg fa-github"></i>
+      <i class="fab fa-lg fa-github" aria-hidden="true"></i>
     </span>
     {{ if .footer }}
     <span class="has-text-weight-bold">
@@ -15,9 +15,9 @@
     {{ end }}
   </a>
 
-  <a class="button is-twitter-white" href="{{ $twitter }}" target="_blank">
+  <a class="button is-twitter-white" href="{{ $twitter }}" target="_blank" aria-label="Twitter">
     <span class="icon">
-       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512 " style="height: 1.25em; width: auto;">
+       <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512 " style="height: 1.25em; width: auto;" aria-hidden="true">
         <path d="M389.2 48h70.6L305.6 224.2 487 464H345L233.7 318.6 106.5 464H35.8L200.7 275.5 26.8 48H172.4L272.9 180.9 389.2 48zM364.4 421.8h39.1L151.1 88h-42L364.4 421.8z"/>
       </svg>
     </span>
@@ -28,9 +28,9 @@
     {{ end }}
   </a>
 
-  <a class="button is-slack-green" href="{{ $slack }}" target="_blank">
+  <a class="button is-slack-green" href="{{ $slack }}" target="_blank" aria-label="Slack">
     <span class="icon">
-      <i class="fab fa-lg fa-slack"></i>
+      <i class="fab fa-lg fa-slack" aria-hidden="true"></i>
     </span>
     {{ if .footer }}
     <span class="has-text-weight-bold">
@@ -39,9 +39,9 @@
     {{ end }}
   </a>
 
-  <a class="button is-stack-overflow-orange" href="{{ $stack }}" target="_blank">
+  <a class="button is-stack-overflow-orange" href="{{ $stack }}" target="_blank" aria-label="Stack Overflow">
     <span class="icon">
-      <i class="fab fa-lg fa-stack-overflow"></i>
+      <i class="fab fa-lg fa-stack-overflow" aria-hidden="true"></i>
     </span>
     {{ if .footer }}
     <span class="has-text-weight-bold">


### PR DESCRIPTION
## Description
This PR addresses 2 accessibility violations related to embedded YouTube iframes that lack title attributes. The iframes are missing accessible names, which prevents screen reader users from understanding the purpose of the embedded videos.

## Issues Details
<img width="2560" height="920" alt="image" src="https://github.com/user-attachments/assets/9b4deed7-e47b-4594-af73-8a7071828eb0" />

**Violation Type**: Inline Frames Missing Title Attributes
**Affected Users**: Screen reader users, visually impaired users
**Problems Identified**:
- 2 embedded YouTube iframes lack title attributes
- Screen readers cannot announce the purpose or content of the videos
- Users relying on assistive technology have no way to understand what video will be embedded


## Changes Made
**Modified File**: `layouts/partials/home/video.html`

**Key Improvements**:

1) **Added title attribute to first iframe (Introduction to Vitess video)**
  title="{{ T "intro_vitess" }}"
  Uses i18n translation key for multi-language support
  Provides accessible name: "An introduction to Vitess"

2) **Added title attribute to second iframe (Scaling Databases with Vitess video)**
  title="{{ T "scaling_vitess" }}"
  Uses i18n translation key for multi-language support
  Provides accessible name: "Scaling Databases with Vitess"

## Screenshot

**Fix Before**
<img width="1815" height="583" alt="image" src="https://github.com/user-attachments/assets/7968de1b-a3c4-48e8-8eb5-2387e4f78525" />

**Fix After**
<img width="1846" height="546" alt="image" src="https://github.com/user-attachments/assets/2faab549-84c9-4efd-bc92-005cac060c53" />

