### PR TITLE
Fix VSchema DDL syntax that vtgate does not accept

### DIFF
--- a/content/en/docs/23.0/user-guides/vschema-guide/vschema_ddl.md
+++ b/content/en/docs/23.0/user-guides/vschema-guide/vschema_ddl.md
@@ -70,7 +70,7 @@ Drops a vindex from the VSchema.
 ### ALTER VSCHEMA ON tbl_name ADD VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name ADD VINDEX tbl_name.vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
+ALTER VSCHEMA ON tbl_name ADD VINDEX vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
 ```
 
 Adds a vindex for table `tbl_name` and columns `column_name`.
@@ -78,13 +78,13 @@ Adds a vindex for table `tbl_name` and columns `column_name`.
 For the various vindex types and vindex options see [Vindexes documentation](https://vitess.io/docs/17.0/reference/features/vindexes/#predefined-vindexes).
 
 
-### ALTER VSCHEMA ON tbl_name REMOVE VINDEX
+### ALTER VSCHEMA ON tbl_name DROP VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name REMOVE VINDEX tbl_name.vindex_name
+ALTER VSCHEMA ON tbl_name DROP VINDEX vindex_name
 ```
 
-Removes a vindex from table `tbl_name`.
+Drops a vindex from table `tbl_name`.
 
 
 ### ALTER VSCHEMA ADD SEQUENCE

--- a/content/en/docs/24.0/user-guides/vschema-guide/vschema_ddl.md
+++ b/content/en/docs/24.0/user-guides/vschema-guide/vschema_ddl.md
@@ -70,7 +70,7 @@ Drops a vindex from the VSchema.
 ### ALTER VSCHEMA ON tbl_name ADD VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name ADD VINDEX tbl_name.vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
+ALTER VSCHEMA ON tbl_name ADD VINDEX vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
 ```
 
 Adds a vindex for table `tbl_name` and columns `column_name`.
@@ -78,13 +78,13 @@ Adds a vindex for table `tbl_name` and columns `column_name`.
 For the various vindex types and vindex options see [Vindexes documentation](https://vitess.io/docs/17.0/reference/features/vindexes/#predefined-vindexes).
 
 
-### ALTER VSCHEMA ON tbl_name REMOVE VINDEX
+### ALTER VSCHEMA ON tbl_name DROP VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name REMOVE VINDEX tbl_name.vindex_name
+ALTER VSCHEMA ON tbl_name DROP VINDEX vindex_name
 ```
 
-Removes a vindex from table `tbl_name`.
+Drops a vindex from table `tbl_name`.
 
 
 ### ALTER VSCHEMA ADD SEQUENCE

--- a/content/en/docs/25.0/user-guides/vschema-guide/vschema_ddl.md
+++ b/content/en/docs/25.0/user-guides/vschema-guide/vschema_ddl.md
@@ -70,7 +70,7 @@ Drops a vindex from the VSchema.
 ### ALTER VSCHEMA ON tbl_name ADD VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name ADD VINDEX tbl_name.vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
+ALTER VSCHEMA ON tbl_name ADD VINDEX vindex_name (column_name[, column_name] ...) [USING vindex_type] [WITH vindex_option[, vindex_option] ...]
 ```
 
 Adds a vindex for table `tbl_name` and columns `column_name`.
@@ -78,13 +78,13 @@ Adds a vindex for table `tbl_name` and columns `column_name`.
 For the various vindex types and vindex options see [Vindexes documentation](https://vitess.io/docs/17.0/reference/features/vindexes/#predefined-vindexes).
 
 
-### ALTER VSCHEMA ON tbl_name REMOVE VINDEX
+### ALTER VSCHEMA ON tbl_name DROP VINDEX
 
 ```
-ALTER VSCHEMA ON tbl_name REMOVE VINDEX tbl_name.vindex_name
+ALTER VSCHEMA ON tbl_name DROP VINDEX vindex_name
 ```
 
-Removes a vindex from table `tbl_name`.
+Drops a vindex from table `tbl_name`.
 
 
 ### ALTER VSCHEMA ADD SEQUENCE


### PR DESCRIPTION
## What's this?

Fixes vitessio/website#2140

The VSchema DDL user guide documented two statement forms the vtgate parser rejects:

- `ALTER VSCHEMA ON tbl_name REMOVE VINDEX` — the grammar only accepts `DROP VINDEX`
- a qualified vindex name (`tbl_name.vindex_name`) in the `ON ... ADD VINDEX` / `ON ... DROP VINDEX` forms — the vindex name is a plain identifier (`sql_id`), so a qualified name is a syntax error

The correct syntax source is the grammar in [`go/vt/sqlparser/sql.y#L3669-L3690`](https://github.com/vitessio/vitess/blob/2bf20f871257c0aef373e1e3154270d7c972ba9f/go/vt/sqlparser/sql.y#L3669-L3690). I ran the documented examples through the parser to confirm, and checked that `release-23.0` and `release-24.0` have the same grammar, so the same fix is applied to the 23.0, 24.0, and 25.0 copies of the page.

---

_Most of this was written by Claude Code - I just provided direction._

🤖 Generated with [Claude Code](https://claude.com/claude-code)