### PR TITLE
docs: Rename task headings to use gerund form in User Guides

### DIFF
--- a/content/en/docs/23.0/user-guides/configuration-advanced/authorization.md
+++ b/content/en/docs/23.0/user-guides/configuration-advanced/authorization.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization
+title: Configuring Authorization
 weight: 10
 aliases: ['/docs/user-guides/authorization/'] 
 ---

--- a/content/en/docs/23.0/user-guides/configuration-advanced/integration-with-orchestrator.md
+++ b/content/en/docs/23.0/user-guides/configuration-advanced/integration-with-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-title: Integration with Orchestrator
+title: Integrating with Orchestrator
 weight: 100
 aliases: ['/docs/user-guides/integration-with-orchestrator/'] 
 ---

--- a/content/en/docs/23.0/user-guides/configuration-advanced/tracing.md
+++ b/content/en/docs/23.0/user-guides/configuration-advanced/tracing.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing
+title: Configuring Tracing
 weight: 40
 aliases: ['/docs/user-guides/tracing/'] 
 ---

--- a/content/en/docs/23.0/user-guides/configuration-basic/add-delete-cell.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/add-delete-cell.md
@@ -1,9 +1,9 @@
 ---
-title: Add or Delete a Cell
+title: Adding or Deleting a Cell
 weight: 15
 ---
 
-## Add
+## Adding a Cell
 To add a cell after a cluster is up and running, you start off by creating one using the same steps previously performed to create the first cell:
 
 ```sh
@@ -31,7 +31,7 @@ If the `cells` option is not specified, the rebuild deploys to all cells.
 
 Once these steps are done, you can bring up the necessary MySQLs, vttablets and vtgates under that cell.
 
-## Delete
+## Deleting a Cell
 
 To delete a cell, bring down all servers in that cell, and then remove its entry from the global topo with:
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/backups-restores.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/backups-restores.md
@@ -1,5 +1,5 @@
 ---
-title: Backups and Restores
+title: Backing Up and Restoring Data
 weight: 12
 ---
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/delete-keyspace.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/delete-keyspace.md
@@ -1,5 +1,5 @@
 ---
-title: Delete a Keyspace
+title: Deleting a Keyspace
 weight: 14
 ---
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/global-topo.md
@@ -38,7 +38,7 @@ To be safe, you may want to bring up etcd with `--enable-v2=true`, even though i
 
 It is generally not recommended that you migrate from one type of toposerver to another. However, if absolutely necessary, you can use the [topo2topo](../../../reference/features/topology-service/#migration-between-implementations) command line tool to perform this migration.
 
-## Backups
+## Backing Up TopoServer Data
 
 It is important to periodically backup the data in the TopoServer. Although most of the information in the TopoServer can be manually reconstructed, it is still a painful task. This can be avoided if a recent backup was readily available.
 

--- a/content/en/docs/23.0/user-guides/configuration-basic/initialize-shard-primary.md
+++ b/content/en/docs/23.0/user-guides/configuration-basic/initialize-shard-primary.md
@@ -1,5 +1,5 @@
 ---
-title: Initialize Shard Primary
+title: Initializing the Shard Primary
 weight: 9
 ---
 

--- a/content/en/docs/23.0/user-guides/migration/materialize.md
+++ b/content/en/docs/23.0/user-guides/migration/materialize.md
@@ -1,5 +1,5 @@
 ---
-title: Materialize
+title: Materializing Data
 weight: 3
 aliases: ['/docs/user-guides/materialize/'] 
 ---

--- a/content/en/docs/23.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/23.0/user-guides/migration/move-tables.md
@@ -1,5 +1,5 @@
 ---
-title: Move Tables
+title: Moving Tables
 weight: 2
 aliases: ['/docs/user-guides/move-tables/']
 ---

--- a/content/en/docs/23.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
+++ b/content/en/docs/23.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Bootstrap and Restore
+title: Bootstrapping and Restoring
 weight: 3
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/23.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
+++ b/content/en/docs/23.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
@@ -1,5 +1,5 @@
 ---
-title: Scheduled Backups
+title: Scheduling Backups
 weight: 5
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/23.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/23.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -1,5 +1,5 @@
 ---
-title: Backfill Lookup Vindexes
+title: Backfilling Lookup Vindexes
 weight: 11
 ---
 

--- a/content/en/docs/24.0/user-guides/configuration-advanced/authorization.md
+++ b/content/en/docs/24.0/user-guides/configuration-advanced/authorization.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization
+title: Configuring Authorization
 weight: 10
 aliases: ['/docs/user-guides/authorization/'] 
 ---

--- a/content/en/docs/24.0/user-guides/configuration-advanced/integration-with-orchestrator.md
+++ b/content/en/docs/24.0/user-guides/configuration-advanced/integration-with-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-title: Integration with Orchestrator
+title: Integrating with Orchestrator
 weight: 100
 aliases: ['/docs/user-guides/integration-with-orchestrator/'] 
 ---

--- a/content/en/docs/24.0/user-guides/configuration-advanced/tracing.md
+++ b/content/en/docs/24.0/user-guides/configuration-advanced/tracing.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing
+title: Configuring Tracing
 weight: 40
 aliases: ['/docs/user-guides/tracing/']
 ---

--- a/content/en/docs/24.0/user-guides/configuration-basic/add-delete-cell.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/add-delete-cell.md
@@ -1,9 +1,9 @@
 ---
-title: Add or Delete a Cell
+title: Adding or Deleting a Cell
 weight: 15
 ---
 
-## Add
+## Adding a Cell
 To add a cell after a cluster is up and running, you start off by creating one using the same steps previously performed to create the first cell:
 
 ```sh
