### PR TITLE
Add missing `HasSemiSync()` to `Durabler` interface docs

### DIFF
--- a/content/en/docs/22.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/22.0/user-guides/configuration-basic/durability_policy.md
@@ -12,6 +12,7 @@ type Durabler interface {
 	PromotionRule(*topodatapb.Tablet) promotionrule.CandidatePromotionRule
 	SemiSyncAckers(*topodatapb.Tablet) int
 	IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool
+	HasSemiSync() bool
 }
 ```
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/durability_policy.md
@@ -12,6 +12,7 @@ type Durabler interface {
 	PromotionRule(*topodatapb.Tablet) promotionrule.CandidatePromotionRule
 	SemiSyncAckers(*topodatapb.Tablet) int
 	IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool
+	HasSemiSync() bool
 }
 ```
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/durability_policy.md
@@ -12,6 +12,7 @@ type Durabler interface {
 	PromotionRule(*topodatapb.Tablet) promotionrule.CandidatePromotionRule
 	SemiSyncAckers(*topodatapb.Tablet) int
 	IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool
+	HasSemiSync() bool
 }
 ```
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/durability_policy.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/durability_policy.md
@@ -12,6 +12,7 @@ type Durabler interface {
 	PromotionRule(*topodatapb.Tablet) promotionrule.CandidatePromotionRule
 	SemiSyncAckers(*topodatapb.Tablet) int
 	IsReplicaSemiSync(primary, replica *topodatapb.Tablet) bool
+	HasSemiSync() bool
 }
 ```
 


### PR DESCRIPTION
The `Durabler` interface definition in the durability policy docs was missing the `HasSemiSync() bool` method that was added to the `release-22.0`+ branches of Vitess

Updated the interface snippet in v22.0, v23.0, v24.0 and v25.0 docs _(v14-v21 are unaffected — v14-v19 correctly show the lowercase/unexported methods, v20-v21 correctly show the 3 x exported methods)_

### AI Disclosure

Claude Code assisted with development. Claude prepared this PR summary