### PR TITLE
docs: Fix non-inclusive language in Vitess docs

### DIFF
--- a/content/en/docs/23.0/overview/history.md
+++ b/content/en/docs/23.0/overview/history.md
@@ -6,9 +6,9 @@ weight: 5
 
 Vitess was created in 2010 to solve the MySQL scalability challenges that the team at YouTube faced. This section briefly summarizes the sequence of events that led to Vitess' creation:
 
-1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a master database for write traffic and a replica database for read traffic.
+1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a primary database for write traffic and a replica database for read traffic.
 2. With demand for cat videos at an all-time high, read-only traffic was still high enough to overload the replica database. So YouTube added more replicas, again providing a temporary solution.
-3. Eventually, write traffic became too high for the master database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
+3. Eventually, write traffic became too high for the primary database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
 4. YouTube's application layer was modified so that before executing any database operation, the code could identify the right database shard to receive that particular query.
 
 Vitess let YouTube remove that logic from the application source code, introducing a proxy between the application and the database to route and manage database interactions. Since then, YouTube has scaled its user base by a factor of more than 50, greatly increasing its capacity to serve pages, process newly uploaded videos, and more. Even more importantly, Vitess is a platform that continues to scale.

--- a/content/en/docs/23.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/23.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -13,7 +13,7 @@ Applies the schema change to the specified keyspace on every primary, running in
 If --allow-long-unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected.
 --ddl-strategy is used to instruct migrations via vreplication, mysql or direct with optional parameters.
 --migration-context allows the user to specify a custom migration context for online DDL migrations.
-If --skip-preflight, SQL goes directly to shards without going through sanity checks.
+If --skip-preflight, SQL goes directly to shards without going through validation checks.
 
 The --uuid and --sql flags are repeatable, so they can be passed multiple times to build a list of values.
 For --uuid, this is used like "--uuid $first_uuid --uuid $second_uuid".

--- a/content/en/docs/23.0/user-guides/configuration-basic/monitoring.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/monitoring.md
@@ -335,7 +335,7 @@ This URL has an MRU list of consolidations. This is a way of identifying if mult
 
 #### /debug/query\_rules
 
-This URL displays the currently active query blacklist rules.
+This URL displays the currently active query blocklist rules.
 
 ### Alerting
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/troubleshooting.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/troubleshooting.md
@@ -115,7 +115,7 @@ In Vitess, you can get into an errant GTID situation if a primary is network par
 
 VTOrc can be used to detect errant GTIDs. You can also set up your own monitoring to detect this situation. This can be performed by ensuring that the GTIDs of the replicas are always a subset of the primary.
 
-If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create dummy transactions with those extra GTIDs on instances that do not contain them.
+If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create placeholder transactions with those extra GTIDs on instances that do not contain them.
 
 If the data has diverged, you have to make a decision about which one is authoritative. Once that is decided, it is recommended that you first take a backup of the instance that you have determined to be authoritative. Following this, you can bring down the instances that were non-authoritative and restart them with empty directories. This will trigger the restore workflow that will start with the authoritative backup. Once restored, the MySQL will point itself to the current primary and catch up to a consistent state.
 