@@ -31,7 +31,7 @@ If the `cells` option is not specified, the rebuild deploys to all cells.
 
 Once these steps are done, you can bring up the necessary MySQLs, vttablets and vtgates under that cell.
 
-## Delete
+## Deleting a Cell
 
 To delete a cell, bring down all servers in that cell, and then remove its entry from the global topo with:
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/backups-restores.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/backups-restores.md
@@ -1,5 +1,5 @@
 ---
-title: Backups and Restores
+title: Backing Up and Restoring Data
 weight: 12
 ---
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/delete-keyspace.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/delete-keyspace.md
@@ -1,5 +1,5 @@
 ---
-title: Delete a Keyspace
+title: Deleting a Keyspace
 weight: 14
 ---
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/global-topo.md
@@ -38,7 +38,7 @@ To be safe, you may want to bring up etcd with `--enable-v2=true`, even though i
 
 It is generally not recommended that you migrate from one type of toposerver to another. However, if absolutely necessary, you can use the [topo2topo](../../../reference/features/topology-service/#migration-between-implementations) command line tool to perform this migration.
 
-## Backups
+## Backing Up TopoServer Data
 
 It is important to periodically backup the data in the TopoServer. Although most of the information in the TopoServer can be manually reconstructed, it is still a painful task. This can be avoided if a recent backup was readily available.
 

--- a/content/en/docs/24.0/user-guides/configuration-basic/initialize-shard-primary.md
+++ b/content/en/docs/24.0/user-guides/configuration-basic/initialize-shard-primary.md
@@ -1,5 +1,5 @@
 ---
-title: Initialize Shard Primary
+title: Initializing the Shard Primary
 weight: 9
 ---
 

--- a/content/en/docs/24.0/user-guides/migration/materialize.md
+++ b/content/en/docs/24.0/user-guides/migration/materialize.md
@@ -1,5 +1,5 @@
 ---
-title: Materialize
+title: Materializing Data
 weight: 3
 aliases: ['/docs/user-guides/materialize/'] 
 ---

--- a/content/en/docs/24.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/24.0/user-guides/migration/move-tables.md
@@ -1,5 +1,5 @@
 ---
-title: Move Tables
+title: Moving Tables
 weight: 2
 aliases: ['/docs/user-guides/move-tables/']
 ---

--- a/content/en/docs/24.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
+++ b/content/en/docs/24.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Bootstrap and Restore
+title: Bootstrapping and Restoring
 weight: 3
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/24.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
+++ b/content/en/docs/24.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
@@ -1,5 +1,5 @@
 ---
-title: Scheduled Backups
+title: Scheduling Backups
 weight: 5
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/24.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/24.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -1,5 +1,5 @@
 ---
-title: Backfill Lookup Vindexes
+title: Backfilling Lookup Vindexes
 weight: 11
 ---
 

--- a/content/en/docs/25.0/user-guides/configuration-advanced/authorization.md
+++ b/content/en/docs/25.0/user-guides/configuration-advanced/authorization.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization
+title: Configuring Authorization
 weight: 10
 aliases: ['/docs/user-guides/authorization/'] 
 ---

--- a/content/en/docs/25.0/user-guides/configuration-advanced/integration-with-orchestrator.md
+++ b/content/en/docs/25.0/user-guides/configuration-advanced/integration-with-orchestrator.md
@@ -1,5 +1,5 @@
 ---
-title: Integration with Orchestrator
+title: Integrating with Orchestrator
 weight: 100
 aliases: ['/docs/user-guides/integration-with-orchestrator/'] 
 ---

--- a/content/en/docs/25.0/user-guides/configuration-advanced/tracing.md
+++ b/content/en/docs/25.0/user-guides/configuration-advanced/tracing.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing
+title: Configuring Tracing
 weight: 40
 aliases: ['/docs/user-guides/tracing/']
 ---

--- a/content/en/docs/25.0/user-guides/configuration-basic/add-delete-cell.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/add-delete-cell.md
@@ -1,9 +1,9 @@
 ---
-title: Add or Delete a Cell
+title: Adding or Deleting a Cell
 weight: 15
 ---
 
-## Add
+## Adding a Cell
 To add a cell after a cluster is up and running, you start off by creating one using the same steps previously performed to create the first cell:
 
 ```sh
@@ -31,7 +31,7 @@ If the `cells` option is not specified, the rebuild deploys to all cells.
 
 Once these steps are done, you can bring up the necessary MySQLs, vttablets and vtgates under that cell.
 
-## Delete
+## Deleting a Cell
 
 To delete a cell, bring down all servers in that cell, and then remove its entry from the global topo with:
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/backups-restores.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/backups-restores.md
@@ -1,5 +1,5 @@
 ---
-title: Backups and Restores
+title: Backing Up and Restoring Data
 weight: 12
 ---
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/delete-keyspace.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/delete-keyspace.md
@@ -1,5 +1,5 @@
 ---
-title: Delete a Keyspace
+title: Deleting a Keyspace
 weight: 14
 ---
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/global-topo.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/global-topo.md
@@ -38,7 +38,7 @@ To be safe, you may want to bring up etcd with `--enable-v2=true`, even though i
 
 It is generally not recommended that you migrate from one type of toposerver to another. However, if absolutely necessary, you can use the [topo2topo](../../../reference/features/topology-service/#migration-between-implementations) command line tool to perform this migration.
 
-## Backing up TopoServer data
+## Backing Up TopoServer Data
 
 It is important to periodically backup the data in the TopoServer. Although most of the information in the TopoServer can be manually reconstructed, it is still a painful task. This can be avoided if a recent backup was readily available.
 

--- a/content/en/docs/25.0/user-guides/configuration-basic/initialize-shard-primary.md
+++ b/content/en/docs/25.0/user-guides/configuration-basic/initialize-shard-primary.md
@@ -1,5 +1,5 @@
 ---
-title: Initialize Shard Primary
+title: Initializing the Shard Primary
 weight: 9
 ---
 

--- a/content/en/docs/25.0/user-guides/migration/materialize.md
+++ b/content/en/docs/25.0/user-guides/migration/materialize.md
@@ -1,5 +1,5 @@
 ---
-title: Materialize
+title: Materializing Data
 weight: 3
 aliases: ['/docs/user-guides/materialize/'] 
 ---

--- a/content/en/docs/25.0/user-guides/migration/move-tables.md
+++ b/content/en/docs/25.0/user-guides/migration/move-tables.md
@@ -1,5 +1,5 @@
 ---
-title: Move Tables
+title: Moving Tables
 weight: 2
 aliases: ['/docs/user-guides/move-tables/']
 ---

--- a/content/en/docs/25.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
+++ b/content/en/docs/25.0/user-guides/operating-vitess/backup-and-restore/bootstrap-and-restore.md
@@ -1,5 +1,5 @@
 ---
-title: Bootstrap and Restore
+title: Bootstrapping and Restoring
 weight: 3
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/25.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
+++ b/content/en/docs/25.0/user-guides/operating-vitess/backup-and-restore/scheduled-backups.md
@@ -1,5 +1,5 @@
 ---
-title: Scheduled Backups
+title: Scheduling Backups
 weight: 5
 aliases: ['/docs/user-guides/backup-and-restore/']
 ---

--- a/content/en/docs/25.0/user-guides/vschema-guide/backfill-vindexes.md
+++ b/content/en/docs/25.0/user-guides/vschema-guide/backfill-vindexes.md
@@ -1,5 +1,5 @@
 ---
-title: Backfill Lookup Vindexes
+title: Backfilling Lookup Vindexes
 weight: 11
 ---
 


### PR DESCRIPTION
Updates task/procedural headings across User Guides versions 23.0, 24.0, and 25.0 to use verb-based titles ending in "-ing" (gerunds) for improved findability. Changes include renaming page titles like "Move Tables" to "Moving Tables", "Backups and Restores" to "Backing Up and Restoring Data", and section headings like "Backups" to "Backing Up TopoServer Data".