### PR TITLE
docs: fix link to Keyspace ID in vindexes documentation

### DIFF
--- a/content/en/docs/23.0/reference/features/vindexes.md
+++ b/content/en/docs/23.0/reference/features/vindexes.md
@@ -6,7 +6,7 @@ aliases: ['/docs/schema-management/consistent-lookup/','/docs/reference/vindexes
 
 ## A Vindex maps column values to keyspace IDs
 
-A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id.md). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
+A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
 Vitess offers various vindexes, each with different trade-offs, allowing you to choose the one that best fits your needs.
 
 The Sharding Key is a concept that was introduced by NoSQL datastores. It is based on the fact that, in NoSQL databases, there is only one access path to the data, which is the Key. 

--- a/content/en/docs/24.0/reference/features/vindexes.md
+++ b/content/en/docs/24.0/reference/features/vindexes.md
@@ -6,7 +6,7 @@ aliases: ['/docs/schema-management/consistent-lookup/','/docs/reference/vindexes
 
 ## A Vindex maps column values to keyspace IDs
 
-A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id.md). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
+A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
 Vitess offers various vindexes, each with different trade-offs, allowing you to choose the one that best fits your needs.
 
 The Sharding Key is a concept that was introduced by NoSQL datastores. It is based on the fact that, in NoSQL databases, there is only one access path to the data, which is the Key. 

--- a/content/en/docs/25.0/reference/features/vindexes.md
+++ b/content/en/docs/25.0/reference/features/vindexes.md
@@ -6,7 +6,7 @@ aliases: ['/docs/schema-management/consistent-lookup/','/docs/reference/vindexes
 
 ## A Vindex maps column values to keyspace IDs
 
-A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id.md). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
+A Vindex provides a way to map a column value to a [Keyspace ID](../../../concepts/keyspace-id). Since each shard in Vitess covers a range of `Keyspace ID` values, this mapping can be used to identify which shard contains a row. 
 Vitess offers various vindexes, each with different trade-offs, allowing you to choose the one that best fits your needs.
 
 The Sharding Key is a concept that was introduced by NoSQL datastores. It is based on the fact that, in NoSQL databases, there is only one access path to the data, which is the Key. 


### PR DESCRIPTION
Currently the `Keyspace ID` link we have in the `VIndexes` document is leading to a 404 page

<img width="1579" height="1338" alt="image" src="https://github.com/user-attachments/assets/2d27a36a-c252-47d3-996b-2ca9574327c5" />

This PR is just about to fix it by removing the unnecessary `.md` suffix at the end of the link