--- a/content/en/docs/23.0/user-guides/schema-changes/unmanaged-schema-changes.md
+++ b/content/en/docs/23.0/user-guides/schema-changes/unmanaged-schema-changes.md
@@ -18,7 +18,7 @@ CREATE TABLE `demo` (
 
 ## ApplySchema
 
-`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some sanity checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
+`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some validation checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
 
 Consider the following examples:
 

--- a/content/en/docs/24.0/overview/history.md
+++ b/content/en/docs/24.0/overview/history.md
@@ -6,9 +6,9 @@ weight: 5
 
 Vitess was created in 2010 to solve the MySQL scalability challenges that the team at YouTube faced. This section briefly summarizes the sequence of events that led to Vitess' creation:
 
-1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a master database for write traffic and a replica database for read traffic.
+1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a primary database for write traffic and a replica database for read traffic.
 2. With demand for cat videos at an all-time high, read-only traffic was still high enough to overload the replica database. So YouTube added more replicas, again providing a temporary solution.
-3. Eventually, write traffic became too high for the master database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
+3. Eventually, write traffic became too high for the primary database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
 4. YouTube's application layer was modified so that before executing any database operation, the code could identify the right database shard to receive that particular query.
 
 Vitess let YouTube remove that logic from the application source code, introducing a proxy between the application and the database to route and manage database interactions. Since then, YouTube has scaled its user base by a factor of more than 50, greatly increasing its capacity to serve pages, process newly uploaded videos, and more. Even more importantly, Vitess is a platform that continues to scale.

--- a/content/en/docs/24.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/24.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -13,7 +13,7 @@ Applies the schema change to the specified keyspace on every primary, running in
 If --allow-long-unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected.
 --ddl-strategy is used to instruct migrations via vreplication, mysql or direct with optional parameters.
 --migration-context allows the user to specify a custom migration context for online DDL migrations.
-If --skip-preflight, SQL goes directly to shards without going through sanity checks.
+If --skip-preflight, SQL goes directly to shards without going through validation checks.
 
 The --uuid and --sql flags are repeatable, so they can be passed multiple times to build a list of values.
 For --uuid, this is used like "--uuid $first_uuid --uuid $second_uuid".

--- a/content/en/docs/24.0/user-guides/configuration-basic/monitoring.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/monitoring.md
@@ -369,7 +369,7 @@ This URL has an MRU list of consolidations. This is a way of identifying if mult
 
 #### /debug/query\_rules
 
-This URL displays the currently active query blacklist rules.
+This URL displays the currently active query blocklist rules.
 
 ### Alerting
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/troubleshooting.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/troubleshooting.md
@@ -115,7 +115,7 @@ In Vitess, you can get into an errant GTID situation if a primary is network par
 
 VTOrc can be used to detect errant GTIDs. You can also set up your own monitoring to detect this situation. This can be performed by ensuring that the GTIDs of the replicas are always a subset of the primary.
 
-If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create dummy transactions with those extra GTIDs on instances that do not contain them.
+If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create placeholder transactions with those extra GTIDs on instances that do not contain them.
 
 If the data has diverged, you have to make a decision about which one is authoritative. Once that is decided, it is recommended that you first take a backup of the instance that you have determined to be authoritative. Following this, you can bring down the instances that were non-authoritative and restart them with empty directories. This will trigger the restore workflow that will start with the authoritative backup. Once restored, the MySQL will point itself to the current primary and catch up to a consistent state.
 

--- a/content/en/docs/24.0/user-guides/schema-changes/unmanaged-schema-changes.md
+++ b/content/en/docs/24.0/user-guides/schema-changes/unmanaged-schema-changes.md
@@ -18,7 +18,7 @@ CREATE TABLE `demo` (
 
 ## ApplySchema
 
-`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some sanity checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
+`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some validation checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
 
 Consider the following examples:
 

--- a/content/en/docs/25.0/overview/history.md
+++ b/content/en/docs/25.0/overview/history.md
@@ -6,9 +6,9 @@ weight: 5
 
 Vitess was created in 2010 to solve the MySQL scalability challenges that the team at YouTube faced. This section briefly summarizes the sequence of events that led to Vitess' creation:
 
-1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a master database for write traffic and a replica database for read traffic.
+1. YouTube's MySQL database reached a point when peak traffic would soon exceed the database's serving capacity. To temporarily alleviate the problem, YouTube created a primary database for write traffic and a replica database for read traffic.
 2. With demand for cat videos at an all-time high, read-only traffic was still high enough to overload the replica database. So YouTube added more replicas, again providing a temporary solution.
-3. Eventually, write traffic became too high for the master database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
+3. Eventually, write traffic became too high for the primary database to handle, requiring YouTube to shard data to handle incoming traffic. As an aside, sharding would have also become necessary if the overall size of the database became too large for a single MySQL instance.
 4. YouTube's application layer was modified so that before executing any database operation, the code could identify the right database shard to receive that particular query.
 
 Vitess let YouTube remove that logic from the application source code, introducing a proxy between the application and the database to route and manage database interactions. Since then, YouTube has scaled its user base by a factor of more than 50, greatly increasing its capacity to serve pages, process newly uploaded videos, and more. Even more importantly, Vitess is a platform that continues to scale.

--- a/content/en/docs/25.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
+++ b/content/en/docs/25.0/reference/programs/vtctldclient/vtctldclient_ApplySchema.md
@@ -13,7 +13,7 @@ Applies the schema change to the specified keyspace on every primary, running in
 If --allow-long-unavailability is set, schema changes affecting a large number of rows (and possibly incurring a longer period of unavailability) will not be rejected.
 --ddl-strategy is used to instruct migrations via vreplication, mysql or direct with optional parameters.
 --migration-context allows the user to specify a custom migration context for online DDL migrations.
-If --skip-preflight, SQL goes directly to shards without going through sanity checks.
+If --skip-preflight, SQL goes directly to shards without going through validation checks.
 
 The --uuid and --sql flags are repeatable, so they can be passed multiple times to build a list of values.
 For --uuid, this is used like "--uuid $first_uuid --uuid $second_uuid".

--- a/content/en/docs/25.0/user-guides/configuration-basic/monitoring.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/monitoring.md
@@ -369,7 +369,7 @@ This URL has an MRU list of consolidations. This is a way of identifying if mult
 
 #### /debug/query\_rules
 
-This URL displays the currently active query blacklist rules.
+This URL displays the currently active query blocklist rules.
 
 ### Alerting
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/troubleshooting.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/troubleshooting.md
@@ -115,7 +115,7 @@ In Vitess, you can get into an errant GTID situation if a primary is network par
 
 VTOrc can be used to detect errant GTIDs. You can also set up your own monitoring to detect this situation. This can be performed by ensuring that the GTIDs of the replicas are always a subset of the primary.
 
-If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create dummy transactions with those extra GTIDs on instances that do not contain them.
+If an errant GTID is detected, the first task is to identify the GTIDs that are diverged. If the divergence did not cause any data skew, you could choose to create placeholder transactions with those extra GTIDs on instances that do not contain them.
 
 If the data has diverged, you have to make a decision about which one is authoritative. Once that is decided, it is recommended that you first take a backup of the instance that you have determined to be authoritative. Following this, you can bring down the instances that were non-authoritative and restart them with empty directories. This will trigger the restore workflow that will start with the authoritative backup. Once restored, the MySQL will point itself to the current primary and catch up to a consistent state.
 

--- a/content/en/docs/25.0/user-guides/schema-changes/unmanaged-schema-changes.md
+++ b/content/en/docs/25.0/user-guides/schema-changes/unmanaged-schema-changes.md
@@ -18,7 +18,7 @@ CREATE TABLE `demo` (
 
 ## ApplySchema
 
-`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some sanity checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
+`ApplySchema` is a `vtctldclient` command that can be used to apply a schema change to a keyspace. The main advantage of using this tool is that it performs some validation checks about the schema before applying it. However, a downside is that it can be a little too strict and may not work for all use cases.
 
 Consider the following examples:
 

--- a/content/en/docs/troubleshoot/elevated-query-latency.md
+++ b/content/en/docs/troubleshoot/elevated-query-latency.md
@@ -7,7 +7,7 @@ weight: 1
 
 Diagnosis 1: Inspect the graphs to see if QPS has gone up. If yes, drill down on the more detailed QPS graphs to see which table, or user caused the increase. If a table is identified, look at /debug/queryz for queries on that table.
 
-Action: Inform engineer about the toxic queries. If it’s a specific user, you can stop their job or throttle them to keep the load manageable. As a last resort, blacklist query to allow the rest of the system to stay healthy.
+Action: Inform engineer about the toxic queries. If it’s a specific user, you can stop their job or throttle them to keep the load manageable. As a last resort, blocklist the query to allow the rest of the system to stay healthy.
 
 Diagnosis 2: QPS did not go up, only latency did. Inspect the per-table latency graphs. If it’s a specific table, then it’s most likely a long-running low QPS query that’s skewing the numbers. Identify the culprit query and take necessary steps to get it optimized. Such queries usually do not cause outage. So, there may not be a need to take extreme measures.
 


### PR DESCRIPTION
Replaces non-inclusive terminology in current doc versions (23.0, 24.0, 25.0) per GitHub issue #1987 and the Inclusive Naming Initiative: "master database" → "primary database", "blacklist" → "blocklist", "sanity checks" → "validation checks", and "dummy transactions" → "placeholder transactions".