### PR TITLE
fix: update teardown script reference from 401 to 501 for v22+

### DIFF
--- a/content/en/docs/22.0/get-started/local-mac.md
+++ b/content/en/docs/22.0/get-started/local-mac.md
@@ -296,10 +296,10 @@ The schema has been simplified to include only those fields that are significant
 
 You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 
-Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
+Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 501_teardown script:
 
 ```sh
-$ ./401_teardown.sh
+$ ./501_teardown.sh
 $ rm -rf ./vtdataroot
 ```
 

--- a/content/en/docs/22.0/get-started/local.md
+++ b/content/en/docs/22.0/get-started/local.md
@@ -339,6 +339,6 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, if you would like to teardown your example:
 
 ```bash
-./401_teardown.sh
+./501_teardown.sh
 rm -rf vtdataroot
 ```

--- a/content/en/docs/22.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/22.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -463,7 +463,7 @@ rebuild:
 Terminal 1:
     Hit "Ctrl + C" to kill the vtgate process
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get install mysql-client-core-8.0=8.0.19-0ubuntu5 mysql-server-core-8.0=8.0.19-0ubuntu5
@@ -564,7 +564,7 @@ then rebuild the vitess cluster:
 Terminal 1:
     Ctrl + C
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get upgrade && sudo apt-get update

--- a/content/en/docs/23.0/get-started/local-mac.md
+++ b/content/en/docs/23.0/get-started/local-mac.md
@@ -296,10 +296,10 @@ The schema has been simplified to include only those fields that are significant
 
 You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 
-Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
+Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 501_teardown script:
 
 ```sh
-$ ./401_teardown.sh
+$ ./501_teardown.sh
 $ rm -rf ./vtdataroot
 ```
 

--- a/content/en/docs/23.0/get-started/local.md
+++ b/content/en/docs/23.0/get-started/local.md
@@ -339,6 +339,6 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, if you would like to teardown your example:
 
 ```bash
-./401_teardown.sh
+./501_teardown.sh
 rm -rf vtdataroot
 ```

--- a/content/en/docs/23.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/23.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -463,7 +463,7 @@ rebuild:
 Terminal 1:
     Hit "Ctrl + C" to kill the vtgate process
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get install mysql-client-core-8.0=8.0.19-0ubuntu5 mysql-server-core-8.0=8.0.19-0ubuntu5
@@ -564,7 +564,7 @@ then rebuild the vitess cluster:
 Terminal 1:
     Ctrl + C
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get upgrade && sudo apt-get update

--- a/content/en/docs/24.0/get-started/local-mac.md
+++ b/content/en/docs/24.0/get-started/local-mac.md
@@ -296,10 +296,10 @@ The schema has been simplified to include only those fields that are significant
 
 You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 
-Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 401_teardown script:
+Or alternatively, once you are finished with the local examples or if you would like to start over, you can clean up by running the 501_teardown script:
 
 ```sh
-$ ./401_teardown.sh
+$ ./501_teardown.sh
 $ rm -rf ./vtdataroot
 ```
 

--- a/content/en/docs/24.0/get-started/local.md
+++ b/content/en/docs/24.0/get-started/local.md
@@ -339,6 +339,6 @@ You can now proceed with [MoveTables](../../user-guides/migration/move-tables).
 Or alternatively, if you would like to teardown your example:
 
 ```bash
-./401_teardown.sh
+./501_teardown.sh
 rm -rf vtdataroot
 ```

--- a/content/en/docs/24.0/user-guides/configuration-advanced/buffering-scenarios.md
+++ b/content/en/docs/24.0/user-guides/configuration-advanced/buffering-scenarios.md
@@ -463,7 +463,7 @@ rebuild:
 Terminal 1:
     Hit "Ctrl + C" to kill the vtgate process
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get install mysql-client-core-8.0=8.0.19-0ubuntu5 mysql-server-core-8.0=8.0.19-0ubuntu5
@@ -564,7 +564,7 @@ then rebuild the vitess cluster:
 Terminal 1:
     Ctrl + C
 
-    $ ./401_teardown.sh
+    $ ./501_teardown.sh
     $ rm -rf ./vtdataroot
 
     $ sudo apt-get upgrade && sudo apt-get update

--- a/content/en/docs/contributing/build-on-centos.md
+++ b/content/en/docs/contributing/build-on-centos.md
@@ -142,7 +142,7 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./501_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]

--- a/content/en/docs/contributing/build-on-macos.md
+++ b/content/en/docs/contributing/build-on-macos.md
@@ -126,7 +126,7 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./501_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]

--- a/content/en/docs/contributing/build-on-ubuntu.md
+++ b/content/en/docs/contributing/build-on-ubuntu.md
@@ -154,7 +154,7 @@ In addition to running tests, you can try running the [local example](../../get-
 
 ### Key Already Exists
 
-This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./401_teardown.sh`, removing vtdataroot and then starting again:
+This error is because etcd was not cleaned up from the previous run of the example. You can manually fix this by running `./501_teardown.sh`, removing vtdataroot and then starting again:
 ```
 Error:  105: Key already exists (/vitess/zone1) [6]
 Error:  105: Key already exists (/vitess/global) [6]

--- a/content/zh/docs/22.0/get-started/local.md
+++ b/content/zh/docs/22.0/get-started/local.md
@@ -649,5 +649,5 @@ COrder
 如果您不继续进行其他练习，则可以删除整个示例。
 
 ``` sh
-./401_teardown.sh
+./501_teardown.sh
 ```

--- a/content/zh/docs/23.0/get-started/local.md
+++ b/content/zh/docs/23.0/get-started/local.md
@@ -649,5 +649,5 @@ COrder
 如果您不继续进行其他练习，则可以删除整个示例。
 
 ``` sh
-./401_teardown.sh
+./501_teardown.sh
 ```

--- a/content/zh/docs/24.0/get-started/local.md
+++ b/content/zh/docs/24.0/get-started/local.md
@@ -649,5 +649,5 @@ COrder
 如果您不继续进行其他练习，则可以删除整个示例。
 
 ``` sh
-./401_teardown.sh
+./501_teardown.sh
 ```


### PR DESCRIPTION
## What's this?

The teardown script was renamed from `401_teardown.sh` to `501_teardown.sh` in vitessio/vitess#16893 when backup/restore scripts (40x) were added. This was included starting from release-22.0, but the website docs still reference the old name.

## Changes

- Updated `401_teardown.sh` → `501_teardown.sh` in v22.0, v23.0, v24.0 docs (en/zh)
- Updated contributing guides (build-on-centos, build-on-macos, build-on-ubuntu)
- Left v21.0 and older docs unchanged since they correctly reference `401_teardown.sh`

15 files changed, 21 substitutions total.